### PR TITLE
feat(frontend): polish and improve UI across all pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -383,24 +383,54 @@ export default function AppComponent() {
             zIndex: 30,
           }}
         >
-          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-            <Icon
-              size={16}
-              style={{ color: "var(--color-blue)", flexShrink: 0 }}
-            />
-            <h1
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span
               style={{
-                fontSize: 14,
-                fontWeight: 600,
-                color: "var(--color-text)",
-                margin: 0,
-                fontFamily: "var(--font-display)",
-                letterSpacing: "-0.02em",
+                fontSize: 12,
+                color: "var(--color-text-tertiary)",
+                fontFamily: "var(--font-text)",
               }}
             >
-              {currentNavItem.label}
-            </h1>
+              OmniLLM
+            </span>
+            <span
+              style={{ fontSize: 12, color: "var(--color-separator-opaque)" }}
+            >
+              /
+            </span>
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <Icon
+                size={14}
+                style={{ color: "var(--color-blue)", flexShrink: 0 }}
+              />
+              <h1
+                style={{
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: "var(--color-text)",
+                  margin: 0,
+                  fontFamily: "var(--font-display)",
+                  letterSpacing: "-0.02em",
+                }}
+              >
+                {currentNavItem.label}
+              </h1>
+            </div>
           </div>
+          {info && (
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <div className="status-dot status-dot-active" />
+              <span
+                style={{
+                  fontSize: 11,
+                  color: "var(--color-text-tertiary)",
+                  fontFamily: "var(--font-mono)",
+                }}
+              >
+                :{info.port}
+              </span>
+            </div>
+          )}
         </header>
 
         <MuiThemeWrapper isDark={theme === "dark"}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -478,6 +478,11 @@
   border-color: color-mix(in srgb, var(--color-text-tertiary) 40%, transparent);
 }
 
+.panel.panel-active {
+  border-color: var(--color-blue);
+  box-shadow: var(--shadow-card), 0 0 0 2px rgba(88,166,255,0.12);
+}
+
 /* ─── Stat card ─────────────────────────────────────────────────────────── */
 
 .stat-card {
@@ -566,11 +571,9 @@
   border-left-color: var(--color-text-tertiary);
 }
 
