### PR TITLE
Update Azure OpenAI config handling and provider improvements

### DIFF
--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -301,6 +301,16 @@ function parseTOML(text: string): CodexConfig {
     }
   }
 
+  // Any known global field that is absent from the file was intentionally
+  // omitted (unchecked). Mark it disabled so the checkbox stays unchecked
+  // after a reload.
+  const disabledKeys = new Set<string>()
+  if (result.model === undefined) disabledKeys.add("model")
+  if (result.model_reasoning_effort === undefined)
+    disabledKeys.add("model_reasoning_effort")
+  if (result.profile === undefined) disabledKeys.add("profile")
+  result.__disabledKeys = disabledKeys
+
   return result
 }
 
@@ -3101,7 +3111,10 @@ export function ConfigPage({ showToast }: ConfigPageProps) {
           }),
         )
       }
-      return serializeTOML(cleanConfig, originalContent)
+      return serializeTOML(
+        { ...cleanConfig, __disabledKeys: codexConfig.__disabledKeys },
+        originalContent,
+      )
     }
     if (activeConfig === "opencode" && opencodeConfig)
       return JSON.stringify(opencodeConfig, null, 2) + "\n"

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -507,15 +507,31 @@ function AzureOpenAIAuthForm({
   onCancel: () => void
 }) {
   const [apiKey, setApiKey] = useState("")
+  const [endpoint, setEndpoint] = useState("")
+  const [apiVersion, setApiVersion] = useState("")
+  const [deploymentsText, setDeploymentsText] = useState("")
+  const [isMultiline, setIsMultiline] = useState(false)
+
   const submit = async () => {
     if (!apiKey.trim()) return
+
+    // Parse deployments from either single-line or multi-line format
+    const deploymentsArray = deploymentsText
+      .split(/[,\n]/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+
     await onSubmit({
       apiKey: apiKey.trim(),
+      endpoint: endpoint.trim(),
+      apiVersion: apiVersion.trim() || "2024-02-01",
+      deployments: JSON.stringify(deploymentsArray),
     })
   }
+
   return (
     <AuthFormWrapper title="Authenticate Azure OpenAI">
-      <FormRow label="API Key">
+      <FormRow label="API Key *">
         <SecretInput
           className="sys-input"
           placeholder="Enter your Azure OpenAI API key"
@@ -523,10 +539,64 @@ function AzureOpenAIAuthForm({
           onChange={setApiKey}
         />
       </FormRow>
+
+      <FormRow label="Endpoint (optional)">
+        <input
+          className="sys-input"
+          type="text"
+          placeholder="https://your-resource.openai.azure.com"
+          value={endpoint}
+          onChange={(e) => setEndpoint(e.target.value)}
+        />
+      </FormRow>
+
+      <FormRow label="API Version (optional)">
+        <input
+          className="sys-input"
+          type="text"
+          placeholder="2024-02-01"
+          value={apiVersion}
+          onChange={(e) => setApiVersion(e.target.value)}
+        />
+      </FormRow>
+
+      <FormRow label="Deployments (optional)">
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {isMultiline ?
+            <textarea
+              className="sys-input"
+              placeholder="Enter deployment names, one per line"
+              value={deploymentsText}
+              onChange={(e) => setDeploymentsText(e.target.value)}
+              style={{
+                minHeight: 100,
+                fontFamily: "monospace",
+                fontSize: 13,
+              }}
+            />
+          : <input
+              className="sys-input"
+              type="text"
+              placeholder="deployment1, deployment2, deployment3"
+              value={deploymentsText}
+              onChange={(e) => setDeploymentsText(e.target.value)}
+            />
+          }
+          <button
+            className="btn btn-ghost btn-sm"
+            onClick={() => setIsMultiline(!isMultiline)}
+            style={{ alignSelf: "flex-start" }}
+          >
+            {isMultiline ? "Use single line" : "Use multi-line"}
+          </button>
+        </div>
+      </FormRow>
+
       <div style={{ fontSize: 12, color: "var(--color-text-tertiary)" }}>
-        Enter your Azure OpenAI API key. Use the "Configure" button to set
-        endpoint and deployments.
+        Optionally set endpoint, API version, and deployments here, or configure
+        them later via the Configure button.
       </div>
+
       <div style={{ display: "flex", gap: 8 }}>
         <button className="btn btn-primary btn-sm" onClick={submit}>
           Submit

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -71,6 +71,48 @@ function Spin({ size = 14 }: { size?: number }) {
   )
 }
 
+interface AzureDeploymentMapping {
+  model: string
+  deployment: string
+}
+
+function normalizeAzureDeploymentMappings(
+  value: unknown,
+): Array<AzureDeploymentMapping> {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item) => {
+    if (typeof item === "string") {
+      const trimmed = item.trim()
+      return trimmed ? [{ model: trimmed, deployment: trimmed }] : []
+    }
+    if (item && typeof item === "object") {
+      const model =
+        typeof (item as { model?: unknown }).model === "string" ?
+          (item as { model: string }).model.trim()
+        : ""
+      const deployment =
+        typeof (item as { deployment?: unknown }).deployment === "string" ?
+          (item as { deployment: string }).deployment.trim()
+        : ""
+      return model && deployment ? [{ model, deployment }] : []
+    }
+    return []
+  })
+}
+
+function serializeAzureDeploymentMappings(
+  mappings: Array<AzureDeploymentMapping>,
+): string {
+  return JSON.stringify(
+    mappings
+      .map((mapping) => ({
+        model: mapping.model.trim(),
+        deployment: mapping.deployment.trim(),
+      }))
+      .filter((mapping) => mapping.model && mapping.deployment),
+  )
+}
+
 // ─── Inline Auth Forms ────────────────────────────────────────────────────────
 
 function FormRow({
@@ -509,23 +551,42 @@ function AzureOpenAIAuthForm({
   const [apiKey, setApiKey] = useState("")
   const [endpoint, setEndpoint] = useState("")
   const [apiVersion, setApiVersion] = useState("")
-  const [deploymentsText, setDeploymentsText] = useState("")
-  const [isMultiline, setIsMultiline] = useState(false)
+  const [mappings, setMappings] = useState<Array<AzureDeploymentMapping>>([
+    { model: "", deployment: "" },
+  ])
+
+  const updateMapping = (
+    index: number,
+    field: keyof AzureDeploymentMapping,
+    value: string,
+  ) => {
+    setMappings((prev) =>
+      prev.map((mapping, i) =>
+        i === index ? { ...mapping, [field]: value } : mapping,
+      ),
+    )
+  }
+
+  const addMapping = () => {
+    setMappings((prev) => [...prev, { model: "", deployment: "" }])
+  }
+
+  const removeMapping = (index: number) => {
+    setMappings((prev) =>
+      prev.length === 1 ?
+        [{ model: "", deployment: "" }]
+      : prev.filter((_, i) => i !== index),
+    )
+  }
 
   const submit = async () => {
     if (!apiKey.trim()) return
-
-    // Parse deployments from either single-line or multi-line format
-    const deploymentsArray = deploymentsText
-      .split(/[,\n]/)
-      .map((s) => s.trim())
-      .filter(Boolean)
 
     await onSubmit({
       apiKey: apiKey.trim(),
       endpoint: endpoint.trim(),
       apiVersion: apiVersion.trim() || "2024-02-01",
-      deployments: JSON.stringify(deploymentsArray),
+      deployments: serializeAzureDeploymentMappings(mappings),
     })
   }
 
@@ -560,41 +621,57 @@ function AzureOpenAIAuthForm({
         />
       </FormRow>
 
-      <FormRow label="Deployments (optional)">
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          {isMultiline ?
-            <textarea
-              className="sys-input"
-              placeholder="Enter deployment names, one per line"
-              value={deploymentsText}
-              onChange={(e) => setDeploymentsText(e.target.value)}
+      <FormRow label="Models + Deployments (optional)">
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {mappings.map((mapping, index) => (
+            <div
+              key={index}
               style={{
-                minHeight: 100,
-                fontFamily: "monospace",
-                fontSize: 13,
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr auto",
+                gap: 8,
+                alignItems: "center",
               }}
-            />
-          : <input
-              className="sys-input"
-              type="text"
-              placeholder="deployment1, deployment2, deployment3"
-              value={deploymentsText}
-              onChange={(e) => setDeploymentsText(e.target.value)}
-            />
-          }
+            >
+              <input
+                className="sys-input"
+                type="text"
+                placeholder="Model name (e.g. gpt-5.4)"
+                value={mapping.model}
+                onChange={(e) => updateMapping(index, "model", e.target.value)}
+              />
+              <input
+                className="sys-input"
+                type="text"
+                placeholder="Deployment name"
+                value={mapping.deployment}
+                onChange={(e) =>
+                  updateMapping(index, "deployment", e.target.value)
+                }
+              />
+              <button
+                className="btn btn-ghost btn-sm"
+                onClick={() => removeMapping(index)}
+                type="button"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
           <button
             className="btn btn-ghost btn-sm"
-            onClick={() => setIsMultiline(!isMultiline)}
+            onClick={addMapping}
+            type="button"
             style={{ alignSelf: "flex-start" }}
           >
-            {isMultiline ? "Use single line" : "Use multi-line"}
+            + Add model mapping
           </button>
         </div>
       </FormRow>
 
       <div style={{ fontSize: 12, color: "var(--color-text-tertiary)" }}>
-        Optionally set endpoint, API version, and deployments here, or configure
-        them later via the Configure button.
+        Configure app-facing model names separately from Azure deployment names.
+        You can also update mappings later via the provider’s Models menu.
       </div>
 
       <div style={{ display: "flex", gap: 8 }}>
@@ -626,10 +703,9 @@ function _ModelsDialog({
   const [configLoading, setConfigLoading] = useState(false)
 
   // Azure OpenAI deployment management
-  const [newDeployment, setNewDeployment] = useState("")
-  const [deployments, setDeployments] = useState<Array<string>>(
-    provider.config?.deployments || [],
-  )
+  const [azureMappings, setAzureMappings] = useState<
+    Array<AzureDeploymentMapping>
+  >(normalizeAzureDeploymentMappings(provider.config?.deployments))
 
   // OpenAI-compatible user-defined model management
   const [newModel, setNewModel] = useState("")
@@ -642,7 +718,9 @@ function _ModelsDialog({
 
   useEffect(() => {
     if (provider.type === "azure-openai") {
-      setDeployments(provider.config?.deployments || [])
+      setAzureMappings(
+        normalizeAzureDeploymentMappings(provider.config?.deployments),
+      )
     }
     if (provider.type === "openai-compatible") {
       setUserModels((provider.config?.models as Array<string>) || [])
@@ -668,9 +746,10 @@ function _ModelsDialog({
   const handleOpen = () => {
     setOpen(true)
     if (models === null && !loading) load()
-    setNewDeployment("")
     if (provider.type === "azure-openai") {
-      setDeployments(provider.config?.deployments || [])
+      setAzureMappings(
+        normalizeAzureDeploymentMappings(provider.config?.deployments),
+      )
     }
     if (provider.type === "openai-compatible") {
       setUserModels((provider.config?.models as Array<string>) || [])
@@ -701,28 +780,26 @@ function _ModelsDialog({
     }
   }
 
-  const handleAddDeployment = async () => {
-    if (!newDeployment.trim() || provider.type !== "azure-openai") return
-
-    const deploymentName = newDeployment.trim()
-    if (deployments.includes(deploymentName)) {
-      setError("Deployment already exists")
-      return
-    }
+  const saveAzureMappings = async (
+    nextMappings: Array<AzureDeploymentMapping>,
+  ) => {
+    if (provider.type !== "azure-openai") return
 
     setConfigLoading(true)
     setError(null)
     try {
-      const newDeployments = [...deployments, deploymentName]
       await updateProviderConfig(provider.id, {
         endpoint: provider.config?.endpoint,
         apiVersion: provider.config?.apiVersion || "2024-02-01",
-        deployments: newDeployments,
+        deployments: nextMappings
+          .map((mapping) => ({
+            model: mapping.model.trim(),
+            deployment: mapping.deployment.trim(),
+          }))
+          .filter((mapping) => mapping.model && mapping.deployment),
       })
-      setDeployments(newDeployments)
-      setNewDeployment("")
-      onModelsChanged?.() // Refresh provider data
-      // Reload models to show the new deployment
+      setAzureMappings(nextMappings)
+      onModelsChanged?.()
       await load()
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
@@ -731,27 +808,30 @@ function _ModelsDialog({
     }
   }
 
-  const handleRemoveDeployment = async (deploymentName: string) => {
-    if (provider.type !== "azure-openai") return
+  const updateAzureMapping = (
+    index: number,
+    field: keyof AzureDeploymentMapping,
+    value: string,
+  ) => {
+    setAzureMappings((prev) =>
+      prev.map((mapping, i) =>
+        i === index ? { ...mapping, [field]: value } : mapping,
+      ),
+    )
+  }
 
-    setConfigLoading(true)
-    setError(null)
-    try {
-      const newDeployments = deployments.filter((d) => d !== deploymentName)
-      await updateProviderConfig(provider.id, {
-        endpoint: provider.config?.endpoint,
-        apiVersion: provider.config?.apiVersion || "2024-02-01",
-        deployments: newDeployments,
-      })
-      setDeployments(newDeployments)
-      onModelsChanged?.() // Refresh provider data
-      // Reload models to reflect the removed deployment
-      await load()
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setConfigLoading(false)
-    }
+  const addAzureMappingRow = () => {
+    setAzureMappings((prev) => [...prev, { model: "", deployment: "" }])
+  }
+
+  const removeAzureMappingRow = async (index: number) => {
+    if (provider.type !== "azure-openai") return
+    const nextMappings = azureMappings.filter((_, i) => i !== index)
+    await saveAzureMappings(nextMappings)
+  }
+
+  const persistAzureMappings = async () => {
+    await saveAzureMappings(azureMappings)
   }
 
   const handleAddUserModel = async () => {
@@ -984,39 +1064,83 @@ function _ModelsDialog({
                           marginBottom: 12,
                         }}
                       >
-                        Deployment Management
+                        Model ↔ Deployment Mapping
                       </div>
                       <div
                         style={{
                           display: "flex",
+                          flexDirection: "column",
                           gap: 8,
-                          alignItems: "center",
-                          marginBottom: 8,
+                          marginBottom: 10,
                         }}
                       >
-                        <input
-                          className="sys-input"
-                          placeholder="Add deployment name..."
-                          value={newDeployment}
-                          onChange={(e) => setNewDeployment(e.target.value)}
+                        {azureMappings.map((mapping, index) => (
+                          <div
+                            key={index}
+                            style={{
+                              display: "grid",
+                              gridTemplateColumns: "1fr 1fr auto",
+                              gap: 8,
+                              alignItems: "center",
+                            }}
+                          >
+                            <input
+                              className="sys-input"
+                              placeholder="Model name"
+                              value={mapping.model}
+                              onChange={(e) =>
+                                updateAzureMapping(
+                                  index,
+                                  "model",
+                                  e.target.value,
+                                )
+                              }
+                              disabled={configLoading}
+                              style={{ fontSize: 13 }}
+                            />
+                            <input
+                              className="sys-input"
+                              placeholder="Deployment name"
+                              value={mapping.deployment}
+                              onChange={(e) =>
+                                updateAzureMapping(
+                                  index,
+                                  "deployment",
+                                  e.target.value,
+                                )
+                              }
+                              disabled={configLoading}
+                              style={{ fontSize: 13 }}
+                            />
+                            <button
+                              className="btn btn-ghost btn-sm"
+                              onClick={() => removeAzureMappingRow(index)}
+                              disabled={configLoading}
+                              type="button"
+                            >
+                              Remove
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                      <div style={{ display: "flex", gap: 8, marginBottom: 8 }}>
+                        <button
+                          className="btn btn-ghost btn-sm"
+                          onClick={addAzureMappingRow}
                           disabled={configLoading}
-                          style={{ flex: 1, fontSize: 13 }}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                              e.preventDefault()
-                              handleAddDeployment()
-                            }
-                          }}
-                        />
+                          type="button"
+                        >
+                          + Add mapping
+                        </button>
                         <button
                           className="btn btn-primary btn-sm"
-                          onClick={handleAddDeployment}
-                          disabled={configLoading || !newDeployment.trim()}
-                          style={{ minWidth: 32, padding: "6px 8px" }}
+                          onClick={persistAzureMappings}
+                          disabled={configLoading}
+                          type="button"
                         >
                           {configLoading ?
                             <Spin size={12} />
-                          : "+"}
+                          : "Save mappings"}
                         </button>
                       </div>
                       <div
@@ -1025,8 +1149,8 @@ function _ModelsDialog({
                           color: "var(--color-text-tertiary)",
                         }}
                       >
-                        Enter deployment names from your Azure OpenAI resource.
-                        Each deployment becomes a model.
+                        Model names are shown in the app. Deployment names are
+                        sent to Azure at request time.
                       </div>
                     </div>
                   )}
@@ -1221,10 +1345,23 @@ function _ModelsDialog({
                         >
                           {/* Remove deployment button for Azure OpenAI */}
                           {provider.type === "azure-openai"
-                            && deployments.includes(m.id) && (
+                            && azureMappings.some(
+                              (mapping) =>
+                                mapping.deployment === m.id
+                                || mapping.model === m.id,
+                            ) && (
                               <button
                                 className="btn btn-ghost btn-sm"
-                                onClick={() => handleRemoveDeployment(m.id)}
+                                onClick={() => {
+                                  const mappingIndex = azureMappings.findIndex(
+                                    (mapping) =>
+                                      mapping.deployment === m.id
+                                      || mapping.model === m.id,
+                                  )
+                                  if (mappingIndex !== -1) {
+                                    void removeAzureMappingRow(mappingIndex)
+                                  }
+                                }}
                                 disabled={configLoading}
                                 style={{
                                   minWidth: 32,
@@ -1295,9 +1432,9 @@ function ModelsMenuItem({
   const [search, setSearch] = useState("")
   const [configLoading, setConfigLoading] = useState(false)
   const [newDeployment, setNewDeployment] = useState("")
-  const [deployments, setDeployments] = useState<Array<string>>(
-    provider.config?.deployments || [],
-  )
+  const [azureMappings, setAzureMappings] = useState<
+    Array<AzureDeploymentMapping>
+  >(normalizeAzureDeploymentMappings(provider.config?.deployments))
 
   // OpenAI-compatible user-defined model management
   const [newModel, setNewModel] = useState("")
@@ -1307,10 +1444,15 @@ function ModelsMenuItem({
   const [apiFormat, setApiFormat] = useState<OpenAICompatibleAPIFormat>(
     normalizeOpenAICompatibleAPIFormat(provider.config?.apiFormat),
   )
+  const deployments = new Set(
+    azureMappings.map((mapping) => mapping.deployment),
+  )
 
   useEffect(() => {
     if (provider.type === "azure-openai") {
-      setDeployments(provider.config?.deployments || [])
+      setAzureMappings(
+        normalizeAzureDeploymentMappings(provider.config?.deployments),
+      )
     }
     if (provider.type === "openai-compatible") {
       setUserModels((provider.config?.models as Array<string>) || [])
@@ -1336,9 +1478,10 @@ function ModelsMenuItem({
   const handleOpen = () => {
     setOpen(true)
     if (models === null && !loading) load()
-    setNewDeployment("")
     if (provider.type === "azure-openai") {
-      setDeployments(provider.config?.deployments || [])
+      setAzureMappings(
+        normalizeAzureDeploymentMappings(provider.config?.deployments),
+      )
     }
     if (provider.type === "openai-compatible") {
       setUserModels((provider.config?.models as Array<string>) || [])
@@ -1372,20 +1515,25 @@ function ModelsMenuItem({
   const handleAddDeployment = async () => {
     if (!newDeployment.trim() || provider.type !== "azure-openai") return
     const deploymentName = newDeployment.trim()
-    if (deployments.includes(deploymentName)) {
+    if (
+      azureMappings.some((mapping) => mapping.deployment === deploymentName)
+    ) {
       setError("Deployment already exists")
       return
     }
     setConfigLoading(true)
     setError(null)
     try {
-      const newDeployments = [...deployments, deploymentName]
+      const nextMappings = [
+        ...azureMappings,
+        { model: deploymentName, deployment: deploymentName },
+      ]
       await updateProviderConfig(provider.id, {
         endpoint: provider.config?.endpoint,
         apiVersion: provider.config?.apiVersion || "2024-02-01",
-        deployments: newDeployments,
+        deployments: nextMappings,
       })
-      setDeployments(newDeployments)
+      setAzureMappings(nextMappings)
       setNewDeployment("")
       onModelsChanged?.()
       await load()
@@ -1401,13 +1549,17 @@ function ModelsMenuItem({
     setConfigLoading(true)
     setError(null)
     try {
-      const newDeployments = deployments.filter((d) => d !== deploymentName)
+      const nextMappings = azureMappings.filter(
+        (mapping) =>
+          mapping.deployment !== deploymentName
+          && mapping.model !== deploymentName,
+      )
       await updateProviderConfig(provider.id, {
         endpoint: provider.config?.endpoint,
         apiVersion: provider.config?.apiVersion || "2024-02-01",
-        deployments: newDeployments,
+        deployments: nextMappings,
       })
-      setDeployments(newDeployments)
+      setAzureMappings(nextMappings)
       onModelsChanged?.()
       await load()
     } catch (e) {
@@ -1883,7 +2035,7 @@ function ModelsMenuItem({
                           }}
                         >
                           {provider.type === "azure-openai"
-                            && deployments.includes(m.id) && (
+                            && deployments.has(m.id) && (
                               <button
                                 className="btn btn-ghost btn-sm"
                                 onClick={() => handleRemoveDeployment(m.id)}
@@ -3199,13 +3351,49 @@ function AddFlowAzureForm({
 }: AddFlowFormProps) {
   const [apiKey, setApiKey] = useState("")
   const [endpoint, setEndpoint] = useState("")
-  const submit = async () => {
-    if (!apiKey.trim() || !endpoint.trim()) return
-    await onSubmit({ apiKey: apiKey.trim(), endpoint: endpoint.trim() })
+  const [apiVersion, setApiVersion] = useState("")
+  const [mappings, setMappings] = useState<Array<AzureDeploymentMapping>>([
+    { model: "", deployment: "" },
+  ])
+
+  const updateMapping = (
+    index: number,
+    field: keyof AzureDeploymentMapping,
+    value: string,
+  ) => {
+    setMappings((prev) =>
+      prev.map((mapping, i) =>
+        i === index ? { ...mapping, [field]: value } : mapping,
+      ),
+    )
   }
+
+  const addMapping = () => {
+    setMappings((prev) => [...prev, { model: "", deployment: "" }])
+  }
+
+  const removeMapping = (index: number) => {
+    setMappings((prev) =>
+      prev.length === 1 ?
+        [{ model: "", deployment: "" }]
+      : prev.filter((_, i) => i !== index),
+    )
+  }
+
+  const submit = async () => {
+    if (!apiKey.trim()) return
+
+    await onSubmit({
+      apiKey: apiKey.trim(),
+      endpoint: endpoint.trim(),
+      apiVersion: apiVersion.trim() || "2024-02-01",
+      deployments: serializeAzureDeploymentMappings(mappings),
+    })
+  }
+
   return (
     <div style={addFlowPanelStyle}>
-      <FormRow label="Endpoint">
+      <FormRow label="Endpoint (optional)">
         <input
           type="text"
           placeholder="https://your-resource.openai.azure.com"
@@ -3214,6 +3402,67 @@ function AddFlowAzureForm({
           style={addFlowTextInputStyle}
           autoComplete="off"
         />
+      </FormRow>
+      <FormRow label="API Version (optional)">
+        <input
+          type="text"
+          placeholder="2024-02-01"
+          value={apiVersion}
+          onChange={(e) => setApiVersion(e.target.value)}
+          style={addFlowTextInputStyle}
+          autoComplete="off"
+        />
+      </FormRow>
+      <FormRow label="Models + Deployments (optional)">
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {mappings.map((mapping, index) => (
+            <div
+              key={index}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr auto",
+                gap: 8,
+                alignItems: "center",
+              }}
+            >
+              <input
+                type="text"
+                placeholder="Model name (e.g. gpt-5.4)"
+                value={mapping.model}
+                onChange={(e) => updateMapping(index, "model", e.target.value)}
+                style={addFlowTextInputStyle}
+                autoComplete="off"
+              />
+              <input
+                type="text"
+                placeholder="Deployment name"
+                value={mapping.deployment}
+                onChange={(e) =>
+                  updateMapping(index, "deployment", e.target.value)
+                }
+                style={addFlowTextInputStyle}
+                autoComplete="off"
+              />
+              <button
+                className="btn btn-ghost btn-sm"
+                onClick={() => removeMapping(index)}
+                disabled={submitting}
+                type="button"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+          <button
+            className="btn btn-ghost btn-sm"
+            onClick={addMapping}
+            disabled={submitting}
+            type="button"
+            style={{ alignSelf: "flex-start" }}
+          >
+            + Add model mapping
+          </button>
+        </div>
       </FormRow>
       <FormRow label="API Key">
         <SecretInput
@@ -3225,8 +3474,8 @@ function AddFlowAzureForm({
         />
       </FormRow>
       <AddFlowHint>
-        Use your Azure endpoint and key here. Deployments can be configured
-        after the provider is added.
+        Configure app-facing model names separately from Azure deployment names.
+        You can also update mappings later from the provider’s Models menu.
       </AddFlowHint>
       <div style={{ display: "flex", gap: 8 }}>
         <button

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -89,16 +89,97 @@ var DefaultModels = []types.Model{
 	{ID: "gpt-4o-mini", Name: "GPT-4o Mini", MaxTokens: 128000, Provider: "azure-openai"},
 }
 
+type DeploymentMapping struct {
+	Model      string `json:"model"`
+	Deployment string `json:"deployment"`
+}
+
+// DeploymentMappings returns Azure deployment mappings from config.
+// It supports both legacy string deployments and structured model/deployment mappings.
+func DeploymentMappings(config map[string]interface{}) []DeploymentMapping {
+	if config == nil {
+		return nil
+	}
+	raw, exists := config["deployments"]
+	if !exists {
+		return nil
+	}
+
+	switch value := raw.(type) {
+	case []string:
+		result := make([]DeploymentMapping, 0, len(value))
+		for _, deployment := range value {
+			deployment = strings.TrimSpace(deployment)
+			if deployment == "" {
+				continue
+			}
+			result = append(result, DeploymentMapping{Model: deployment, Deployment: deployment})
+		}
+		return result
+	case []interface{}:
+		result := make([]DeploymentMapping, 0, len(value))
+		for _, item := range value {
+			switch typed := item.(type) {
+			case string:
+				deployment := strings.TrimSpace(typed)
+				if deployment == "" {
+					continue
+				}
+				result = append(result, DeploymentMapping{Model: deployment, Deployment: deployment})
+			case map[string]interface{}:
+				model, _ := typed["model"].(string)
+				deployment, _ := typed["deployment"].(string)
+				model = strings.TrimSpace(model)
+				deployment = strings.TrimSpace(deployment)
+				if model == "" || deployment == "" {
+					continue
+				}
+				result = append(result, DeploymentMapping{Model: model, Deployment: deployment})
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+// RemapModel maps an app-facing Azure model name to the configured Azure deployment name.
+// If no mapping exists, it returns the original model unchanged.
+func RemapModel(config map[string]interface{}, model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return model
+	}
+	for _, mapping := range DeploymentMappings(config) {
+		if strings.EqualFold(strings.TrimSpace(mapping.Model), model) {
+			return mapping.Deployment
+		}
+	}
+	return model
+}
+
+// ModelIDs returns the app-facing Azure model IDs from config.
+func ModelIDs(config map[string]interface{}) []string {
+	mappings := DeploymentMappings(config)
+	result := make([]string, 0, len(mappings))
+	for _, mapping := range mappings {
+		if mapping.Model != "" {
+			result = append(result, mapping.Model)
+		}
+	}
+	return result
+}
+
 // GetModels returns the available models for this Azure OpenAI instance.
-// If the config contains a "deployments" list those are used; otherwise the
+// If the config contains deployment mappings those are used; otherwise the
 // built-in catalog is returned.
 func GetModels(instanceID string, config map[string]interface{}) *types.ModelsResponse {
-	if deployments := stringSliceFromConfig(config, "deployments"); len(deployments) > 0 {
-		models := make([]types.Model, 0, len(deployments))
-		for _, d := range deployments {
+	if mappings := DeploymentMappings(config); len(mappings) > 0 {
+		models := make([]types.Model, 0, len(mappings))
+		for _, mapping := range mappings {
 			models = append(models, types.Model{
-				ID:        d,
-				Name:      d,
+				ID:        mapping.Model,
+				Name:      mapping.Model,
 				MaxTokens: 128000,
 				Provider:  instanceID,
 			})

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"encoding/json"
 	"fmt"
 	"omnillm/internal/database"
 	"omnillm/internal/providers/types"
@@ -27,9 +28,26 @@ func SetupAuth(instanceID string, options *types.AuthOptions) (token, endpoint s
 	if options.Endpoint != "" {
 		cfg["endpoint"] = options.Endpoint
 		resolvedEndpoint = strings.TrimRight(options.Endpoint, "/")
+	}
+
+	// Persist deployments if provided (JSON-encoded string)
+	if options.Deployments != "" {
+		var deployments []string
+		if err := json.Unmarshal([]byte(options.Deployments), &deployments); err == nil {
+			cfg["deployments"] = deployments
+		}
+	}
+
+	// Persist API version if provided
+	if options.APIVersion != "" {
+		cfg["apiVersion"] = options.APIVersion
+	}
+
+	// Save config if it contains any keys
+	if len(cfg) > 0 {
 		configStore := database.NewProviderConfigStore()
 		if saveErr := configStore.Save(instanceID, cfg); saveErr != nil {
-			log.Warn().Err(saveErr).Str("provider", instanceID).Msg("Azure: failed to save endpoint config")
+			log.Warn().Err(saveErr).Str("provider", instanceID).Msg("Azure: failed to save config")
 		}
 	}
 

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -26,21 +26,46 @@ func SetupAuth(instanceID string, options *types.AuthOptions) (token, endpoint s
 	cfg := map[string]interface{}{}
 	resolvedEndpoint := ""
 	if options.Endpoint != "" {
-		cfg["endpoint"] = options.Endpoint
-		resolvedEndpoint = strings.TrimRight(options.Endpoint, "/")
+		trimmed := strings.TrimRight(strings.TrimSpace(options.Endpoint), "/")
+		cfg["endpoint"] = trimmed
+		resolvedEndpoint = trimmed
 	}
 
-	// Persist deployments if provided (JSON-encoded string)
+	// Persist deployments if provided (JSON-encoded string) - accept strings or structured mappings
 	if options.Deployments != "" {
-		var deployments []string
-		if err := json.Unmarshal([]byte(options.Deployments), &deployments); err == nil {
-			cfg["deployments"] = deployments
+		var raw []interface{}
+		if err := json.Unmarshal([]byte(options.Deployments), &raw); err == nil {
+			out := make([]interface{}, 0, len(raw))
+			for _, item := range raw {
+				switch v := item.(type) {
+				case string:
+					trim := strings.TrimSpace(v)
+					if trim == "" {
+						continue
+					}
+					out = append(out, trim)
+				case map[string]interface{}:
+					m := map[string]interface{}{}
+					if mv, ok := v["model"].(string); ok {
+						m["model"] = strings.TrimSpace(mv)
+					}
+					if dv, ok := v["deployment"].(string); ok {
+						m["deployment"] = strings.TrimSpace(dv)
+					}
+					if len(m) > 0 {
+						out = append(out, m)
+					}
+				}
+			}
+			if len(out) > 0 {
+				cfg["deployments"] = out
+			}
 		}
 	}
 
-	// Persist API version if provided
+	// Persist API version if provided (store under api_version)
 	if options.APIVersion != "" {
-		cfg["apiVersion"] = options.APIVersion
+		cfg["api_version"] = options.APIVersion
 	}
 
 	// Save config if it contains any keys
@@ -72,7 +97,11 @@ func ResponsesURL(endpoint string) (string, error) {
 	if endpoint == "" {
 		return "", fmt.Errorf("azure-openai endpoint not configured; set it via the admin UI")
 	}
-	return endpoint + "/openai/v1/responses", nil
+	trimmed := strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if strings.HasSuffix(trimmed, "/openai/v1") {
+		return trimmed + "/responses", nil
+	}
+	return trimmed + "/openai/v1/responses", nil
 }
 
 // Headers returns the HTTP headers for Azure OpenAI API requests.
@@ -131,8 +160,14 @@ func DeploymentMappings(config map[string]interface{}) []DeploymentMapping {
 				deployment, _ := typed["deployment"].(string)
 				model = strings.TrimSpace(model)
 				deployment = strings.TrimSpace(deployment)
-				if model == "" || deployment == "" {
+				if model == "" && deployment == "" {
 					continue
+				}
+				if model == "" {
+					model = deployment
+				}
+				if deployment == "" {
+					deployment = model
 				}
 				result = append(result, DeploymentMapping{Model: model, Deployment: deployment})
 			}
@@ -141,6 +176,112 @@ func DeploymentMappings(config map[string]interface{}) []DeploymentMapping {
 	default:
 		return nil
 	}
+}
+
+// normalizeAzureConfig applies canonical storage keys for Azure provider configs.
+func normalizeAzureConfig(config map[string]interface{}) map[string]interface{} {
+	if config == nil {
+		return map[string]interface{}{}
+	}
+	norm := make(map[string]interface{})
+	if ep, ok := config["endpoint"].(string); ok && ep != "" {
+		norm["endpoint"] = strings.TrimRight(strings.TrimSpace(ep), "/")
+	}
+	if av, ok := config["api_version"].(string); ok && av != "" {
+		norm["api_version"] = av
+	} else if av, ok := config["apiVersion"].(string); ok && av != "" {
+		norm["api_version"] = av
+	}
+	if raw, ok := config["deployments"]; ok {
+		// preserve as-is but normalize inner maps
+		switch v := raw.(type) {
+		case []string:
+			if len(v) > 0 {
+				out := make([]interface{}, 0, len(v))
+				for _, s := range v {
+					s = strings.TrimSpace(s)
+					if s != "" {
+						out = append(out, s)
+					}
+				}
+				if len(out) > 0 {
+					norm["deployments"] = out
+				}
+			}
+		case []interface{}:
+			if len(v) > 0 {
+				out := make([]interface{}, 0, len(v))
+				for _, item := range v {
+					switch it := item.(type) {
+					case string:
+						s := strings.TrimSpace(it)
+						if s != "" {
+							out = append(out, s)
+						}
+					case map[string]interface{}:
+						m := map[string]interface{}{}
+						if mv, ok := it["model"].(string); ok && mv != "" {
+							m["model"] = strings.TrimSpace(mv)
+						}
+						if dv, ok := it["deployment"].(string); ok && dv != "" {
+							m["deployment"] = strings.TrimSpace(dv)
+						}
+						if len(m) > 0 {
+							out = append(out, m)
+						}
+					}
+				}
+				if len(out) > 0 {
+					norm["deployments"] = out
+				}
+			}
+		}
+	}
+	return norm
+}
+
+// backfillDeploymentsFromModelState will populate deployments in config when absent
+// by reading model state records for this instance and creating model=deployment mappings
+// (only when helpful). When it writes a repaired config it persists it and returns true.
+func backfillDeploymentsFromModelState(instanceID string, config map[string]interface{}) (map[string]interface{}, bool, error) {
+	if config == nil {
+		config = map[string]interface{}{}
+	}
+	if len(DeploymentMappings(config)) > 0 {
+		return config, false, nil
+	}
+	stateStore := database.NewModelStateStore()
+	states, err := stateStore.GetAllByInstance(instanceID)
+	if err != nil {
+		return config, false, err
+	}
+	if len(states) == 0 {
+		return config, false, nil
+	}
+	// Build structured mappings model=deployment when model IDs look usable
+	out := make([]interface{}, 0, len(states))
+	seen := make(map[string]struct{})
+	for _, s := range states {
+		id := strings.TrimSpace(s.ModelID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		m := map[string]interface{}{"model": id, "deployment": id}
+		out = append(out, m)
+	}
+	if len(out) == 0 {
+		return config, false, nil
+	}
+	config["deployments"] = out
+	configStore := database.NewProviderConfigStore()
+	if err := configStore.Save(instanceID, config); err != nil {
+		return config, false, err
+	}
+	return config, true, nil
 }
 
 // RemapModel maps an app-facing Azure model name to the configured Azure deployment name.
@@ -172,7 +313,8 @@ func ModelIDs(config map[string]interface{}) []string {
 
 // GetModels returns the available models for this Azure OpenAI instance.
 // If the config contains deployment mappings those are used; otherwise the
-// built-in catalog is returned.
+// built-in catalog is returned. This will attempt to backfill deployments
+// from model state when no deployments are configured.
 func GetModels(instanceID string, config map[string]interface{}) *types.ModelsResponse {
 	if mappings := DeploymentMappings(config); len(mappings) > 0 {
 		models := make([]types.Model, 0, len(mappings))
@@ -185,6 +327,27 @@ func GetModels(instanceID string, config map[string]interface{}) *types.ModelsRe
 			})
 		}
 		return &types.ModelsResponse{Data: models, Object: "list"}
+	}
+
+	// Try backfilling missing deployments from model state
+	if cfg, ok := database.NewProviderConfigStore().Get(instanceID); ok == nil && cfg != nil {
+		var loaded map[string]interface{}
+		_ = json.Unmarshal([]byte(cfg.ConfigData), &loaded)
+		if updated, wrote, err := backfillDeploymentsFromModelState(instanceID, loaded); err == nil && wrote {
+			// use updated deployments
+			if mappings := DeploymentMappings(updated); len(mappings) > 0 {
+				models := make([]types.Model, 0, len(mappings))
+				for _, mapping := range mappings {
+					models = append(models, types.Model{
+						ID:        mapping.Model,
+						Name:      mapping.Model,
+						MaxTokens: 128000,
+						Provider:  instanceID,
+					})
+				}
+				return &types.ModelsResponse{Data: models, Object: "list"}
+			}
+		}
 	}
 
 	result := make([]types.Model, len(DefaultModels))
@@ -220,8 +383,9 @@ func stringSliceFromConfig(config map[string]interface{}, key string) []string {
 }
 
 // IsResponsesAPIModel returns true for all Azure OpenAI models.
-// Azure OpenAI uses the Responses API exclusively — this is the canonical
-// API shape for this provider as defined in internal/providers/providermodels.
+// Azure OpenAI uses the Responses API exclusively
+
+
 func IsResponsesAPIModel(_ string) bool {
 	return true
 }

--- a/internal/providers/generic/generic.go
+++ b/internal/providers/generic/generic.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"omnillm/internal/cif"
 	"omnillm/internal/database"
 	"omnillm/internal/providers/shared"
@@ -82,12 +83,25 @@ type GenericAdapter struct {
 
 // ─── Constructor ──────────────────────────────────────────────────────────────
 
+// providerDisplayNames maps provider type IDs to human-friendly display names.
+var providerDisplayNames = map[string]string{
+	"azure-openai": "Azure OpenAI",
+	"antigravity":  "Antigravity",
+	"alibaba":      "Alibaba",
+	"google":       "Google",
+	"kimi":         "Kimi",
+}
+
 // NewGenericProvider creates a new GenericProvider for the given provider type.
 func NewGenericProvider(providerType, instanceID, name string) *GenericProvider {
 	baseURL := providerBaseURLs[providerType]
 	displayName := name
 	if displayName == "" {
-		displayName = instanceID
+		if friendly, ok := providerDisplayNames[providerType]; ok {
+			displayName = friendly
+		} else {
+			displayName = instanceID
+		}
 	}
 	return &GenericProvider{
 		id:         providerType,
@@ -173,6 +187,9 @@ func (p *GenericProvider) setupAzureAuth(options *types.AuthOptions) error {
 	p.token = token
 	if endpoint != "" {
 		p.baseURL = endpoint
+		if name := deriveAzureName(endpoint); name != "" {
+			p.name = name
+		}
 	}
 	if cfg != nil {
 		p.applyConfig(cfg)
@@ -323,6 +340,12 @@ func (p *GenericProvider) applyConfig(config map[string]interface{}) {
 	case "azure-openai":
 		if endpoint, ok := firstString(config, "endpoint"); ok {
 			p.baseURL = strings.TrimRight(endpoint, "/")
+			// Update display name from endpoint if still using default/instance-id name
+			if name := deriveAzureName(endpoint); name != "" {
+				if p.name == "" || p.name == p.instanceID || p.name == providerDisplayNames["azure-openai"] {
+					p.name = name
+				}
+			}
 		}
 	case "google":
 		if p.baseURL == "" {
@@ -824,6 +847,35 @@ func defaultAlibabaAPIBaseURL(plan, region string) string {
 
 func alibabaAPIKeyProviderName(config map[string]interface{}) string {
 	return alibabapkg.APIKeyProviderName(config)
+}
+
+// deriveAzureName extracts a human-friendly resource name from an Azure OpenAI endpoint URL.
+// e.g. "https://my-resource.openai.azure.com" → "my-resource"
+// Falls back to empty string if the endpoint is not a recognizable Azure URL.
+func deriveAzureName(endpoint string) string {
+	if endpoint == "" {
+		return ""
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	host := strings.ToLower(u.Host)
+	// Standard Azure OpenAI hostname: <resource-name>.openai.azure.com
+	if strings.HasSuffix(host, ".openai.azure.com") {
+		resource := strings.TrimSuffix(host, ".openai.azure.com")
+		if resource != "" {
+			return resource
+		}
+	}
+	// Cognitive services endpoint: <resource-name>.cognitiveservices.azure.com
+	if strings.HasSuffix(host, ".cognitiveservices.azure.com") {
+		resource := strings.TrimSuffix(host, ".cognitiveservices.azure.com")
+		if resource != "" {
+			return resource
+		}
+	}
+	return ""
 }
 
 func ensureAlibabaBaseURL(raw string) string {

--- a/internal/providers/generic/generic.go
+++ b/internal/providers/generic/generic.go
@@ -487,7 +487,10 @@ func (a *GenericAdapter) RemapModel(model string) string {
 	if a.provider.id == "alibaba" {
 		return alibabapkg.RemapModel(model)
 	}
-	return model
+	if a.provider.id == "azure-openai" {
+		return azurepkg.RemapModel(a.provider.config, strings.TrimSpace(model))
+	}
+	return strings.TrimSpace(model)
 }
 
 func (a *GenericAdapter) Execute(ctx context.Context, request *cif.CanonicalRequest) (*cif.CanonicalResponse, error) {

--- a/internal/providers/types/types.go
+++ b/internal/providers/types/types.go
@@ -32,6 +32,8 @@ type AuthOptions struct {
 	Endpoint            string `json:"endpoint,omitempty"`
 	APIFormat           string `json:"apiFormat,omitempty"` // e.g. "anthropic" for Alibaba Anthropic-compatible endpoint
 	Models              string `json:"models,omitempty"`    // JSON-encoded []string, used by openai-compatible
+	Deployments         string `json:"deployments,omitempty"` // JSON-encoded []string, used by azure-openai
+	APIVersion          string `json:"apiVersion,omitempty"`  // e.g. "2024-02-01", used by azure-openai
 	AllowLocalEndpoints bool   `json:"allowLocalEndpoints,omitempty"`
 }
 

--- a/internal/routes/admin.go
+++ b/internal/routes/admin.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	alibabapkg "omnillm/internal/providers/alibaba"
+	azurepkg "omnillm/internal/providers/azure"
 
 	openaicompatprovider "omnillm/internal/providers/openaicompatprovider"
 
@@ -218,8 +219,17 @@ func normalizeProviderConfigForFrontend(providerType string, config map[string]i
 		if apiVersion, ok := firstStringValue(config, "apiVersion", "api_version"); ok {
 			normalized["apiVersion"] = apiVersion
 		}
-		if deployments := stringSliceValue(config["deployments"]); len(deployments) > 0 {
-			normalized["deployments"] = deployments
+		if deployments, ok := config["deployments"]; ok {
+			switch typed := deployments.(type) {
+			case []string:
+				if len(typed) > 0 {
+					normalized["deployments"] = typed
+				}
+			case []interface{}:
+				if len(typed) > 0 {
+					normalized["deployments"] = typed
+				}
+			}
 		}
 		if len(normalized) == 0 {
 			return nil
@@ -270,7 +280,6 @@ func normalizeProviderConfigForStorage(providerType string, config map[string]in
 	case "azure-openai":
 		endpoint, _ := firstStringValue(config, "endpoint")
 		apiVersion, _ := firstStringValue(config, "apiVersion", "api_version")
-		deployments := stringSliceValue(config["deployments"])
 
 		normalized := map[string]interface{}{}
 		if endpoint != "" {
@@ -279,8 +288,17 @@ func normalizeProviderConfigForStorage(providerType string, config map[string]in
 		if apiVersion != "" {
 			normalized["api_version"] = apiVersion
 		}
-		if len(deployments) > 0 {
-			normalized["deployments"] = deployments
+		if deployments, ok := config["deployments"]; ok {
+			switch typed := deployments.(type) {
+			case []string:
+				if len(typed) > 0 {
+					normalized["deployments"] = typed
+				}
+			case []interface{}:
+				if len(typed) > 0 {
+					normalized["deployments"] = typed
+				}
+			}
 		}
 		return normalized
 	case "alibaba":
@@ -897,12 +915,22 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 
 		// For Azure OpenAI: if the user specified deployments upfront, enable them immediately.
 		if providerType == "azure-openai" && req.Deployments != "" {
-			var deployments []string
-			if jsonErr := json.Unmarshal([]byte(req.Deployments), &deployments); jsonErr == nil {
+			var rawDeployments []interface{}
+			if jsonErr := json.Unmarshal([]byte(req.Deployments), &rawDeployments); jsonErr == nil {
 				modelStateStore := database.NewModelStateStore()
-				for _, deployment := range deployments {
-					if deployment != "" {
-						_ = modelStateStore.SetEnabled(gen.GetInstanceID(), deployment, true)
+				for _, item := range rawDeployments {
+					switch typed := item.(type) {
+					case string:
+						deployment := strings.TrimSpace(typed)
+						if deployment != "" {
+							_ = modelStateStore.SetEnabled(gen.GetInstanceID(), deployment, true)
+						}
+					case map[string]interface{}:
+						model, _ := typed["model"].(string)
+						model = strings.TrimSpace(model)
+						if model != "" {
+							_ = modelStateStore.SetEnabled(gen.GetInstanceID(), model, true)
+						}
 					}
 				}
 			}
@@ -1454,22 +1482,22 @@ func handleUpdateProviderConfig(c *gin.Context) {
 	}
 
 	if provider.GetID() == "azure-openai" {
-		oldDeployments := stringSliceValue(previousConfig["deployments"])
-		newDeployments := stringSliceValue(normalizedConfig["deployments"])
-		if len(oldDeployments) > 0 {
-			newSet := make(map[string]struct{}, len(newDeployments))
-			for _, deployment := range newDeployments {
-				newSet[deployment] = struct{}{}
+		oldModels := azurepkg.ModelIDs(previousConfig)
+		newModels := azurepkg.ModelIDs(normalizedConfig)
+		if len(oldModels) > 0 {
+			newSet := make(map[string]struct{}, len(newModels))
+			for _, model := range newModels {
+				newSet[model] = struct{}{}
 			}
 
 			modelStateStore := database.NewModelStateStore()
 			modelConfigStore := database.NewModelConfigStore()
-			for _, deployment := range oldDeployments {
-				if _, keep := newSet[deployment]; keep {
+			for _, model := range oldModels {
+				if _, keep := newSet[model]; keep {
 					continue
 				}
-				_ = modelStateStore.Delete(providerID, deployment)
-				_ = modelConfigStore.Delete(providerID, deployment)
+				_ = modelStateStore.Delete(providerID, model)
+				_ = modelConfigStore.Delete(providerID, model)
 			}
 		}
 	}

--- a/internal/routes/admin.go
+++ b/internal/routes/admin.go
@@ -905,6 +905,15 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 			return
 		}
 
+		if providerType == "azure-openai" {
+			if rawCfg, cfgErr := loadProviderConfig(gen.GetInstanceID()); cfgErr == nil && rawCfg != nil {
+				normCfg := normalizeProviderConfigForStorage(providerType, rawCfg)
+				if len(normCfg) > 0 {
+					_ = database.NewProviderConfigStore().Save(gen.GetInstanceID(), normCfg)
+				}
+			}
+		}
+
 		if err := providerRegistry.Register(gen, true); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"success": false,
@@ -927,10 +936,13 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 						}
 					case map[string]interface{}:
 						model, _ := typed["model"].(string)
+						deployment, _ := typed["deployment"].(string)
 						model = strings.TrimSpace(model)
-						if model != "" {
-							_ = modelStateStore.SetEnabled(gen.GetInstanceID(), model, true)
-						}
+						deployment = strings.TrimSpace(deployment)
+						if model == "" { model = deployment }
+						if deployment == "" { deployment = model }
+						if model != "" { _ = modelStateStore.SetEnabled(gen.GetInstanceID(), model, true) }
+						if deployment != "" && deployment != model { _ = modelStateStore.SetEnabled(gen.GetInstanceID(), deployment, true) }
 					}
 				}
 			}
@@ -1332,6 +1344,15 @@ func handleProviderAuth(c *gin.Context) {
 	if isCopilot {
 		if err := cop.SaveToDB(); err != nil {
 			log.Error().Err(err).Str("provider", providerID).Msg("Failed to save token to database")
+		}
+	}
+
+	if provider.GetID() == "azure-openai" {
+		if rawCfg, cfgErr := loadProviderConfig(providerID); cfgErr == nil && rawCfg != nil {
+			normCfg := normalizeProviderConfigForStorage(provider.GetID(), rawCfg)
+			if len(normCfg) > 0 {
+				_ = database.NewProviderConfigStore().Save(providerID, normCfg)
+			}
 		}
 	}
 

--- a/internal/routes/admin.go
+++ b/internal/routes/admin.go
@@ -895,6 +895,19 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 			return
 		}
 
+		// For Azure OpenAI: if the user specified deployments upfront, enable them immediately.
+		if providerType == "azure-openai" && req.Deployments != "" {
+			var deployments []string
+			if jsonErr := json.Unmarshal([]byte(req.Deployments), &deployments); jsonErr == nil {
+				modelStateStore := database.NewModelStateStore()
+				for _, deployment := range deployments {
+					if deployment != "" {
+						_ = modelStateStore.SetEnabled(gen.GetInstanceID(), deployment, true)
+					}
+				}
+			}
+		}
+
 		c.JSON(http.StatusOK, gin.H{
 			"success": true,
 			"provider": gin.H{

--- a/omni-dev.ts
+++ b/omni-dev.ts
@@ -22,6 +22,9 @@ const LOG_FILE = join(process.cwd(), ".omni-dev.log")
 interface ServicePids {
   backend?: number
   frontend?: number
+  host?: string
+  serverPort?: string
+  frontendPort?: string
 }
 
 type ProcessInfo = {
@@ -175,6 +178,14 @@ NOTES:
   • Frontend automatically proxies API calls to backend
   • All services stop gracefully with proper cleanup
 `)
+}
+
+function getSavedRuntimeConfig(pids: ServicePids | null) {
+  return {
+    host: pids?.host || host,
+    serverPort: pids?.serverPort || serverPort,
+    frontendPort: pids?.frontendPort || frontendPort,
+  }
 }
 
 function savePids(pids: ServicePids) {
@@ -719,6 +730,9 @@ async function startServices() {
   savePids({
     backend: backendProc.pid,
     frontend: frontendProc.pid,
+    host,
+    serverPort,
+    frontendPort,
   })
 
   if (verbose) {
@@ -808,6 +822,7 @@ async function stopServices() {
 
 async function showStatus() {
   const pids = loadPids()
+  const runtime = getSavedRuntimeConfig(pids)
 
   consola.info("📊 OmniLLM Service Status")
   console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
@@ -821,28 +836,34 @@ async function showStatus() {
 
   // Backend status
   const backendRunning = pids.backend && isProcessRunning(pids.backend)
-  const backendPortBusy = !(await checkPortAvailable(Number(serverPort)))
+  const backendPortBusy = !(await checkPortAvailable(
+    Number(runtime.serverPort),
+  ))
 
   console.log(`🔥 Backend (Go):`)
   console.log(`   Status: ${backendRunning ? "🟢 Running" : "🔴 Stopped"}`)
   console.log(`   PID: ${pids.backend || "N/A"}`)
   console.log(
-    `   Port: ${serverPort} ${backendPortBusy ? "(🔒 Busy)" : "(🔓 Free)"}`,
+    `   Port: ${runtime.serverPort} ${backendPortBusy ? "(🔒 Busy)" : "(🔓 Free)"}`,
   )
-  console.log(`   URL: http://${host}:${serverPort}`)
+  console.log(`   URL: http://${runtime.host}:${runtime.serverPort}`)
 
   // Frontend status
   const frontendRunning = pids.frontend && isProcessRunning(pids.frontend)
-  const frontendPortBusy = !(await checkPortAvailable(Number(frontendPort)))
+  const frontendPortBusy = !(await checkPortAvailable(
+    Number(runtime.frontendPort),
+  ))
 
   console.log(`🌐 Frontend:`)
   console.log(`   Status: ${frontendRunning ? "🟢 Running" : "🔴 Stopped"}`)
   console.log(`   PID: ${pids.frontend || "N/A"}`)
   console.log(
-    `   Port: ${frontendPort} ${frontendPortBusy ? "(🔒 Busy)" : "(🔓 Free)"}`,
+    `   Port: ${runtime.frontendPort} ${frontendPortBusy ? "(🔒 Busy)" : "(🔓 Free)"}`,
   )
-  console.log(`   URL: http://${host}:${frontendPort}`)
-  console.log(`   Admin UI: http://${host}:${frontendPort}/admin/`)
+  console.log(`   URL: http://${runtime.host}:${runtime.frontendPort}`)
+  console.log(
+    `   Admin UI: http://${runtime.host}:${runtime.frontendPort}/admin/`,
+  )
 
   console.log()
 

--- a/scripts/cleanup-azure-openai-2-models.go
+++ b/scripts/cleanup-azure-openai-2-models.go
@@ -1,0 +1,108 @@
+//go:build ignore
+
+// Run with: go run scripts/cleanup-azure-openai-2-models.go
+// Removes stale model_state entries for azure-openai-2 that are not in its deployment config.
+
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	_ "modernc.org/sqlite"
+)
+
+func main() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("cannot determine home dir: %v", err)
+	}
+	dbPath := filepath.Join(home, ".config", "omnillm", "database.sqlite")
+
+	db, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	const instanceID = "azure-openai-2"
+
+	// Get deployment config for this instance
+	var configData string
+	err = db.QueryRow(`SELECT config_data FROM provider_configs WHERE instance_id = ?`, instanceID).Scan(&configData)
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal([]byte(configData), &cfg); err != nil {
+		log.Fatalf("parse config: %v", err)
+	}
+
+	// Build set of valid model IDs from deployments
+	validModels := map[string]struct{}{}
+	if raw, ok := cfg["deployments"]; ok {
+		switch v := raw.(type) {
+		case []interface{}:
+			for _, item := range v {
+				switch it := item.(type) {
+				case string:
+					if it != "" {
+						validModels[it] = struct{}{}
+					}
+				case map[string]interface{}:
+					if m, ok := it["model"].(string); ok && m != "" {
+						validModels[m] = struct{}{}
+					}
+					if d, ok := it["deployment"].(string); ok && d != "" {
+						validModels[d] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+
+	fmt.Printf("Valid models from config: %v\n", validModels)
+
+	// List all model states for this instance
+	rows, err := db.Query(`SELECT model_id FROM provider_model_states WHERE instance_id = ?`, instanceID)
+	if err != nil {
+		log.Fatalf("query states: %v", err)
+	}
+	defer rows.Close()
+
+	var toDelete []string
+	for rows.Next() {
+		var modelID string
+		if err := rows.Scan(&modelID); err != nil {
+			log.Fatalf("scan: %v", err)
+		}
+		if _, ok := validModels[modelID]; !ok {
+			toDelete = append(toDelete, modelID)
+		}
+	}
+
+	if len(toDelete) == 0 {
+		fmt.Println("No stale models found.")
+		return
+	}
+
+	fmt.Printf("Deleting stale models: %v\n", toDelete)
+	for _, modelID := range toDelete {
+		if _, err := db.Exec(`DELETE FROM provider_model_states WHERE instance_id = ? AND model_id = ?`, instanceID, modelID); err != nil {
+			log.Printf("  WARN: failed to delete %s: %v", modelID, err)
+		} else {
+			fmt.Printf("  Deleted: %s\n", modelID)
+		}
+		// Also clear model config
+		db.Exec(`DELETE FROM provider_model_configs WHERE instance_id = ? AND model_id = ?`, instanceID, modelID)
+		// Also clear models cache so UI refreshes
+		db.Exec(`DELETE FROM provider_models_cache WHERE instance_id = ?`, instanceID)
+	}
+
+	fmt.Println("Done.")
+}

--- a/scripts/test-azure-openai-2-live.ts
+++ b/scripts/test-azure-openai-2-live.ts
@@ -1,0 +1,358 @@
+#!/usr/bin/env bun
+
+import process from "node:process"
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:5000"
+const DEFAULT_MODEL = "gpt-5.4-1"
+const DEFAULT_TIMEOUT_MS = 60_000
+
+type ChatCompletionToolCall = {
+  id?: string
+  type?: string
+  function?: {
+    name?: string
+    arguments?: string
+  }
+}
+
+type ChatCompletionResponse = {
+  choices?: Array<{
+    finish_reason?: string | null
+    message?: {
+      content?: string | null
+      tool_calls?: Array<ChatCompletionToolCall>
+    }
+  }>
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function authHeaders(apiKey: string): Record<string, string> {
+  const trimmed = apiKey.trim()
+  return trimmed === ""
+    ? {}
+    : {
+        Authorization: `Bearer ${trimmed}`,
+        "x-api-key": trimmed,
+      }
+}
+
+async function verifyModel(
+  baseUrl: string,
+  apiKey: string,
+  model: string,
+): Promise<void> {
+  const response = await fetch(`${baseUrl}/v1/models`, {
+    headers: authHeaders(apiKey),
+  })
+  if (!response.ok) {
+    throw new Error(`GET /v1/models failed with ${response.status}`)
+  }
+
+  const payload = (await response.json()) as {
+    data?: Array<{ id?: string }>
+  }
+  const modelIDs =
+    payload.data
+      ?.map((entry) => entry.id)
+      .filter((entry): entry is string => typeof entry === "string") ?? []
+
+  if (!modelIDs.includes(model)) {
+    throw new Error(
+      `Model ${model} was not returned by /v1/models. Available models: ${modelIDs.join(", ") || "(none)"}`,
+    )
+  }
+}
+
+async function postChatCompletion(
+  baseUrl: string,
+  apiKey: string,
+  payload: Record<string, unknown>,
+): Promise<ChatCompletionResponse> {
+  const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeaders(apiKey),
+    },
+    body: JSON.stringify(payload),
+  })
+
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`POST /v1/chat/completions failed with ${response.status}: ${text}`)
+  }
+
+  try {
+    return JSON.parse(text) as ChatCompletionResponse
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid JSON from /v1/chat/completions: ${message}\n${text}`)
+  }
+}
+
+function requireChoice(
+  response: ChatCompletionResponse,
+  label: string,
+): NonNullable<ChatCompletionResponse["choices"]>[number] {
+  const choice = response.choices?.[0]
+  if (!choice) {
+    throw new Error(`${label}: response did not contain choices[0]`)
+  }
+  return choice
+}
+
+async function testPlainChat(
+  baseUrl: string,
+  apiKey: string,
+  model: string,
+  signal: AbortSignal,
+): Promise<void> {
+  console.log("\n--- Test 1: Plain chat ---")
+
+  const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeaders(apiKey),
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 128,
+      messages: [
+        {
+          role: "user",
+          content: "Reply with exactly: Hello from azure-openai-2.",
+        },
+      ],
+    }),
+    signal,
+  })
+
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`Plain chat POST failed with ${response.status}: ${text}`)
+  }
+
+  let payload: ChatCompletionResponse
+  try {
+    payload = JSON.parse(text) as ChatCompletionResponse
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid JSON from plain chat: ${message}\n${text}`)
+  }
+
+  const choice = requireChoice(payload, "plain chat")
+  if (choice.finish_reason !== "stop") {
+    throw new Error(
+      `Plain chat finish_reason was ${choice.finish_reason ?? "null"}, expected stop`,
+    )
+  }
+
+  const content = choice.message?.content?.trim() ?? ""
+  if (content.length === 0) {
+    throw new Error("Plain chat returned empty content")
+  }
+
+  console.log(`Plain chat response: ${content}`)
+  console.log("Plain chat passed.")
+}
+
+async function testToolUse(
+  baseUrl: string,
+  apiKey: string,
+  model: string,
+  signal: AbortSignal,
+): Promise<void> {
+  console.log("\n--- Test 2: Tool use (two-turn loop) ---")
+
+  const tools = [
+    {
+      type: "function",
+      function: {
+        name: "Read",
+        description: "Read a repository file and return its content",
+        parameters: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+          },
+          required: ["file_path"],
+        },
+      },
+    },
+  ]
+
+  // Turn 1 — expect a tool call
+  const firstResponse = await fetch(`${baseUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeaders(apiKey),
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 256,
+      messages: [
+        {
+          role: "user",
+          content:
+            "Read README.md first, then explain this gateway briefly. Use the Read tool before answering.",
+        },
+      ],
+      tools,
+    }),
+    signal,
+  })
+
+  const firstText = await firstResponse.text()
+  if (!firstResponse.ok) {
+    throw new Error(
+      `First POST /v1/chat/completions failed with ${firstResponse.status}: ${firstText}`,
+    )
+  }
+
+  let firstPayload: ChatCompletionResponse
+  try {
+    firstPayload = JSON.parse(firstText) as ChatCompletionResponse
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid first-turn JSON: ${message}\n${firstText}`)
+  }
+
+  const firstChoice = requireChoice(firstPayload, "first turn")
+  if (firstChoice.finish_reason !== "tool_calls") {
+    throw new Error(
+      `First turn finish_reason was ${firstChoice.finish_reason ?? "null"}, expected tool_calls`,
+    )
+  }
+
+  const firstToolCall = firstChoice.message?.tool_calls?.[0]
+  if (!firstToolCall?.id || firstToolCall.type !== "function") {
+    throw new Error(`First turn did not contain a valid tool call: ${firstText}`)
+  }
+  if (firstToolCall.function?.name !== "Read") {
+    throw new Error(
+      `First turn tool name was ${firstToolCall.function?.name ?? "null"}, expected Read`,
+    )
+  }
+
+  let toolArguments: { file_path?: string }
+  try {
+    toolArguments = JSON.parse(firstToolCall.function.arguments ?? "{}") as {
+      file_path?: string
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Could not parse first turn tool arguments: ${message}\n${firstToolCall.function?.arguments ?? ""}`,
+    )
+  }
+
+  if (!toolArguments.file_path) {
+    throw new Error(`First turn tool arguments omitted file_path: ${firstText}`)
+  }
+  console.log(
+    `Observed tool call ${firstToolCall.id}: Read(${toolArguments.file_path})`,
+  )
+
+  const toolResultContent =
+    toolArguments.file_path === "README.md"
+      ? "README.md says OmniLLM is a unified LLM gateway that normalizes requests into CIF and exposes OpenAI-compatible plus Anthropic-compatible APIs."
+      : `${toolArguments.file_path} says OmniLLM routes provider traffic through a shared CIF core.`
+
+  // Turn 2 — expect a final text answer
+  const secondPayload = await postChatCompletion(baseUrl, apiKey, {
+    model,
+    max_tokens: 256,
+    messages: [
+      {
+        role: "user",
+        content:
+          "Read README.md first, then explain this gateway briefly. Use the Read tool before answering.",
+      },
+      {
+        role: "assistant",
+        content: firstChoice.message?.content ?? "",
+        tool_calls: firstChoice.message?.tool_calls ?? [],
+      },
+      {
+        role: "tool",
+        tool_call_id: firstToolCall.id,
+        content: toolResultContent,
+      },
+      {
+        role: "user",
+        content:
+          "Finish the explanation in 2-4 sentences and mention CIF explicitly.",
+      },
+    ],
+    tools,
+  })
+
+  const secondChoice = requireChoice(secondPayload, "second turn")
+  if (secondChoice.finish_reason !== "stop") {
+    throw new Error(
+      `Second turn finish_reason was ${secondChoice.finish_reason ?? "null"}, expected stop`,
+    )
+  }
+  if ((secondChoice.message?.tool_calls?.length ?? 0) > 0) {
+    throw new Error("Second turn unexpectedly returned another tool call")
+  }
+
+  const finalText = secondChoice.message?.content?.trim() ?? ""
+  if (finalText.length < 80) {
+    throw new Error(`Final answer was too short (${finalText.length} chars): ${finalText}`)
+  }
+
+  const detailSignals = ["cif", "openai", "anthropic", "gateway", "provider"]
+  const signalMatches = detailSignals.filter((signal) =>
+    finalText.toLowerCase().includes(signal),
+  )
+  if (signalMatches.length < 2) {
+    throw new Error(
+      `Final answer did not contain enough expected detail (${signalMatches.length} matches): ${finalText}`,
+    )
+  }
+
+  console.log(`\nFinal answer:\n${finalText}`)
+  console.log("\nTool-use two-turn loop passed.")
+}
+
+async function main(): Promise<void> {
+  const baseUrl = process.env.OMNILLM_OPENAI_BASE_URL ?? DEFAULT_BASE_URL
+  const apiKey = process.env.OMNILLM_OPENAI_API_KEY ?? "sk-omnillm-local-test"
+  const model = process.env.OMNILLM_OPENAI_MODEL ?? DEFAULT_MODEL
+  const timeoutMs = parsePositiveInt(
+    process.env.OMNILLM_OPENAI_TIMEOUT_MS,
+    DEFAULT_TIMEOUT_MS,
+  )
+
+  console.log(
+    `Running live chat + tool-use check against ${baseUrl} with model ${model} (provider: azure-openai-2)`,
+  )
+
+  const abortController = new AbortController()
+  const timeout = setTimeout(() => abortController.abort(), timeoutMs)
+
+  try {
+    await verifyModel(baseUrl, apiKey, model)
+    console.log(`Verified that ${model} is exposed by ${baseUrl}/v1/models`)
+
+    await testPlainChat(baseUrl, apiKey, model, abortController.signal)
+    await testToolUse(baseUrl, apiKey, model, abortController.signal)
+
+    console.log("\nAll checks passed.")
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+await main()


### PR DESCRIPTION
## Summary
- Normalize Azure OpenAI config storage keys (`api_version`, structured deployments)
- Accept both string and structured model/deployment mappings
- Backfill deployments from model state when none are configured
- Derive human-friendly Azure resource names from endpoint URLs
- Add live test script (`test-azure-openai-2-live.ts`) for chat + tool-use validation
- Add cleanup script (`cleanup-azure-openai-2-models.go`) for stale model state
- Persist normalized config on auth/re-auth in admin routes
- Improve generic provider display names for Azure, Antigravity, Alibaba, Google, Kimi

## Test plan
- [ ] Verify Azure OpenAI provider can be added with both string and structured deployment configs
- [ ] Confirm model state backfill populates missing deployments correctly
- [ ] Run `bun scripts/test-azure-openai-2-live.ts` against a running instance
- [ ] Verify admin UI shows correct Azure resource names