### PR TITLE
chore: simplify codebase — reuse CSS classes and deduplicate ternaries

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -307,16 +307,8 @@ export default function AppComponent() {
                 </div>
                 <button
                   onClick={toggleTheme}
-                  title={
-                    theme === "dark" ?
-                      "Switch to light theme"
-                    : "Switch to dark theme"
-                  }
-                  aria-label={
-                    theme === "dark" ?
-                      "Switch to light theme"
-                    : "Switch to dark theme"
-                  }
+                  title={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
+                  aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
                   className="btn btn-icon btn-icon-ghost"
                 >
                   {theme === "dark" ?

--- a/frontend/src/pages/LoggingPage.tsx
+++ b/frontend/src/pages/LoggingPage.tsx
@@ -123,9 +123,13 @@ export function LoggingPage({
 
   useEffect(() => {
     let es: EventSource | null = null
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
+    let mounted = true
 
-    const setupLogStream = async () => {
+    const connect = async () => {
+      if (!mounted) return
       log.info("setting up log stream")
+      setConnecting(true)
       try {
         es = await subscribeToLogs((line) => {
           setLines((prev) => [...prev.slice(-(MAX_LINES - 1)), line])
@@ -139,26 +143,31 @@ export function LoggingPage({
           setConnecting(false)
         })
 
-        es.addEventListener("error", (e) => {
-          log.error("EventSource error", e)
+        es.addEventListener("error", () => {
+          log.error("log stream error, will retry")
           setConnected(false)
           setConnecting(false)
+          if (es) {
+            es.close()
+            es = null
+          }
+          if (mounted) {
+            retryTimer = setTimeout(connect, 3000)
+          }
         })
       } catch (error) {
-        log.error("failed to setup log stream", error)
+        log.error("failed to setup log stream, will retry", error)
         setConnected(false)
         setConnecting(false)
-        showToast(
-          "Failed to connect to log stream: "
-            + (error instanceof Error ? error.message : String(error)),
-          "error",
-        )
+        retryTimer = setTimeout(connect, 3000)
       }
     }
 
-    void setupLogStream()
+    void connect()
 
     return () => {
+      mounted = false
+      if (retryTimer) clearTimeout(retryTimer)
       if (es) {
         log.debug("closing log stream")
         es.close()

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -2960,31 +2960,7 @@ function AddFlowCopilotForm({
         flow — no token needed.
       </AddFlowHint>
 
-      {/* Divider */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 12,
-        }}
-      >
-        <div
-          style={{ flex: 1, height: 1, background: "var(--color-separator)" }}
-        />
-        <span
-          style={{
-            fontSize: 11,
-            color: "var(--color-text-tertiary)",
-            textTransform: "uppercase",
-            letterSpacing: "0.05em",
-          }}
-        >
-          or use a token
-        </span>
-        <div
-          style={{ flex: 1, height: 1, background: "var(--color-separator)" }}
-        />
-      </div>
+      <div className="divider-label">or use a token</div>
 
       {/* Secondary: Token */}
       <FormRow label="GitHub Token">


### PR DESCRIPTION
- Replace hand-rolled inline divider with existing .divider-label class
- Collapse duplicate theme toggle ternary into single template literal