-.nav-item.active {
-  background: var(--color-blue-fill);
+.nav-item.active:hover {
+  background: var(--color-blue-fill-hover);
   color: var(--color-blue);
-  font-weight: 500;
-  border-left-color: var(--color-blue);
 }
 
 /* ─── Chat layout ────────────────────────────────────────────────────────── */
@@ -1024,6 +1027,45 @@ header :focus-visible {
   color: var(--color-text-tertiary);
   margin-bottom: 4px;
 }
+
+/* ─── Chat input area ────────────────────────────────────────────────────────── */
+
+.chat-input-wrapper {
+  border: 1px solid var(--color-separator-opaque);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg);
+  transition: border-color 0.12s var(--ease), box-shadow 0.12s var(--ease);
+}
+
+.chat-input-wrapper:focus-within {
+  border-color: var(--color-blue);
+  box-shadow: var(--glow-blue);
+}
+
+/* ─── Thinking dots animation ────────────────────────────────────────────────── */
+
+@keyframes thinking-dot {
+  0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
+  40%           { opacity: 1;   transform: scale(1); }
+}
+
+.thinking-dots {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.thinking-dots span {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: thinking-dot 1.2s ease-in-out infinite;
+}
+
+.thinking-dots span:nth-child(2) { animation-delay: 0.2s; }
+.thinking-dots span:nth-child(3) { animation-delay: 0.4s; }
 
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -676,21 +676,25 @@ export function ChatPage({ showToast }: ChatPageProps) {
                 <MessageAvatar role="assistant" />
                 <div
                   style={{
-                    padding: "12px 16px",
+                    padding: "14px 18px",
                     borderRadius: "var(--radius-lg)",
                     background: "var(--color-surface)",
                     border: "1px solid var(--color-separator)",
-                    color: "var(--color-text-secondary)",
-                    fontSize: 14,
-                    fontStyle: "italic",
+                    color: "var(--color-text-tertiary)",
                     boxShadow: "var(--shadow-btn)",
                     display: "flex",
                     alignItems: "center",
-                    gap: 8,
+                    gap: 10,
                   }}
                 >
-                  <span className="spinner" aria-hidden="true" />
-                  Thinking…
+                  <span style={{ fontSize: 12, fontStyle: "italic" }}>
+                    Thinking
+                  </span>
+                  <span className="thinking-dots" aria-hidden="true">
+                    <span />
+                    <span />
+                    <span />
+                  </span>
                 </div>
               </div>
             </div>
@@ -702,14 +706,17 @@ export function ChatPage({ showToast }: ChatPageProps) {
         {/* Input */}
         <div
           style={{
-            padding: "20px 24px",
+            padding: "12px 16px 16px",
             borderTop: "1px solid var(--color-separator)",
             background: "var(--color-surface)",
             borderBottomLeftRadius: "var(--radius-lg)",
             borderBottomRightRadius: "var(--radius-lg)",
           }}
         >
-          <div style={{ display: "flex", gap: 12, alignItems: "flex-end" }}>
+          <div
+            className="chat-input-wrapper"
+            style={{ display: "flex", alignItems: "flex-end", gap: 8 }}
+          >
             <div style={{ flex: 1 }}>
               <label
                 htmlFor="chat-input"
@@ -738,6 +745,7 @@ export function ChatPage({ showToast }: ChatPageProps) {
                   !selectedModel ? "model-required-hint" : undefined
                 }
                 className="chat-textarea"
+                style={{ minHeight: 52 }}
               />
             </div>
             <button
@@ -745,17 +753,19 @@ export function ChatPage({ showToast }: ChatPageProps) {
               disabled={!inputValue.trim() || !selectedModel || isLoading}
               className="btn btn-primary"
               style={{
-                width: 44,
-                height: 44,
+                width: 40,
+                height: 40,
                 padding: 0,
                 flexShrink: 0,
-                borderRadius: "var(--radius-lg)",
+                borderRadius: "var(--radius-md)",
+                marginBottom: 6,
+                marginRight: 6,
               }}
               aria-label={isLoading ? "Sending message…" : "Send message"}
             >
               {isLoading ?
-                <Loader2 size={18} className="animate-spin" />
-              : <SendIcon size={18} />}
+                <Loader2 size={16} className="animate-spin" />
+              : <SendIcon size={16} />}
             </button>
           </div>
           {!selectedModel && (

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -3001,7 +3001,7 @@ export function ConfigPage({ showToast }: ConfigPageProps) {
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: "repeat(5, 1fr)", // Exactly 5 equal columns for all tools
+          gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
           gap: 14,
           marginBottom: 24,
         }}
@@ -3101,8 +3101,18 @@ export function ConfigPage({ showToast }: ConfigPageProps) {
                 </button>
               )}
               {dirty && (
-                <span style={{ fontSize: 11, color: "var(--color-amber)" }}>
-                  unsaved changes
+                <span
+                  style={{
+                    fontSize: 11,
+                    fontWeight: 600,
+                    color: "var(--color-orange)",
+                    background: "var(--color-orange-fill)",
+                    border: "1px solid rgba(210,153,34,0.2)",
+                    borderRadius: "var(--radius-pill)",
+                    padding: "2px 10px",
+                  }}
+                >
+                  ● unsaved
                 </span>
               )}
               {dirty && (

--- a/frontend/src/pages/LoggingPage.tsx
+++ b/frontend/src/pages/LoggingPage.tsx
@@ -237,7 +237,7 @@ export function LoggingPage({
           alignItems: "flex-start",
           justifyContent: "space-between",
           gap: 18,
-          marginBottom: 28,
+          marginBottom: 24,
           flexWrap: "wrap",
         }}
       >
@@ -265,12 +265,96 @@ export function LoggingPage({
           </p>
         </div>
 
-        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <div
+          style={{
+            display: "flex",
+            gap: 8,
+            alignItems: "center",
+            flexWrap: "wrap",
+          }}
+        >
+          {/* Connection badge */}
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            {connecting ?
+              <Spin />
+            : <span
+                className={`status-dot ${connected ? "status-dot-active" : "status-dot-inactive"}`}
+              />
+            }
+            <span
+              style={{
+                fontSize: 12,
+                fontWeight: 600,
+                padding: "3px 10px",
+                borderRadius: "var(--radius-pill)",
+                background:
+                  connected ?
+                    "var(--color-green-fill)"
+                  : "var(--color-orange-fill)",
+                color: connected ? "var(--color-green)" : "var(--color-orange)",
+              }}
+            >
+              {/* eslint-disable-next-line no-nested-ternary */}
+              {connecting ?
+                "Connecting"
+              : connected ?
+                "Live"
+              : "Retrying"}
+            </span>
+          </div>
+
+          {/* Log Level inline */}
+          <select
+            value={logLevel ?? "info"}
+            onChange={async (e) => {
+              const newLevel = e.target.value as LogLevel
+              try {
+                log.info("changing log level", { from: logLevel, to: newLevel })
+                await updateLogLevel(newLevel)
+                setLogLevelState(newLevel)
+                showToast(
+                  `Log level → ${LOG_LEVELS.find((l) => l.value === newLevel)?.label ?? newLevel}`,
+                )
+              } catch (error) {
+                log.error("failed to update log level", error)
+                const errMsg =
+                  error instanceof Error ? error.message : String(error)
+                showToast(`Failed to update log level: ${errMsg}`, "error")
+              }
+            }}
+            className="sys-select"
+            style={{
+              width: "auto",
+              fontSize: 12,
+              height: 28,
+              padding: "0 28px 0 10px",
+            }}
+          >
+            {LOG_LEVELS.map((level) => (
+              <option key={level.value} value={level.value}>
+                {level.label}
+              </option>
+            ))}
+          </select>
+
+          <div
+            style={{
+              width: 1,
+              height: 20,
+              background: "var(--color-separator-opaque)",
+            }}
+          />
+
           <button
             className="btn btn-ghost btn-sm"
             onClick={() => setAutoScroll((prev) => !prev)}
+            title={
+              autoScroll ?
+                "Auto-scroll is on — click to disable"
+              : "Auto-scroll is off — click to enable"
+            }
           >
-            {autoScroll ? "Auto-scroll On" : "Auto-scroll Off"}
+            {autoScroll ? "⬇ Auto" : "Manual"}
           </button>
           <button
             className="btn btn-ghost btn-sm"
@@ -288,7 +372,11 @@ export function LoggingPage({
           >
             ↓ Bottom
           </button>
-          <button className="btn btn-ghost btn-sm" onClick={clearLogs}>
+          <button
+            className="btn btn-ghost btn-sm"
+            onClick={clearLogs}
+            disabled={lines.length === 0}
+          >
             Clear
           </button>
           <button
@@ -301,164 +389,8 @@ export function LoggingPage({
         </div>
       </div>
 
-      {/* Stream State moved to top */}
-      <div style={{ marginBottom: 24 }}>
-        <div
-          style={{
-            fontSize: 12,
-            fontWeight: 600,
-            color: "var(--color-text-secondary)",
-            marginBottom: 10,
-          }}
-        >
-          Stream State
-        </div>
-        <div
-          style={{
-            ...card,
-            display: "flex",
-            alignItems: "center",
-            padding: "12px 16px",
-            gap: 24,
-          }}
-        >
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <span
-              style={{ fontSize: 13, color: "var(--color-text-secondary)" }}
-            >
-              Connection
-            </span>
-            <span
-              style={{
-                fontSize: 12,
-                fontWeight: 600,
-                padding: "3px 10px",
-                borderRadius: "var(--radius-pill)",
-                background:
-                  connected ?
-                    "var(--color-green-fill)"
-                  : "var(--color-orange-fill)",
-                color: connected ? "var(--color-green)" : "var(--color-orange)",
-              }}
-            >
-              {
-                /* eslint-disable-next-line no-nested-ternary */
-                connecting ?
-                  "Connecting"
-                : connected ?
-                  "Live"
-                : "Retrying"
-              }
-            </span>
-          </div>
-
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <span
-              style={{ fontSize: 13, color: "var(--color-text-secondary)" }}
-            >
-              Visible Lines
-            </span>
-            <span
-              style={{
-                fontSize: 13,
-                fontFamily: "var(--font-mono)",
-                color: "var(--color-text)",
-                fontWeight: 600,
-              }}
-            >
-              {lines.length}
-            </span>
-          </div>
-
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <span
-              style={{ fontSize: 13, color: "var(--color-text-secondary)" }}
-            >
-              Log Level
-            </span>
-            <select
-              value={logLevel ?? "info"}
-              onChange={async (e) => {
-                const newLevel = e.target.value as LogLevel
-                try {
-                  log.info("changing log level", {
-                    from: logLevel,
-                    to: newLevel,
-                  })
-                  await updateLogLevel(newLevel)
-                  setLogLevelState(newLevel)
-                  showToast(
-                    `Log level changed to ${LOG_LEVELS.find((level) => level.value === newLevel)?.label ?? newLevel}`,
-                  )
-                } catch (error) {
-                  log.error("failed to update log level", error)
-                  showToast(
-                    `Failed to update log level: ${error instanceof Error ? error.message : String(error)}`,
-                    "error",
-                  )
-                }
-              }}
-              style={{
-                fontSize: 12,
-                fontFamily: "var(--font-mono)",
-                color: "var(--color-blue)",
-                fontWeight: 600,
-                background: "transparent",
-                border: "1px solid var(--color-separator)",
-                borderRadius: "var(--radius-sm)",
-                padding: "4px 8px",
-                cursor: "pointer",
-              }}
-            >
-              {LOG_LEVELS.map((level) => (
-                <option key={level.value} value={level.value}>
-                  {level.value} {level.label}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              marginLeft: "auto",
-            }}
-          >
-            {connecting ?
-              <Spin />
-            : <span
-                className={`status-dot ${
-                  connected ? "status-dot-active" : "status-dot-inactive"
-                }`}
-              />
-            }
-            <span
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: 11,
-                color: "var(--color-text-tertiary)",
-              }}
-            >
-              /api/admin/logs/stream
-            </span>
-          </div>
-        </div>
-      </div>
-
       {/* Full-width logging area */}
       <section>
-        <div
-          style={{
-            fontSize: 12,
-            fontWeight: 600,
-            color: "var(--color-text-secondary)",
-            marginBottom: 10,
-          }}
-        >
-          Live Output
-        </div>
         <div style={card}>
           <div
             style={{
@@ -466,7 +398,7 @@ export function LoggingPage({
               alignItems: "center",
               justifyContent: "space-between",
               gap: 12,
-              padding: "11px 16px",
+              padding: "10px 16px",
               borderBottom: "1px solid var(--color-separator)",
               background: "rgba(255,255,255,0.02)",
             }}
@@ -483,36 +415,44 @@ export function LoggingPage({
               {connecting ?
                 <Spin />
               : <span
-                  className={`status-dot ${
-                    connected ? "status-dot-active" : "status-dot-inactive"
-                  }`}
+                  className={`status-dot ${connected ? "status-dot-active" : "status-dot-inactive"}`}
                 />
               }
-              {
-                /* eslint-disable-next-line no-nested-ternary */
-                connecting ?
-                  "Opening stream..."
-                : connected ?
-                  "Receiving new log lines"
-                : "Waiting for reconnect"
-              }
+              {/* eslint-disable-next-line no-nested-ternary */}
+              {connecting ?
+                "Opening stream…"
+              : connected ?
+                "Receiving new log lines"
+              : "Waiting for reconnect"}
             </div>
-            <span
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: 11,
-                color: "var(--color-text-tertiary)",
-              }}
-            >
-              Buffer: {lines.length}/{MAX_LINES} lines
-            </span>
+            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 11,
+                  color: "var(--color-text-tertiary)",
+                }}
+              >
+                {lines.length}/{MAX_LINES} lines
+              </span>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 10,
+                  color: "var(--color-text-tertiary)",
+                  opacity: 0.7,
+                }}
+              >
+                /api/admin/logs/stream
+              </span>
+            </div>
           </div>
 
           <div
             ref={logViewportRef}
             style={{
               minHeight: 500,
-              maxHeight: "calc(100vh - 280px)",
+              maxHeight: "calc(100vh - 260px)",
               overflow: "auto",
               background:
                 "linear-gradient(180deg, rgba(255,255,255,0.015), rgba(255,255,255,0.005))",
@@ -531,13 +471,14 @@ export function LoggingPage({
                   fontSize: 13,
                 }}
               >
-                {connecting ?
+                {connecting && (
                   <div
                     style={{ display: "flex", alignItems: "center", gap: 10 }}
                   >
                     <Spin /> Connecting to log stream...
                   </div>
-                : "No log lines received yet."}
+                )}
+                {!connecting && "No log lines received yet."}
               </div>
             : <div
                 style={{

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -199,30 +199,58 @@ export function AboutPage({
             gap: 12,
           }}
         >
-          <div style={{ ...card, padding: "16px 18px" }}>
-            <div style={{ fontSize: 12, color: "var(--color-text-secondary)" }}>
+          <div
+            style={{
+              ...card,
+              padding: "16px 18px",
+              borderTop: "2px solid var(--color-blue)",
+            }}
+          >
+            <div
+              style={{
+                fontSize: 11,
+                fontWeight: 600,
+                textTransform: "uppercase",
+                letterSpacing: "0.06em",
+                color: "var(--color-text-tertiary)",
+              }}
+            >
               Version
             </div>
             <div
               style={{
-                marginTop: 6,
-                fontSize: 18,
+                marginTop: 8,
+                fontSize: 20,
                 fontWeight: 700,
-                color: "var(--color-text)",
+                color: "var(--color-blue)",
                 fontFamily: "var(--font-mono)",
               }}
             >
               {info?.version ?? "—"}
             </div>
           </div>
-          <div style={{ ...card, padding: "16px 18px" }}>
-            <div style={{ fontSize: 12, color: "var(--color-text-secondary)" }}>
+          <div
+            style={{
+              ...card,
+              padding: "16px 18px",
+              borderTop: "2px solid var(--color-green)",
+            }}
+          >
+            <div
+              style={{
+                fontSize: 11,
+                fontWeight: 600,
+                textTransform: "uppercase",
+                letterSpacing: "0.06em",
+                color: "var(--color-text-tertiary)",
+              }}
+            >
               Active Provider
             </div>
             <div
               style={{
-                marginTop: 6,
-                fontSize: 18,
+                marginTop: 8,
+                fontSize: 20,
                 fontWeight: 700,
                 color: "var(--color-text)",
               }}
@@ -230,14 +258,28 @@ export function AboutPage({
               {displayedProvider}
             </div>
           </div>
-          <div style={{ ...card, padding: "16px 18px" }}>
-            <div style={{ fontSize: 12, color: "var(--color-text-secondary)" }}>
+          <div
+            style={{
+              ...card,
+              padding: "16px 18px",
+              borderTop: "2px solid var(--color-purple)",
+            }}
+          >
+            <div
+              style={{
+                fontSize: 11,
+                fontWeight: 600,
+                textTransform: "uppercase",
+                letterSpacing: "0.06em",
+                color: "var(--color-text-tertiary)",
+              }}
+            >
               Available Models
             </div>
             <div
               style={{
-                marginTop: 6,
-                fontSize: 18,
+                marginTop: 8,
+                fontSize: 20,
                 fontWeight: 700,
                 color: "var(--color-text)",
               }}

--- a/frontend/src/pages/VmodelPage.tsx
+++ b/frontend/src/pages/VmodelPage.tsx
@@ -391,8 +391,12 @@ export function VmodelPage({ showToast }: Props) {
                     style={{
                       textAlign: "left",
                       padding: 16,
-                      background: "var(--color-bg-elevated)",
+                      background:
+                        isSelected ?
+                          "var(--color-blue-fill)"
+                        : "var(--color-bg-elevated)",
                       cursor: "pointer",
+                      transition: "all 0.15s var(--ease)",
                     }}
                   >
                     <div
@@ -546,13 +550,24 @@ export function VmodelPage({ showToast }: Props) {
                       </div>
                       <button
                         type="button"
-                        className="btn btn-ghost btn-sm"
+                        className="btn btn-icon btn-icon-ghost btn-icon-danger"
+                        title={`Delete ${vm.virtual_model_id}`}
                         onClick={(e) => {
                           e.stopPropagation()
                           handleDelete(vm.virtual_model_id)
                         }}
                       >
-                        Delete
+                        <svg
+                          width="13"
+                          height="13"
+                          viewBox="0 0 14 14"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.8"
+                          strokeLinecap="round"
+                        >
+                          <path d="M2 3.5h10M5.5 3.5V2.5a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1M5.5 6v4M8.5 6v4M3 3.5l.7 7a1 1 0 001 .9h4.6a1 1 0 001-.9l.7-7" />
+                        </svg>
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
- App: add breadcrumb-style header (OmniLLM / Page) and live port status dot
- CSS: add panel-active glow style, nav-item active hover, chat-input-wrapper
  focus-ring, and animated thinking-dots keyframes
- ChatPage: wrap input in chat-input-wrapper for unified focus ring; replace
  spinner + italic text with 3-dot animated thinking indicator; tighten padding
- LoggingPage: consolidate stream state into header toolbar, remove redundant
  status card, use sys-select for log level, improve maxHeight
- SettingsPage: add colored top-border accents to stat cards (blue/green/purple)
  with uppercase labels for visual hierarchy
- ConfigPage: switch tool card grid to auto-fill minmax for responsive layout;
  improve unsaved-changes indicator to an orange pill badge
- VmodelPage: apply panel-active class for selected card highlight; replace text
  Delete button with icon-only trash button using btn-icon-danger styling
