### PR TITLE
Add Codex provider and API key auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Route AI traffic through a controlled internal endpoint instead of binding appli
 
 ![Virtual Models](docs/assets/virtual-models.png)
 
-### Admin Demo Video
+### Admin Demo
 
-[OmniLLM Admin Demo (MP4)](pages/admin/assets/OmniLLM%20Admin.mp4)
+<video src="pages/admin/OmniLLM_Admin.mp4" controls muted playsinline preload="metadata"></video>
 
 ## Quick Start
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -440,8 +440,7 @@ export const authAndCreateProvider = (
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const updateProviderConfig = (id: string, config: Record<string, any>) =>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  apiFetch<{ success?: boolean; config?: any }>(
+  apiFetch<{ success?: boolean; config?: Provider["config"] }>(
     `/api/admin/providers/${id}/config`,
     { method: "PUT", body: JSON.stringify(config) },
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -769,18 +769,25 @@
 
 /* ─── Dialog ────────────────────────────────────────────────────────────── */
 
+:root {
+  --dialog-top-offset: 52px;
+  --dialog-padding-y: 24px;
+  --dialog-padding-x: 20px;
+}
+
 .dialog-overlay {
   position: fixed;
   inset: 0;
-  top: 52px;
+  top: var(--dialog-top-offset);
   background: rgba(1,4,9,0.65);
   backdrop-filter: blur(6px);
   z-index: 100;
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding: 24px 20px;
+  padding: var(--dialog-padding-y) var(--dialog-padding-x);
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .dialog-box {
@@ -789,12 +796,20 @@
   border-radius: var(--radius-xl);
   width: 100%;
   max-width: 560px;
-  max-height: calc(100vh - 52px - 48px);
+  max-height: calc(100vh - var(--dialog-top-offset) - (2 * var(--dialog-padding-y)));
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   box-shadow: var(--shadow-modal);
   animation: slide-up 0.2s var(--ease) both;
   flex-shrink: 0;
+  box-sizing: border-box;
+}
+
+@supports (height: 100dvh) {
+  .dialog-box {
+    max-height: calc(100dvh - var(--dialog-top-offset) - (2 * var(--dialog-padding-y)));
+  }
 }
 
 .dialog-header {
@@ -810,6 +825,8 @@
   padding: 18px 20px 22px;
   overflow-y: auto;
   flex: 1;
+  min-height: 0;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* ─── Toast ─────────────────────────────────────────────────────────────── */

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -4425,7 +4425,7 @@ export function ProvidersPage({ showToast }: ProvidersPageProps) {
               showActiveOnly ?
                 typeProviders.filter((p) => p.isActive)
               : typeProviders
-            if (showActiveOnly && visibleProviders.length === 0) return null
+            if (visibleProviders.length === 0) return null
             return [providerType, visibleProviders] as [string, Array<Provider>]
           })
           .filter((entry): entry is [string, Array<Provider>] => entry !== null)

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -490,6 +490,50 @@ function CopilotAuthForm({
   )
 }
 
+function CodexAuthForm({
+  onSubmit,
+  onCancel,
+}: {
+  onSubmit: (body: Record<string, string>) => Promise<void>
+  onCancel: () => void
+}) {
+  const [token, setToken] = useState("")
+  const submit = async () => {
+    await (token.trim() ?
+      onSubmit({ method: "token", token: token.trim() })
+    : onSubmit({ method: "oauth" }))
+  }
+  return (
+    <AuthFormWrapper title="Authenticate Codex">
+      <div
+        style={{
+          fontSize: 12,
+          color: "var(--color-text-tertiary)",
+          marginBottom: 4,
+        }}
+      >
+        Sign in via GitHub OAuth (recommended) or paste a GitHub token directly.
+      </div>
+      <FormRow label="GitHub Token (optional)">
+        <SecretInput
+          className="sys-input"
+          placeholder="ghu_… (leave blank to use OAuth)"
+          value={token}
+          onChange={setToken}
+        />
+      </FormRow>
+      <div style={{ display: "flex", gap: 8 }}>
+        <button className="btn btn-primary btn-sm" onClick={submit}>
+          {token.trim() ? "Submit" : "Start OAuth"}
+        </button>
+        <button className="btn btn-ghost btn-sm" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </AuthFormWrapper>
+  )
+}
+
 function AntigravityAuthForm({
   onSubmit,
   onCancel,
@@ -2626,6 +2670,12 @@ function ProviderCard({
               onCancel={() => setShowAuthForm(false)}
             />
           )}
+          {provider.type === "codex" && (
+            <CodexAuthForm
+              onSubmit={handleAuthSubmit}
+              onCancel={() => setShowAuthForm(false)}
+            />
+          )}
           {provider.type === "azure-openai" && (
             <AzureOpenAIAuthForm
               onSubmit={handleAuthSubmit}
@@ -2965,6 +3015,7 @@ function AddProviderFlow({
           {selectedType === "github-copilot" && (
             <AddFlowCopilotForm {...authFormProps} />
           )}
+          {selectedType === "codex" && <AddFlowCodexForm {...authFormProps} />}
           {selectedType === "antigravity" && (
             <AddFlowAntigravityForm {...authFormProps} />
           )}
@@ -3265,6 +3316,74 @@ function AddFlowCopilotForm({
         Generate a token from GitHub Settings → Developer settings → Personal
         access tokens.
       </AddFlowHint>
+      <div style={{ display: "flex", gap: 8 }}>
+        <button
+          className="btn btn-outline btn-sm"
+          onClick={submitToken}
+          disabled={submitting}
+        >
+          {submitting ?
+            <>
+              <Spin size={13} /> Connecting…
+            </>
+          : "Add with Token"}
+        </button>
+        <button
+          className="btn btn-ghost btn-sm"
+          onClick={onCancel}
+          disabled={submitting}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function AddFlowCodexForm({
+  onSubmit,
+  onCancel,
+  submitting,
+}: AddFlowFormProps) {
+  const [token, setToken] = useState("")
+  const submitToken = async () => {
+    if (!token.trim()) return
+    await onSubmit({ method: "token", token: token.trim() })
+  }
+  const submitOAuth = async () => {
+    await onSubmit({ method: "oauth" })
+  }
+  return (
+    <div style={addFlowPanelStyle}>
+      {/* Primary: OAuth */}
+      <button
+        className="btn btn-primary btn-sm"
+        onClick={submitOAuth}
+        disabled={submitting}
+        style={{ width: "100%" }}
+      >
+        {submitting ?
+          <>
+            <Spin size={13} /> Connecting…
+          </>
+        : "Sign in with GitHub (OAuth)"}
+      </button>
+      <AddFlowHint>
+        Recommended. Starts a GitHub device-code OAuth flow — no token needed.
+      </AddFlowHint>
+
+      <div className="divider-label">or use a token</div>
+
+      {/* Secondary: Token */}
+      <FormRow label="GitHub Token">
+        <SecretInput
+          placeholder="ghu_…"
+          value={token}
+          onChange={setToken}
+          style={addFlowTextInputStyle}
+          autoComplete="off"
+        />
+      </FormRow>
       <div style={{ display: "flex", gap: 8 }}>
         <button
           className="btn btn-outline btn-sm"

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -3923,6 +3923,11 @@ const PROVIDER_TYPES = [
     desc: "Kimi models via API key",
   },
   {
+    id: "codex",
+    name: "Codex",
+    desc: "OpenAI Codex models via GitHub OAuth",
+  },
+  {
     id: "openai-compatible",
     name: "OpenAI-Compatible",
     desc: "Any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, etc.)",

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -497,34 +497,36 @@ function CodexAuthForm({
   onSubmit: (body: Record<string, string>) => Promise<void>
   onCancel: () => void
 }) {
-  const [token, setToken] = useState("")
+  const [apiKey, setApiKey] = useState("")
+
   const submit = async () => {
-    await (token.trim() ?
-      onSubmit({ method: "token", token: token.trim() })
-    : onSubmit({ method: "oauth" }))
+    if (!apiKey.trim()) return
+    await onSubmit({ method: "api-key", apiKey: apiKey.trim() })
   }
+
   return (
     <AuthFormWrapper title="Authenticate Codex">
       <div
         style={{
           fontSize: 12,
           color: "var(--color-text-tertiary)",
-          marginBottom: 4,
+          marginBottom: 12,
         }}
       >
-        Sign in via GitHub OAuth (recommended) or paste a GitHub token directly.
+        Official Codex supports ChatGPT sign-in and API key authentication. Use
+        an OpenAI API key here for programmatic access.
       </div>
-      <FormRow label="GitHub Token (optional)">
+      <FormRow label="OpenAI API Key">
         <SecretInput
           className="sys-input"
-          placeholder="ghu_… (leave blank to use OAuth)"
-          value={token}
-          onChange={setToken}
+          placeholder="sk-..."
+          value={apiKey}
+          onChange={setApiKey}
         />
       </FormRow>
       <div style={{ display: "flex", gap: 8 }}>
         <button className="btn btn-primary btn-sm" onClick={submit}>
-          {token.trim() ? "Submit" : "Start OAuth"}
+          Save API Key
         </button>
         <button className="btn btn-ghost btn-sm" onClick={onCancel}>
           Cancel
@@ -3345,56 +3347,40 @@ function AddFlowCodexForm({
   onCancel,
   submitting,
 }: AddFlowFormProps) {
-  const [token, setToken] = useState("")
-  const submitToken = async () => {
-    if (!token.trim()) return
-    await onSubmit({ method: "token", token: token.trim() })
+  const [apiKey, setApiKey] = useState("")
+
+  const submit = async () => {
+    if (!apiKey.trim()) return
+    await onSubmit({ method: "api-key", apiKey: apiKey.trim() })
   }
-  const submitOAuth = async () => {
-    await onSubmit({ method: "oauth" })
-  }
+
   return (
     <div style={addFlowPanelStyle}>
-      {/* Primary: OAuth */}
-      <button
-        className="btn btn-primary btn-sm"
-        onClick={submitOAuth}
-        disabled={submitting}
-        style={{ width: "100%" }}
-      >
-        {submitting ?
-          <>
-            <Spin size={13} /> Connecting…
-          </>
-        : "Sign in with GitHub (OAuth)"}
-      </button>
       <AddFlowHint>
-        Recommended. Starts a GitHub device-code OAuth flow — no token needed.
+        Official Codex supports ChatGPT sign-in and API key authentication. Use
+        an OpenAI API key here for programmatic access.
       </AddFlowHint>
 
-      <div className="divider-label">or use a token</div>
-
-      {/* Secondary: Token */}
-      <FormRow label="GitHub Token">
+      <FormRow label="OpenAI API Key">
         <SecretInput
-          placeholder="ghu_…"
-          value={token}
-          onChange={setToken}
+          placeholder="sk-..."
+          value={apiKey}
+          onChange={setApiKey}
           style={addFlowTextInputStyle}
           autoComplete="off"
         />
       </FormRow>
       <div style={{ display: "flex", gap: 8 }}>
         <button
-          className="btn btn-outline btn-sm"
-          onClick={submitToken}
+          className="btn btn-primary btn-sm"
+          onClick={submit}
           disabled={submitting}
         >
           {submitting ?
             <>
               <Spin size={13} /> Connecting…
             </>
-          : "Add with Token"}
+          : "Add with API Key"}
         </button>
         <button
           className="btn btn-ghost btn-sm"
@@ -3925,7 +3911,7 @@ const PROVIDER_TYPES = [
   {
     id: "codex",
     name: "Codex",
-    desc: "OpenAI Codex models via GitHub OAuth",
+    desc: "Official OpenAI Codex via ChatGPT or API key",
   },
   {
     id: "openai-compatible",

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -1481,6 +1481,12 @@ function ModelsMenuItem({
   const [azureMappings, setAzureMappings] = useState<
     Array<AzureDeploymentMapping>
   >(normalizeAzureDeploymentMappings(provider.config?.deployments))
+  const [azureEndpoint, setAzureEndpoint] = useState<string | undefined>(
+    provider.config?.endpoint,
+  )
+  const [azureAPIVersion, setAzureAPIVersion] = useState<string>(
+    provider.config?.apiVersion || "2024-02-01",
+  )
 
   // OpenAI-compatible user-defined model management
   const [newModel, setNewModel] = useState("")
@@ -1499,6 +1505,8 @@ function ModelsMenuItem({
       setAzureMappings(
         normalizeAzureDeploymentMappings(provider.config?.deployments),
       )
+      setAzureEndpoint(provider.config?.endpoint)
+      setAzureAPIVersion(provider.config?.apiVersion || "2024-02-01")
     }
     if (provider.type === "openai-compatible") {
       setUserModels((provider.config?.models as Array<string>) || [])
@@ -1575,8 +1583,8 @@ function ModelsMenuItem({
         { model: deploymentName, deployment: deploymentName },
       ]
       const result = await updateProviderConfig(provider.id, {
-        endpoint: provider.config?.endpoint,
-        apiVersion: provider.config?.apiVersion || "2024-02-01",
+        endpoint: azureEndpoint,
+        apiVersion: azureAPIVersion,
         deployments: nextMappings,
       })
       setAzureMappings(
@@ -1584,6 +1592,8 @@ function ModelsMenuItem({
           result.config?.deployments ?? nextMappings,
         ),
       )
+      setAzureEndpoint(result.config?.endpoint ?? azureEndpoint)
+      setAzureAPIVersion(result.config?.apiVersion ?? azureAPIVersion)
       setNewDeployment("")
       onModelsChanged?.()
       await load()
@@ -1605,8 +1615,8 @@ function ModelsMenuItem({
           && mapping.model !== deploymentName,
       )
       const result = await updateProviderConfig(provider.id, {
-        endpoint: provider.config?.endpoint,
-        apiVersion: provider.config?.apiVersion || "2024-02-01",
+        endpoint: azureEndpoint,
+        apiVersion: azureAPIVersion,
         deployments: nextMappings,
       })
       setAzureMappings(
@@ -1614,6 +1624,8 @@ function ModelsMenuItem({
           result.config?.deployments ?? nextMappings,
         ),
       )
+      setAzureEndpoint(result.config?.endpoint ?? azureEndpoint)
+      setAzureAPIVersion(result.config?.apiVersion ?? azureAPIVersion)
       onModelsChanged?.()
       await load()
     } catch (e) {

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -1528,12 +1528,16 @@ function ModelsMenuItem({
         ...azureMappings,
         { model: deploymentName, deployment: deploymentName },
       ]
-      await updateProviderConfig(provider.id, {
+      const result = await updateProviderConfig(provider.id, {
         endpoint: provider.config?.endpoint,
         apiVersion: provider.config?.apiVersion || "2024-02-01",
         deployments: nextMappings,
       })
-      setAzureMappings(nextMappings)
+      setAzureMappings(
+        normalizeAzureDeploymentMappings(
+          result.config?.deployments ?? nextMappings,
+        ),
+      )
       setNewDeployment("")
       onModelsChanged?.()
       await load()
@@ -1554,12 +1558,16 @@ function ModelsMenuItem({
           mapping.deployment !== deploymentName
           && mapping.model !== deploymentName,
       )
-      await updateProviderConfig(provider.id, {
+      const result = await updateProviderConfig(provider.id, {
         endpoint: provider.config?.endpoint,
         apiVersion: provider.config?.apiVersion || "2024-02-01",
         deployments: nextMappings,
       })
-      setAzureMappings(nextMappings)
+      setAzureMappings(
+        normalizeAzureDeploymentMappings(
+          result.config?.deployments ?? nextMappings,
+        ),
+      )
       onModelsChanged?.()
       await load()
     } catch (e) {

--- a/frontend/src/pages/providers/constants/providerRegistry.tsx
+++ b/frontend/src/pages/providers/constants/providerRegistry.tsx
@@ -7,6 +7,7 @@ export const PROVIDER_ACCENT: Record<string, string> = {
   "azure-openai": "#0078d4",
   google: "#4285f4",
   kimi: "#e040fb",
+  codex: "#6e40c9",
   "openai-compatible": "#10b981",
 }
 
@@ -73,6 +74,18 @@ export const PROVIDER_ICONS: Record<string, ReactNode> = {
       />
     </svg>
   ),
+  codex: (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+      <path
+        d="M8 6l-6 6 6 6M16 6l6 6-6 6"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
 }
 
 export const TYPE_NAMES: Record<string, string> = {
@@ -82,6 +95,7 @@ export const TYPE_NAMES: Record<string, string> = {
   "azure-openai": "Azure OpenAI",
   google: "Google Gemini",
   kimi: "Kimi (Moonshot)",
+  codex: "Codex",
 }
 
 export const PROVIDER_TYPES = [
@@ -91,5 +105,6 @@ export const PROVIDER_TYPES = [
   "azure-openai",
   "google",
   "kimi",
+  "codex",
   "openai-compatible",
 ] as const satisfies ReadonlyArray<string>

--- a/internal/providers/codex/codex.go
+++ b/internal/providers/codex/codex.go
@@ -1,0 +1,445 @@
+// Package codex provides the Codex provider implementation.
+// Codex authenticates via GitHub OAuth (device-code flow) and exposes
+// Codex-flavoured OpenAI-compatible completions.
+package codex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"omnillm/internal/cif"
+	"omnillm/internal/database"
+	"omnillm/internal/providers/shared"
+	"omnillm/internal/providers/types"
+	"strings"
+	"time"
+
+	ghservice "omnillm/internal/services/github"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	codexBaseURL    = "https://api.githubcopilot.com"
+	codexProviderID = "codex"
+)
+
+var (
+	codexHTTPClient = &http.Client{
+		Timeout: 120 * time.Second,
+		Transport: &http.Transport{
+			Proxy:               http.ProxyFromEnvironment,
+			ForceAttemptHTTP2:   true,
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 20,
+			IdleConnTimeout:     90 * time.Second,
+		},
+	}
+	codexStreamClient = &http.Client{
+		Transport: &http.Transport{
+			Proxy:               http.ProxyFromEnvironment,
+			ForceAttemptHTTP2:   true,
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 20,
+			IdleConnTimeout:     90 * time.Second,
+		},
+	}
+)
+
+// CodexProvider authenticates via GitHub OAuth and routes requests to the
+// Codex endpoint.
+type CodexProvider struct {
+	id          string
+	instanceID  string
+	name        string
+	token       string // short-lived Copilot/Codex API token
+	githubToken string // long-lived GitHub OAuth token
+	expiresAt   int64
+	baseURL     string
+}
+
+// CodexAdapter bridges the provider to the CIF execution layer.
+type CodexAdapter struct {
+	provider *CodexProvider
+}
+
+// NewCodexProvider creates a new CodexProvider for the given instance ID.
+func NewCodexProvider(instanceID string) *CodexProvider {
+	return &CodexProvider{
+		id:         codexProviderID,
+		instanceID: instanceID,
+		name:       "Codex",
+		baseURL:    codexBaseURL,
+	}
+}
+
+// ── Provider interface ───────────────────────────────────────────────────────
+
+func (p *CodexProvider) GetID() string         { return p.id }
+func (p *CodexProvider) GetInstanceID() string { return p.instanceID }
+func (p *CodexProvider) GetName() string       { return p.name }
+func (p *CodexProvider) SetInstanceID(id string) { p.instanceID = id }
+
+// SetupAuth accepts a direct GitHub token.  When no token is provided the
+// caller should start the device-code flow via InitiateDeviceCodeFlow.
+func (p *CodexProvider) SetupAuth(options *types.AuthOptions) error {
+	token := ""
+	if options != nil {
+		token = options.GithubToken
+		if token == "" {
+			token = options.Token
+		}
+		if token == "" {
+			token = options.APIKey
+		}
+	}
+	if token == "" {
+		return fmt.Errorf("GitHub token required; use the OAuth device-code flow")
+	}
+	p.githubToken = token
+	if err := p.RefreshToken(); err != nil {
+		return fmt.Errorf("failed to exchange GitHub token for Codex token: %w", err)
+	}
+	user, err := ghservice.GetUser(p.githubToken)
+	if err == nil {
+		if login, ok := user["login"].(string); ok {
+			p.name = fmt.Sprintf("Codex (%s)", login)
+		}
+	}
+	return nil
+}
+
+// InitiateDeviceCodeFlow starts the GitHub OAuth device-code flow.
+func (p *CodexProvider) InitiateDeviceCodeFlow() (*ghservice.DeviceCodeResponse, error) {
+	log.Info().Str("provider", p.instanceID).Msg("Codex: initiating GitHub OAuth device-code flow")
+	dc, err := ghservice.GetDeviceCode()
+	if err != nil {
+		return nil, fmt.Errorf("codex: failed to get device code: %w", err)
+	}
+	log.Info().Str("user_code", dc.UserCode).Str("uri", dc.VerificationURI).Msg("Codex: device code generated")
+	return dc, nil
+}
+
+// PollAndCompleteDeviceCodeFlow polls GitHub until the user authorises and
+// then exchanges the OAuth token for a Codex API token.
+func (p *CodexProvider) PollAndCompleteDeviceCodeFlow(dc *ghservice.DeviceCodeResponse) error {
+	log.Info().Str("provider", p.instanceID).Msg("Codex: polling for GitHub access token")
+	accessToken, err := ghservice.PollAccessToken(dc)
+	if err != nil {
+		return fmt.Errorf("codex: failed to poll access token: %w", err)
+	}
+	p.githubToken = accessToken
+	user, err := ghservice.GetUser(accessToken)
+	if err == nil {
+		if login, ok := user["login"].(string); ok {
+			p.name = fmt.Sprintf("Codex (%s)", login)
+			log.Info().Str("login", login).Msg("Codex: authenticated via device code")
+		}
+	}
+	if err := p.RefreshToken(); err != nil {
+		return fmt.Errorf("codex: failed to get API token after OAuth: %w", err)
+	}
+	return nil
+}
+
+// RefreshToken exchanges the long-lived GitHub token for a short-lived
+// Copilot/Codex API token.
+func (p *CodexProvider) RefreshToken() error {
+	if p.githubToken == "" {
+		return nil
+	}
+	resp, err := ghservice.GetCopilotToken(p.githubToken)
+	if err != nil {
+		return fmt.Errorf("codex: refresh failed: %w", err)
+	}
+	p.token = resp.Token
+	p.expiresAt = resp.ExpiresAt
+	log.Info().Str("provider", p.instanceID).Msg("Codex: token refreshed")
+	return nil
+}
+
+// GetToken returns a valid short-lived token, refreshing if necessary.
+func (p *CodexProvider) GetToken() string {
+	if p.githubToken != "" {
+		if p.token == "" || p.expiresAt == 0 || time.Now().Unix() > p.expiresAt-300 {
+			if err := p.RefreshToken(); err != nil {
+				log.Warn().Err(err).Msg("Codex: auto-refresh failed")
+			}
+		}
+	}
+	return p.token
+}
+
+// SaveToDB persists GitHub and API tokens to the database.
+func (p *CodexProvider) SaveToDB() error {
+	return database.NewTokenStore().Save(p.instanceID, p.id, map[string]interface{}{
+		"github_token": p.githubToken,
+		"codex_token":  p.token,
+		"expires_at":   p.expiresAt,
+		"name":         p.name,
+	})
+}
+
+// LoadFromDB restores tokens from the database.
+func (p *CodexProvider) LoadFromDB() error {
+	record, err := database.NewTokenStore().Get(p.instanceID)
+	if err != nil {
+		return fmt.Errorf("codex: load from DB failed: %w", err)
+	}
+	if record == nil {
+		return nil
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(record.TokenData), &data); err != nil {
+		return fmt.Errorf("codex: failed to parse token data: %w", err)
+	}
+	if v, ok := data["github_token"].(string); ok {
+		p.githubToken = v
+	}
+	if v, ok := data["codex_token"].(string); ok {
+		p.token = v
+	}
+	if v, ok := data["expires_at"].(float64); ok {
+		p.expiresAt = int64(v)
+	}
+	if v, ok := data["name"].(string); ok && v != "" {
+		p.name = v
+	}
+	if p.githubToken != "" && (p.token == "" || time.Now().Unix() > p.expiresAt-300) {
+		if err := p.RefreshToken(); err != nil {
+			log.Warn().Err(err).Str("provider", p.instanceID).Msg("Codex: refresh on load failed")
+		}
+	}
+	return nil
+}
+
+func (p *CodexProvider) GetBaseURL() string { return p.baseURL }
+
+// GetHeaders returns the HTTP headers to use for Codex API requests.
+func (p *CodexProvider) GetHeaders(_ bool) map[string]string {
+	return map[string]string{
+		"Authorization":          fmt.Sprintf("Bearer %s", p.GetToken()),
+		"Content-Type":           "application/json",
+		"Accept":                 "application/json",
+		"Editor-Version":         ghservice.EditorVersion,
+		"Editor-Plugin-Version":  ghservice.PluginVersion,
+		"User-Agent":             ghservice.UserAgent,
+		"X-Github-Api-Version":   ghservice.APIVersion,
+		"copilot-integration-id": "vscode-chat",
+	}
+}
+
+// GetModels returns the available Codex models.
+func (p *CodexProvider) GetModels() (*types.ModelsResponse, error) {
+	token := p.GetToken()
+	if token == "" {
+		return nil, fmt.Errorf("codex: provider not authenticated")
+	}
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/models", p.baseURL), nil)
+	if err == nil {
+		for k, v := range p.GetHeaders(false) {
+			req.Header.Set(k, v)
+		}
+		if resp, err := codexHTTPClient.Do(req); err == nil {
+			defer resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				var payload struct {
+					Data []struct {
+						ID   string `json:"id"`
+						Name string `json:"name"`
+					} `json:"data"`
+				}
+				if json.NewDecoder(resp.Body).Decode(&payload) == nil && len(payload.Data) > 0 {
+					models := make([]types.Model, 0, len(payload.Data))
+					for _, m := range payload.Data {
+						if !strings.Contains(strings.ToLower(m.ID), "codex") {
+							continue
+						}
+						name := m.Name
+						if name == "" {
+							name = m.ID
+						}
+						models = append(models, types.Model{
+							ID:        m.ID,
+							Name:      name,
+							MaxTokens: 8096,
+							Provider:  p.instanceID,
+						})
+					}
+					if len(models) > 0 {
+						return &types.ModelsResponse{Data: models, Object: "list"}, nil
+					}
+				}
+			}
+		}
+	}
+
+	// Fall back to known Codex models.
+	return &types.ModelsResponse{
+		Object: "list",
+		Data: []types.Model{
+			{ID: "code-davinci-002", Name: "Codex (code-davinci-002)", MaxTokens: 8001, Provider: p.instanceID},
+			{ID: "code-cushman-001", Name: "Codex (code-cushman-001)", MaxTokens: 2048, Provider: p.instanceID},
+		},
+	}, nil
+}
+
+// GetUsage is not available for Codex; returns an empty map.
+func (p *CodexProvider) GetUsage() (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
+}
+
+// GetAdapter returns the CIF adapter for this provider.
+func (p *CodexProvider) GetAdapter() types.ProviderAdapter {
+	return &CodexAdapter{provider: p}
+}
+
+// ── CIF Adapter ──────────────────────────────────────────────────────────────
+
+func (a *CodexAdapter) GetProvider() types.Provider { return a.provider }
+
+func (a *CodexAdapter) RemapModel(model string) string { return model }
+
+// ── Provider legacy interface methods ────────────────────────────────────────
+
+// CreateChatCompletions implements the legacy types.Provider interface.
+func (p *CodexProvider) CreateChatCompletions(payload map[string]interface{}) (map[string]interface{}, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("codex: marshal error: %w", err)
+	}
+	url := fmt.Sprintf("%s/chat/completions", p.baseURL)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("codex: create request error: %w", err)
+	}
+	for k, v := range p.GetHeaders(false) {
+		req.Header.Set(k, v)
+	}
+	resp, err := codexHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("codex: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("codex: API error %d: %s", resp.StatusCode, b)
+	}
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("codex: decode error: %w", err)
+	}
+	return result, nil
+}
+
+// CreateEmbeddings is not supported by Codex.
+func (p *CodexProvider) CreateEmbeddings(_ map[string]interface{}) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("codex: embeddings are not supported")
+}
+
+func (a *CodexAdapter) Execute(ctx context.Context, request *cif.CanonicalRequest) (*cif.CanonicalResponse, error) {
+	payload := a.buildPayload(request, false)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("codex: marshal error: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/chat/completions", a.provider.GetBaseURL())
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("codex: create request error: %w", err)
+	}
+	for k, v := range a.provider.GetHeaders(false) {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := codexHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("codex: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("codex: API error %d: %s", resp.StatusCode, b)
+	}
+
+	var openaiResp map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&openaiResp); err != nil {
+		return nil, fmt.Errorf("codex: decode response error: %w", err)
+	}
+	return a.convertResponseToCIF(openaiResp), nil
+}
+
+func (a *CodexAdapter) ExecuteStream(ctx context.Context, request *cif.CanonicalRequest) (<-chan cif.CIFStreamEvent, error) {
+	payload := a.buildPayload(request, true)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("codex: marshal error: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/chat/completions", a.provider.GetBaseURL())
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("codex: create request error: %w", err)
+	}
+	for k, v := range a.provider.GetHeaders(false) {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := codexStreamClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("codex: stream request failed: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("codex: API error %d: %s", resp.StatusCode, b)
+	}
+
+	ch := make(chan cif.CIFStreamEvent, 64)
+	go shared.ParseOpenAISSE(resp.Body, ch)
+	return ch, nil
+}
+
+func (a *CodexAdapter) buildPayload(request *cif.CanonicalRequest, stream bool) map[string]interface{} {
+	messages := shared.CIFMessagesToOpenAI(request.Messages)
+	payload := map[string]interface{}{
+		"model":    request.Model,
+		"messages": messages,
+		"stream":   stream,
+	}
+	if request.MaxTokens != nil {
+		payload["max_tokens"] = *request.MaxTokens
+	}
+	if request.Temperature != nil {
+		payload["temperature"] = *request.Temperature
+	}
+	if len(request.Tools) > 0 {
+		var tools []map[string]interface{}
+		for _, tool := range request.Tools {
+			t := map[string]interface{}{
+				"type": "function",
+				"function": map[string]interface{}{
+					"name":       tool.Name,
+					"parameters": shared.NormalizeToolParameters(tool.ParametersSchema),
+				},
+			}
+			if tool.Description != nil {
+				t["function"].(map[string]interface{})["description"] = *tool.Description
+			}
+			tools = append(tools, t)
+		}
+		payload["tools"] = tools
+	}
+	return payload
+}
+
+func (a *CodexAdapter) convertResponseToCIF(resp map[string]interface{}) *cif.CanonicalResponse {
+	return shared.OpenAIRespToCIF(resp)
+}

--- a/internal/providers/codex/codex.go
+++ b/internal/providers/codex/codex.go
@@ -1,6 +1,7 @@
 // Package codex provides the Codex provider implementation.
-// Codex authenticates via GitHub OAuth (device-code flow) and exposes
-// Codex-flavoured OpenAI-compatible completions.
+// Codex authenticates via an OpenAI API key and routes requests to the
+// official OpenAI Codex endpoint (or the GitHub Copilot endpoint for legacy
+// GitHub OAuth tokens).
 package codex
 
 import (
@@ -23,8 +24,11 @@ import (
 )
 
 const (
-	codexBaseURL    = "https://api.githubcopilot.com"
-	codexProviderID = "codex"
+	// codexBaseURL is the OpenAI endpoint used when authenticating with an API key.
+	codexBaseURL = "https://api.openai.com/v1"
+	// codexGitHubBaseURL is the GitHub Copilot endpoint for legacy OAuth tokens.
+	codexGitHubBaseURL = "https://api.githubcopilot.com"
+	codexProviderID    = "codex"
 )
 
 var (
@@ -49,14 +53,15 @@ var (
 	}
 )
 
-// CodexProvider authenticates via GitHub OAuth and routes requests to the
-// Codex endpoint.
+// CodexProvider authenticates via an OpenAI API key (primary) or a legacy
+// GitHub OAuth token and routes requests to the Codex endpoint.
 type CodexProvider struct {
 	id          string
 	instanceID  string
 	name        string
-	token       string // short-lived Copilot/Codex API token
-	githubToken string // long-lived GitHub OAuth token
+	apiKey      string // OpenAI API key (primary auth method)
+	token       string // short-lived Copilot/Codex API token (legacy GitHub path)
+	githubToken string // long-lived GitHub OAuth token (legacy path)
 	expiresAt   int64
 	baseURL     string
 }
@@ -83,23 +88,33 @@ func (p *CodexProvider) GetInstanceID() string { return p.instanceID }
 func (p *CodexProvider) GetName() string       { return p.name }
 func (p *CodexProvider) SetInstanceID(id string) { p.instanceID = id }
 
-// SetupAuth accepts a direct GitHub token.  When no token is provided the
-// caller should start the device-code flow via InitiateDeviceCodeFlow.
+// SetupAuth configures the provider.  Pass an OpenAI API key via
+// options.APIKey (primary), or a GitHub OAuth token via options.GithubToken /
+// options.Token for the legacy GitHub Copilot path.
 func (p *CodexProvider) SetupAuth(options *types.AuthOptions) error {
-	token := ""
-	if options != nil {
-		token = options.GithubToken
-		if token == "" {
-			token = options.Token
-		}
-		if token == "" {
-			token = options.APIKey
-		}
+	if options == nil {
+		return fmt.Errorf("auth options required")
+	}
+
+	// Primary: OpenAI API key.
+	if strings.TrimSpace(options.APIKey) != "" {
+		p.apiKey = strings.TrimSpace(options.APIKey)
+		p.baseURL = codexBaseURL
+		p.name = "Codex"
+		log.Info().Str("provider", p.instanceID).Msg("Codex: configured with OpenAI API key")
+		return nil
+	}
+
+	// Legacy: GitHub OAuth / personal token.
+	token := strings.TrimSpace(options.GithubToken)
+	if token == "" {
+		token = strings.TrimSpace(options.Token)
 	}
 	if token == "" {
-		return fmt.Errorf("GitHub token required; use the OAuth device-code flow")
+		return fmt.Errorf("an OpenAI API key (apiKey) is required for Codex")
 	}
 	p.githubToken = token
+	p.baseURL = codexGitHubBaseURL
 	if err := p.RefreshToken(); err != nil {
 		return fmt.Errorf("failed to exchange GitHub token for Codex token: %w", err)
 	}
@@ -161,8 +176,13 @@ func (p *CodexProvider) RefreshToken() error {
 	return nil
 }
 
-// GetToken returns a valid short-lived token, refreshing if necessary.
+// GetToken returns a valid token for API requests.
+// For API-key auth this is the key itself; for GitHub OAuth it returns the
+// short-lived Copilot token, refreshing it when needed.
 func (p *CodexProvider) GetToken() string {
+	if p.apiKey != "" {
+		return p.apiKey
+	}
 	if p.githubToken != "" {
 		if p.token == "" || p.expiresAt == 0 || time.Now().Unix() > p.expiresAt-300 {
 			if err := p.RefreshToken(); err != nil {
@@ -173,17 +193,24 @@ func (p *CodexProvider) GetToken() string {
 	return p.token
 }
 
-// SaveToDB persists GitHub and API tokens to the database.
+// SaveToDB persists auth credentials to the database.
 func (p *CodexProvider) SaveToDB() error {
-	return database.NewTokenStore().Save(p.instanceID, p.id, map[string]interface{}{
-		"github_token": p.githubToken,
-		"codex_token":  p.token,
-		"expires_at":   p.expiresAt,
-		"name":         p.name,
-	})
+	data := map[string]interface{}{
+		"name": p.name,
+	}
+	if p.apiKey != "" {
+		data["api_key"]     = p.apiKey
+		data["auth_method"] = "api-key"
+	} else {
+		data["github_token"] = p.githubToken
+		data["codex_token"]  = p.token
+		data["expires_at"]   = p.expiresAt
+		data["auth_method"]  = "github"
+	}
+	return database.NewTokenStore().Save(p.instanceID, p.id, data)
 }
 
-// LoadFromDB restores tokens from the database.
+// LoadFromDB restores credentials from the database.
 func (p *CodexProvider) LoadFromDB() error {
 	record, err := database.NewTokenStore().Get(p.instanceID)
 	if err != nil {
@@ -196,6 +223,16 @@ func (p *CodexProvider) LoadFromDB() error {
 	if err := json.Unmarshal([]byte(record.TokenData), &data); err != nil {
 		return fmt.Errorf("codex: failed to parse token data: %w", err)
 	}
+	if v, ok := data["name"].(string); ok && v != "" {
+		p.name = v
+	}
+	// API-key path.
+	if v, ok := data["api_key"].(string); ok && v != "" {
+		p.apiKey  = v
+		p.baseURL = codexBaseURL
+		return nil
+	}
+	// Legacy GitHub OAuth path.
 	if v, ok := data["github_token"].(string); ok {
 		p.githubToken = v
 	}
@@ -205,12 +242,12 @@ func (p *CodexProvider) LoadFromDB() error {
 	if v, ok := data["expires_at"].(float64); ok {
 		p.expiresAt = int64(v)
 	}
-	if v, ok := data["name"].(string); ok && v != "" {
-		p.name = v
-	}
-	if p.githubToken != "" && (p.token == "" || time.Now().Unix() > p.expiresAt-300) {
-		if err := p.RefreshToken(); err != nil {
-			log.Warn().Err(err).Str("provider", p.instanceID).Msg("Codex: refresh on load failed")
+	if p.githubToken != "" {
+		p.baseURL = codexGitHubBaseURL
+		if p.token == "" || time.Now().Unix() > p.expiresAt-300 {
+			if err := p.RefreshToken(); err != nil {
+				log.Warn().Err(err).Str("provider", p.instanceID).Msg("Codex: refresh on load failed")
+			}
 		}
 	}
 	return nil
@@ -219,17 +256,23 @@ func (p *CodexProvider) LoadFromDB() error {
 func (p *CodexProvider) GetBaseURL() string { return p.baseURL }
 
 // GetHeaders returns the HTTP headers to use for Codex API requests.
+// For API-key auth only standard OpenAI headers are sent; GitHub-specific
+// headers are added only for the legacy OAuth path.
 func (p *CodexProvider) GetHeaders(_ bool) map[string]string {
-	return map[string]string{
-		"Authorization":          fmt.Sprintf("Bearer %s", p.GetToken()),
-		"Content-Type":           "application/json",
-		"Accept":                 "application/json",
-		"Editor-Version":         ghservice.EditorVersion,
-		"Editor-Plugin-Version":  ghservice.PluginVersion,
-		"User-Agent":             ghservice.UserAgent,
-		"X-Github-Api-Version":   ghservice.APIVersion,
-		"copilot-integration-id": "vscode-chat",
+	headers := map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", p.GetToken()),
+		"Content-Type":  "application/json",
+		"Accept":        "application/json",
 	}
+	// Add GitHub Copilot headers only for legacy OAuth path.
+	if p.githubToken != "" {
+		headers["Editor-Version"]         = ghservice.EditorVersion
+		headers["Editor-Plugin-Version"]  = ghservice.PluginVersion
+		headers["User-Agent"]             = ghservice.UserAgent
+		headers["X-Github-Api-Version"]   = ghservice.APIVersion
+		headers["copilot-integration-id"] = "vscode-chat"
+	}
+	return headers
 }
 
 // GetModels returns the available Codex models.

--- a/internal/providers/types/types.go
+++ b/internal/providers/types/types.go
@@ -35,6 +35,7 @@ type AuthOptions struct {
 	Deployments         string `json:"deployments,omitempty"` // JSON-encoded []string, used by azure-openai
 	APIVersion          string `json:"apiVersion,omitempty"`  // e.g. "2024-02-01", used by azure-openai
 	AllowLocalEndpoints bool   `json:"allowLocalEndpoints,omitempty"`
+	OAuthProvider       string `json:"oauthProvider,omitempty"` // "github" (default) or "google" for Codex
 }
 
 type Model struct {

--- a/internal/routes/admin.go
+++ b/internal/routes/admin.go
@@ -29,6 +29,7 @@ import (
 	azurepkg "omnillm/internal/providers/azure"
 
 	openaicompatprovider "omnillm/internal/providers/openaicompatprovider"
+	codexpkg "omnillm/internal/providers/codex"
 
 	ghservice "omnillm/internal/services/github"
 )
@@ -892,6 +893,136 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 			},
 		})
 
+	// ── Codex ────────────────────────────────────────────────────────────────
+	case "codex":
+		cdx := codexpkg.NewCodexProvider("codex-tmp")
+
+		if req.Method == "oauth" || (req.GithubToken == "" && req.Token == "" && req.APIKey == "") {
+			deviceCode, err := cdx.InitiateDeviceCodeFlow()
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"success": false,
+					"message": fmt.Sprintf("Failed to initiate Codex OAuth: %v", err),
+				})
+				return
+			}
+
+			const pendingID = "codex-pending"
+			codexCtx, codexCancel := context.WithCancel(context.Background())
+			activeAuthFlowMu.Lock()
+			activeAuthFlow = &authFlowState{
+				ProviderID:     pendingID,
+				Status:         "awaiting_user",
+				InstructionURL: deviceCode.VerificationURI,
+				UserCode:       deviceCode.UserCode,
+				deviceCode:     deviceCode.DeviceCode,
+				cancelFn:       codexCancel,
+			}
+			activeAuthFlowMu.Unlock()
+
+			dc := deviceCode
+			go func() {
+				defer codexCancel()
+				if err := cdx.PollAndCompleteDeviceCodeFlow(dc); err != nil {
+					if codexCtx.Err() != nil {
+						return
+					}
+					activeAuthFlowMu.Lock()
+					if activeAuthFlow != nil && activeAuthFlow.ProviderID == pendingID {
+						activeAuthFlow.Status = "error"
+						activeAuthFlow.Error = err.Error()
+					}
+					activeAuthFlowMu.Unlock()
+					log.Error().Err(err).Str("type", "codex").Msg("Auth-and-create: Codex OAuth failed")
+					return
+				}
+
+				canonicalID := providerRegistry.NextInstanceID("codex")
+				cdx.SetInstanceID(canonicalID)
+
+				if err := cdx.SaveToDB(); err != nil {
+					log.Error().Err(err).Str("provider", canonicalID).Msg("Auth-and-create: failed to save Codex token")
+					activeAuthFlowMu.Lock()
+					if activeAuthFlow != nil && activeAuthFlow.ProviderID == pendingID {
+						activeAuthFlow.Status = "error"
+						activeAuthFlow.Error = "Failed to save token"
+					}
+					activeAuthFlowMu.Unlock()
+					return
+				}
+
+				if err := providerRegistry.Register(cdx, true); err != nil {
+					log.Warn().Err(err).Str("provider", canonicalID).Msg("Auth-and-create: failed to register Codex provider")
+				}
+
+				activeAuthFlowMu.Lock()
+				if activeAuthFlow != nil && activeAuthFlow.ProviderID == pendingID {
+					activeAuthFlow.ProviderID = canonicalID
+					activeAuthFlow.Status = "complete"
+				}
+				activeAuthFlowMu.Unlock()
+
+				log.Info().Str("provider", canonicalID).Msg("Auth-and-create: Codex OAuth completed")
+			}()
+
+			c.JSON(http.StatusOK, gin.H{
+				"success":          false,
+				"requiresAuth":     true,
+				"pending_id":       pendingID,
+				"user_code":        deviceCode.UserCode,
+				"verification_uri": deviceCode.VerificationURI,
+				"message":          fmt.Sprintf("Visit %s and enter code: %s", deviceCode.VerificationURI, deviceCode.UserCode),
+			})
+			return
+		}
+
+		// Direct token path.
+		token := req.Token
+		if token == "" {
+			token = req.GithubToken
+		}
+		if token == "" {
+			token = req.APIKey
+		}
+		req.GithubToken = token
+		if err := cdx.SetupAuth(&req); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"success": false,
+				"message": fmt.Sprintf("Codex authentication failed: %v", err),
+			})
+			return
+		}
+
+		canonicalID := providerRegistry.NextInstanceID("codex")
+		cdx.SetInstanceID(canonicalID)
+
+		if err := cdx.SaveToDB(); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"success": false,
+				"message": fmt.Sprintf("Failed to save Codex credentials: %v", err),
+			})
+			return
+		}
+
+		if err := providerRegistry.Register(cdx, true); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"success": false,
+				"message": fmt.Sprintf("Failed to register Codex provider: %v", err),
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"success": true,
+			"provider": gin.H{
+				"id":         cdx.GetInstanceID(),
+				"type":       cdx.GetID(),
+				"name":       cdx.GetName(),
+				"isActive":   false,
+				"authStatus": "authenticated",
+			},
+		})
+
 	// ── API-key based providers ────────────────────────────────────────────────
 	case "azure-openai", "antigravity", "google", "kimi":
 		instanceID := providerRegistry.NextInstanceID(providerType)
@@ -1217,6 +1348,80 @@ func handleProviderAuth(c *gin.Context) {
 	}
 
 	cop, isCopilot := provider.(*copilot.GitHubCopilotProvider)
+	cdxProv, isCodex := provider.(*codexpkg.CodexProvider)
+
+	// Codex: same GitHub OAuth device-code flow as Copilot.
+	if isCodex {
+		if req.Method == "oauth" || (req.GithubToken == "" && req.Token == "" && req.APIKey == "") {
+			deviceCode, err := cdxProv.InitiateDeviceCodeFlow()
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"success": false,
+					"message": fmt.Sprintf("Failed to initiate Codex OAuth: %v", err),
+				})
+				return
+			}
+
+			codexCtx, codexCancel := context.WithCancel(context.Background())
+			activeAuthFlowMu.Lock()
+			activeAuthFlow = &authFlowState{
+				ProviderID:     providerID,
+				Status:         "awaiting_user",
+				InstructionURL: deviceCode.VerificationURI,
+				UserCode:       deviceCode.UserCode,
+				deviceCode:     deviceCode.DeviceCode,
+				cancelFn:       codexCancel,
+			}
+			activeAuthFlowMu.Unlock()
+
+			dc := deviceCode
+			prov := cdxProv
+			go func() {
+				defer codexCancel()
+				if err := prov.PollAndCompleteDeviceCodeFlow(dc); err != nil {
+					if codexCtx.Err() != nil {
+						return
+					}
+					activeAuthFlowMu.Lock()
+					if activeAuthFlow != nil && activeAuthFlow.ProviderID == providerID {
+						activeAuthFlow.Status = "error"
+						activeAuthFlow.Error = err.Error()
+					}
+					activeAuthFlowMu.Unlock()
+					return
+				}
+				if err := prov.SaveToDB(); err != nil {
+					log.Error().Err(err).Str("provider", providerID).Msg("Codex: failed to save token")
+				}
+				if err := providerRegistry.Register(prov, true); err != nil {
+					log.Warn().Err(err).Str("provider", providerID).Msg("Codex: failed to update provider in registry")
+				}
+				activeAuthFlowMu.Lock()
+				if activeAuthFlow != nil && activeAuthFlow.ProviderID == providerID {
+					activeAuthFlow.Status = "complete"
+				}
+				activeAuthFlowMu.Unlock()
+			}()
+
+			c.JSON(http.StatusOK, gin.H{
+				"success":          false,
+				"requiresAuth":     true,
+				"user_code":        deviceCode.UserCode,
+				"verification_uri": deviceCode.VerificationURI,
+				"message":          fmt.Sprintf("Visit %s and enter code: %s", deviceCode.VerificationURI, deviceCode.UserCode),
+			})
+			return
+		}
+		// Direct token path for Codex.
+		token := req.Token
+		if token == "" {
+			token = req.GithubToken
+		}
+		if token == "" {
+			token = req.APIKey
+		}
+		req.GithubToken = token
+	}
 
 	// Alibaba: API-key only — OAuth is not supported.
 	if aliProv, ok := provider.(*alibabapkg.Provider); ok {

--- a/internal/routes/admin.go
+++ b/internal/routes/admin.go
@@ -895,96 +895,16 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 
 	// ── Codex ────────────────────────────────────────────────────────────────
 	case "codex":
-		cdx := codexpkg.NewCodexProvider("codex-tmp")
-
-		if req.Method == "oauth" || (req.GithubToken == "" && req.Token == "" && req.APIKey == "") {
-			deviceCode, err := cdx.InitiateDeviceCodeFlow()
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"success": false,
-					"message": fmt.Sprintf("Failed to initiate Codex OAuth: %v", err),
-				})
-				return
-			}
-
-			const pendingID = "codex-pending"
-			codexCtx, codexCancel := context.WithCancel(context.Background())
-			activeAuthFlowMu.Lock()
-			activeAuthFlow = &authFlowState{
-				ProviderID:     pendingID,
-				Status:         "awaiting_user",
-				InstructionURL: deviceCode.VerificationURI,
-				UserCode:       deviceCode.UserCode,
-				deviceCode:     deviceCode.DeviceCode,
-				cancelFn:       codexCancel,
-			}
-			activeAuthFlowMu.Unlock()
-
-			dc := deviceCode
-			go func() {
-				defer codexCancel()
-				if err := cdx.PollAndCompleteDeviceCodeFlow(dc); err != nil {
-					if codexCtx.Err() != nil {
-						return
-					}
-					activeAuthFlowMu.Lock()
-					if activeAuthFlow != nil && activeAuthFlow.ProviderID == pendingID {
-						activeAuthFlow.Status = "error"
-						activeAuthFlow.Error = err.Error()
-					}
-					activeAuthFlowMu.Unlock()
-					log.Error().Err(err).Str("type", "codex").Msg("Auth-and-create: Codex OAuth failed")
-					return
-				}
-
-				canonicalID := providerRegistry.NextInstanceID("codex")
-				cdx.SetInstanceID(canonicalID)
-
-				if err := cdx.SaveToDB(); err != nil {
-					log.Error().Err(err).Str("provider", canonicalID).Msg("Auth-and-create: failed to save Codex token")
-					activeAuthFlowMu.Lock()
-					if activeAuthFlow != nil && activeAuthFlow.ProviderID == pendingID {
-						activeAuthFlow.Status = "error"
-						activeAuthFlow.Error = "Failed to save token"
-					}
-					activeAuthFlowMu.Unlock()
-					return
-				}
-
-				if err := providerRegistry.Register(cdx, true); err != nil {
-					log.Warn().Err(err).Str("provider", canonicalID).Msg("Auth-and-create: failed to register Codex provider")
-				}
-
-				activeAuthFlowMu.Lock()
-				if activeAuthFlow != nil && activeAuthFlow.ProviderID == pendingID {
-					activeAuthFlow.ProviderID = canonicalID
-					activeAuthFlow.Status = "complete"
-				}
-				activeAuthFlowMu.Unlock()
-
-				log.Info().Str("provider", canonicalID).Msg("Auth-and-create: Codex OAuth completed")
-			}()
-
-			c.JSON(http.StatusOK, gin.H{
-				"success":          false,
-				"requiresAuth":     true,
-				"pending_id":       pendingID,
-				"user_code":        deviceCode.UserCode,
-				"verification_uri": deviceCode.VerificationURI,
-				"message":          fmt.Sprintf("Visit %s and enter code: %s", deviceCode.VerificationURI, deviceCode.UserCode),
+		if strings.TrimSpace(req.APIKey) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"success": false,
+				"message": "apiKey is required for Codex authentication",
 			})
 			return
 		}
 
-		// Direct token path.
-		token := req.Token
-		if token == "" {
-			token = req.GithubToken
-		}
-		if token == "" {
-			token = req.APIKey
-		}
-		req.GithubToken = token
+		canonicalID := providerRegistry.NextInstanceID("codex")
+		cdx := codexpkg.NewCodexProvider(canonicalID)
 		if err := cdx.SetupAuth(&req); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"success": false,
@@ -992,9 +912,6 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 			})
 			return
 		}
-
-		canonicalID := providerRegistry.NextInstanceID("codex")
-		cdx.SetInstanceID(canonicalID)
 
 		if err := cdx.SaveToDB(); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -1348,79 +1265,16 @@ func handleProviderAuth(c *gin.Context) {
 	}
 
 	cop, isCopilot := provider.(*copilot.GitHubCopilotProvider)
-	cdxProv, isCodex := provider.(*codexpkg.CodexProvider)
 
-	// Codex: same GitHub OAuth device-code flow as Copilot.
-	if isCodex {
-		if req.Method == "oauth" || (req.GithubToken == "" && req.Token == "" && req.APIKey == "") {
-			deviceCode, err := cdxProv.InitiateDeviceCodeFlow()
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"success": false,
-					"message": fmt.Sprintf("Failed to initiate Codex OAuth: %v", err),
-				})
-				return
-			}
-
-			codexCtx, codexCancel := context.WithCancel(context.Background())
-			activeAuthFlowMu.Lock()
-			activeAuthFlow = &authFlowState{
-				ProviderID:     providerID,
-				Status:         "awaiting_user",
-				InstructionURL: deviceCode.VerificationURI,
-				UserCode:       deviceCode.UserCode,
-				deviceCode:     deviceCode.DeviceCode,
-				cancelFn:       codexCancel,
-			}
-			activeAuthFlowMu.Unlock()
-
-			dc := deviceCode
-			prov := cdxProv
-			go func() {
-				defer codexCancel()
-				if err := prov.PollAndCompleteDeviceCodeFlow(dc); err != nil {
-					if codexCtx.Err() != nil {
-						return
-					}
-					activeAuthFlowMu.Lock()
-					if activeAuthFlow != nil && activeAuthFlow.ProviderID == providerID {
-						activeAuthFlow.Status = "error"
-						activeAuthFlow.Error = err.Error()
-					}
-					activeAuthFlowMu.Unlock()
-					return
-				}
-				if err := prov.SaveToDB(); err != nil {
-					log.Error().Err(err).Str("provider", providerID).Msg("Codex: failed to save token")
-				}
-				if err := providerRegistry.Register(prov, true); err != nil {
-					log.Warn().Err(err).Str("provider", providerID).Msg("Codex: failed to update provider in registry")
-				}
-				activeAuthFlowMu.Lock()
-				if activeAuthFlow != nil && activeAuthFlow.ProviderID == providerID {
-					activeAuthFlow.Status = "complete"
-				}
-				activeAuthFlowMu.Unlock()
-			}()
-
-			c.JSON(http.StatusOK, gin.H{
-				"success":          false,
-				"requiresAuth":     true,
-				"user_code":        deviceCode.UserCode,
-				"verification_uri": deviceCode.VerificationURI,
-				"message":          fmt.Sprintf("Visit %s and enter code: %s", deviceCode.VerificationURI, deviceCode.UserCode),
+	// Codex: API-key auth only.
+	if _, isCodex := provider.(*codexpkg.CodexProvider); isCodex {
+		if strings.TrimSpace(req.APIKey) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"success": false,
+				"message": "apiKey is required for Codex authentication",
 			})
 			return
 		}
-		// Direct token path for Codex.
-		token := req.Token
-		if token == "" {
-			token = req.GithubToken
-		}
-		if token == "" {
-			token = req.APIKey
-		}
-		req.GithubToken = token
 	}
 
 	// Alibaba: API-key only — OAuth is not supported.


### PR DESCRIPTION
## Summary
- add the Codex provider to the admin UI and backend provider registry flow
- support Codex authentication with an OpenAI API key and persist credentials for reuse
- polish related provider UX, including hiding empty provider groups and embedding the admin demo video in the README

## Test plan
- [x] `go build ./...`
- [ ] Add a Codex provider from the admin UI using a valid OpenAI API key
- [ ] Re-authenticate an existing Codex provider and verify requests succeed
- [ ] Confirm empty provider groups stay hidden in the providers list