### PR TITLE
Fix antigravity OAuth: COOP header + callback behind auth middleware

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -464,6 +464,16 @@ export const startAntigravityOAuth = (
     },
   )
 
+export const pollAntigravityOAuthStatus = (providerId: string) =>
+  apiFetch<{
+    done: boolean
+    error?: string
+    provider_id?: string
+    is_new?: boolean
+  }>(
+    `/api/admin/providers/antigravity/oauth-status?provider_id=${encodeURIComponent(providerId)}`,
+  )
+
 // ─── Status / Auth flow ───────────────────────────────────────────────────────
 
 export const getStatus = () => apiFetch<Status>("/api/admin/status")

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -445,6 +445,25 @@ export const updateProviderConfig = (id: string, config: Record<string, any>) =>
     { method: "PUT", body: JSON.stringify(config) },
   )
 
+// ─── Antigravity Google OAuth ─────────────────────────────────────────────────
+
+export const startAntigravityOAuth = (
+  clientId: string,
+  clientSecret: string,
+  providerId?: string,
+) =>
+  apiFetch<{ auth_url: string; state: string; provider_id: string }>(
+    "/api/admin/providers/antigravity/start-oauth",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        provider_id: providerId ?? "",
+      }),
+    },
+  )
+
 // ─── Status / Auth flow ───────────────────────────────────────────────────────
 
 export const getStatus = () => apiFetch<Status>("/api/admin/status")

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -18,6 +18,7 @@ import {
   toggleProviderModel,
   getProviderPriorities,
   setProviderPriorities,
+  startAntigravityOAuth,
   updateProviderConfig,
   refreshProviderModels,
   type AuthFlow,
@@ -536,25 +537,94 @@ function CodexAuthForm({
   )
 }
 
+function useAntigravityOAuth(
+  providerId: string | undefined,
+  onSuccess: () => void,
+  onError: (msg: string) => void,
+) {
+  const startOAuth = async (clientId: string, clientSecret: string) => {
+    const resp = await startAntigravityOAuth(clientId, clientSecret, providerId)
+    const popup = window.open(
+      resp.auth_url,
+      "antigravity_oauth",
+      "width=600,height=700,scrollbars=yes",
+    )
+    if (!popup) {
+      onError("Popup blocked — please allow popups for this page and try again")
+      return
+    }
+    const handleMessage = (event: MessageEvent) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data = event.data as Record<string, any>
+      if (data?.type === "antigravity_oauth_complete") {
+        window.removeEventListener("message", handleMessage)
+        popup.close()
+        onSuccess()
+      } else if (data?.type === "antigravity_oauth_error") {
+        window.removeEventListener("message", handleMessage)
+        popup.close()
+        onError(data.error as string)
+      }
+    }
+    window.addEventListener("message", handleMessage)
+    // Safety cleanup if popup is closed without completing
+    const timer = setInterval(() => {
+      if (popup.closed) {
+        clearInterval(timer)
+        window.removeEventListener("message", handleMessage)
+      }
+    }, 500)
+  }
+  return { startOAuth }
+}
+
 function AntigravityAuthForm({
-  onSubmit,
+  provider,
+  onSuccess,
   onCancel,
 }: {
-  onSubmit: (body: Record<string, string>) => Promise<void>
+  provider: Provider
+  onSuccess: () => void
   onCancel: () => void
 }) {
   const [clientId, setClientId] = useState("")
   const [clientSecret, setClientSecret] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const { startOAuth } = useAntigravityOAuth(
+    provider.id,
+    () => {
+      setLoading(false)
+      onSuccess()
+    },
+    (msg) => {
+      setLoading(false)
+      setError(msg)
+    },
+  )
+
   const submit = async () => {
     if (!clientId.trim() || !clientSecret.trim()) return
-    await onSubmit({
-      method: "oauth",
-      clientId: clientId.trim(),
-      clientSecret: clientSecret.trim(),
-    })
+    setLoading(true)
+    setError(null)
+    try {
+      await startOAuth(clientId.trim(), clientSecret.trim())
+    } catch (e) {
+      setLoading(false)
+      setError(e instanceof Error ? e.message : String(e))
+    }
   }
+
   return (
     <AuthFormWrapper title="Authenticate Antigravity (Google)">
+      {error && (
+        <div
+          style={{ fontSize: 12, color: "var(--color-error)", marginBottom: 8 }}
+        >
+          {error}
+        </div>
+      )}
       <FormRow label="OAuth Client ID">
         <input
           className="sys-input"
@@ -573,13 +643,25 @@ function AntigravityAuthForm({
         />
       </FormRow>
       <div style={{ fontSize: 12, color: "var(--color-text-tertiary)" }}>
-        Opens a Google OAuth browser flow once submitted.
+        Opens a Google OAuth browser popup to complete authentication.
       </div>
       <div style={{ display: "flex", gap: 8 }}>
-        <button className="btn btn-primary btn-sm" onClick={submit}>
-          Start OAuth
+        <button
+          className="btn btn-primary btn-sm"
+          onClick={submit}
+          disabled={loading}
+        >
+          {loading ?
+            <>
+              <Spin size={13} /> Waiting…
+            </>
+          : "Start OAuth →"}
         </button>
-        <button className="btn btn-ghost btn-sm" onClick={onCancel}>
+        <button
+          className="btn btn-ghost btn-sm"
+          onClick={onCancel}
+          disabled={loading}
+        >
           Cancel
         </button>
       </div>
@@ -2698,7 +2780,11 @@ function ProviderCard({
           )}
           {provider.type === "antigravity" && (
             <AntigravityAuthForm
-              onSubmit={handleAuthSubmit}
+              provider={provider}
+              onSuccess={() => {
+                setShowAuthForm(false)
+                onModelsChanged?.()
+              }}
               onCancel={() => setShowAuthForm(false)}
             />
           )}
@@ -3031,7 +3117,13 @@ function AddProviderFlow({
           )}
           {selectedType === "codex" && <AddFlowCodexForm {...authFormProps} />}
           {selectedType === "antigravity" && (
-            <AddFlowAntigravityForm {...authFormProps} />
+            <AddFlowAntigravityForm
+              onSuccess={() => {
+                setStep("select")
+                onDone?.()
+              }}
+              onCancel={() => setStep("select")}
+            />
           )}
           {selectedType === "azure-openai" && (
             <AddFlowAzureForm {...authFormProps} />
@@ -3407,22 +3499,51 @@ function AddFlowCodexForm({
 }
 
 function AddFlowAntigravityForm({
-  onSubmit,
+  onSuccess,
   onCancel,
-  submitting,
-}: AddFlowFormProps) {
+}: {
+  onSuccess: (providerId: string) => void
+  onCancel: () => void
+}) {
   const [clientId, setClientId] = useState("")
   const [clientSecret, setClientSecret] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const { startOAuth } = useAntigravityOAuth(
+    undefined,
+    () => {
+      setLoading(false)
+      // provider_id unknown here; caller will refresh the list
+      onSuccess("")
+    },
+    (msg) => {
+      setLoading(false)
+      setError(msg)
+    },
+  )
+
   const submit = async () => {
     if (!clientId.trim() || !clientSecret.trim()) return
-    await onSubmit({
-      method: "oauth",
-      clientId: clientId.trim(),
-      clientSecret: clientSecret.trim(),
-    })
+    setLoading(true)
+    setError(null)
+    try {
+      await startOAuth(clientId.trim(), clientSecret.trim())
+    } catch (e) {
+      setLoading(false)
+      setError(e instanceof Error ? e.message : String(e))
+    }
   }
+
   return (
     <div style={addFlowPanelStyle}>
+      {error && (
+        <div
+          style={{ fontSize: 12, color: "var(--color-error)", marginBottom: 8 }}
+        >
+          {error}
+        </div>
+      )}
       <FormRow label="OAuth Client ID">
         <input
           type="text"
@@ -3442,25 +3563,23 @@ function AddFlowAntigravityForm({
           autoComplete="off"
         />
       </FormRow>
-      <AddFlowHint>
-        Opens a Google OAuth browser flow once submitted.
-      </AddFlowHint>
+      <AddFlowHint>Opens a Google OAuth popup to complete sign-in.</AddFlowHint>
       <div style={{ display: "flex", gap: 8 }}>
         <button
           className="btn btn-primary btn-sm"
           onClick={submit}
-          disabled={submitting}
+          disabled={loading}
         >
-          {submitting ?
+          {loading ?
             <>
-              <Spin size={13} /> Connecting…
+              <Spin size={13} /> Waiting…
             </>
           : "Start OAuth →"}
         </button>
         <button
           className="btn btn-ghost btn-sm"
           onClick={onCancel}
-          disabled={submitting}
+          disabled={loading}
         >
           Cancel
         </button>

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -19,6 +19,7 @@ import {
   getProviderPriorities,
   setProviderPriorities,
   startAntigravityOAuth,
+  pollAntigravityOAuthStatus,
   updateProviderConfig,
   refreshProviderModels,
   type AuthFlow,
@@ -544,36 +545,37 @@ function useAntigravityOAuth(
 ) {
   const startOAuth = async (clientId: string, clientSecret: string) => {
     const resp = await startAntigravityOAuth(clientId, clientSecret, providerId)
-    const popup = window.open(
-      resp.auth_url,
-      "antigravity_oauth",
-      "width=600,height=700,scrollbars=yes",
-    )
-    if (!popup) {
-      onError("Popup blocked — please allow popups for this page and try again")
+    const tab = window.open(resp.auth_url, "_blank")
+    if (!tab) {
+      onError(
+        "Could not open a new tab — please allow popups for this page and try again",
+      )
       return
     }
-    const handleMessage = (event: MessageEvent) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const data = event.data as Record<string, any>
-      if (data?.type === "antigravity_oauth_complete") {
-        window.removeEventListener("message", handleMessage)
-        popup.close()
-        onSuccess()
-      } else if (data?.type === "antigravity_oauth_error") {
-        window.removeEventListener("message", handleMessage)
-        popup.close()
-        onError(data.error as string)
-      }
-    }
-    window.addEventListener("message", handleMessage)
-    // Safety cleanup if popup is closed without completing
-    const timer = setInterval(() => {
-      if (popup.closed) {
+
+    // Poll the backend for completion instead of relying on window.opener/postMessage,
+    // which is severed by Google's Cross-Origin-Opener-Policy header.
+    const timer = setInterval(async () => {
+      try {
+        const status = await pollAntigravityOAuthStatus(resp.provider_id)
+        if (!status.done) return
         clearInterval(timer)
-        window.removeEventListener("message", handleMessage)
+        if (status.error) {
+          onError(status.error)
+        } else {
+          onSuccess()
+        }
+      } catch {
+        // ignore transient fetch errors while polling
       }
-    }, 500)
+      // Also stop polling if the user closed the tab without completing
+      if (tab.closed) {
+        clearInterval(timer)
+      }
+    }, 1500)
+
+    // Safety: stop polling after 10 minutes regardless
+    setTimeout(() => clearInterval(timer), 10 * 60 * 1000)
   }
   return { startOAuth }
 }

--- a/internal/providers/antigravity/oauth.go
+++ b/internal/providers/antigravity/oauth.go
@@ -17,6 +17,11 @@ const (
 
 	// Scopes required to call the Antigravity (Cloud Code) API.
 	OAuthScopes = "https://www.googleapis.com/auth/cloud-platform openid email"
+
+	// Production Cloud Code endpoint (use daily sandbox only for testing).
+	ProductionBaseURL = "https://cloudcode-pa.googleapis.com"
+	// DefaultProjectID is used as a fallback when project discovery fails.
+	DefaultProjectID = "rising-fact-p41fc"
 )
 
 // OAuthTokenResponse holds the payload returned by Google's token endpoint.
@@ -113,4 +118,66 @@ func RefreshAccessToken(clientID, clientSecret, refreshToken string) (*OAuthToke
 		return nil, fmt.Errorf("antigravity: no access_token in refresh response: %s", string(body))
 	}
 	return &t, nil
+}
+
+// DiscoverProject calls the Cloud Code loadCodeAssist endpoint to find or
+// provision a project ID for the authenticated user. Falls back to
+// DefaultProjectID if the endpoint is unreachable or returns no project.
+func DiscoverProject(accessToken string) string {
+	type loadPayload struct {
+		Metadata struct {
+			IdeType    string `json:"ideType"`
+			Platform   string `json:"platform"`
+			PluginType string `json:"pluginType"`
+		} `json:"metadata"`
+	}
+	type loadResponse struct {
+		CloudaicompanionProject interface{} `json:"cloudaicompanionProject"`
+	}
+
+	reqBody, _ := json.Marshal(loadPayload{})
+	endpoints := []string{
+		"https://cloudcode-pa.googleapis.com",
+		"https://daily-cloudcode-pa.sandbox.googleapis.com",
+	}
+
+	for _, base := range endpoints {
+		req, err := http.NewRequest("POST", base+"/v1internal:loadCodeAssist", bytes.NewBuffer(reqBody))
+		if err != nil {
+			continue
+		}
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", "google-api-nodejs-client/9.15.1")
+		req.Header.Set("X-Goog-Api-Client", "google-cloud-sdk vscode_cloudshelleditor/0.1")
+
+		resp, err := oauthHTTPClient.Do(req)
+		if err != nil {
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			continue
+		}
+
+		var result loadResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			continue
+		}
+
+		switch v := result.CloudaicompanionProject.(type) {
+		case string:
+			if v != "" {
+				return v
+			}
+		case map[string]interface{}:
+			if id, ok := v["id"].(string); ok && id != "" {
+				return id
+			}
+		}
+	}
+
+	return DefaultProjectID
 }

--- a/internal/providers/antigravity/oauth.go
+++ b/internal/providers/antigravity/oauth.go
@@ -1,0 +1,116 @@
+// Package antigravity — Google OAuth2 authorization-code helpers.
+package antigravity
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	googleAuthURL  = "https://accounts.google.com/o/oauth2/v2/auth"
+	googleTokenURL = "https://oauth2.googleapis.com/token"
+
+	// Scopes required to call the Antigravity (Cloud Code) API.
+	OAuthScopes = "https://www.googleapis.com/auth/cloud-platform openid email"
+)
+
+// OAuthTokenResponse holds the payload returned by Google's token endpoint.
+type OAuthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+	IDToken      string `json:"id_token,omitempty"`
+	Error        string `json:"error,omitempty"`
+	ErrorDesc    string `json:"error_description,omitempty"`
+}
+
+var oauthHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+// BuildAuthURL returns the Google OAuth2 authorization URL that the user
+// should visit to grant access.
+func BuildAuthURL(clientID, redirectURI, state string) string {
+	v := url.Values{}
+	v.Set("client_id", clientID)
+	v.Set("redirect_uri", redirectURI)
+	v.Set("response_type", "code")
+	v.Set("scope", OAuthScopes)
+	v.Set("access_type", "offline")
+	v.Set("prompt", "consent") // force refresh token to be returned
+	v.Set("state", state)
+	return googleAuthURL + "?" + v.Encode()
+}
+
+// ExchangeCode exchanges an authorization code for access + refresh tokens.
+func ExchangeCode(clientID, clientSecret, code, redirectURI string) (*OAuthTokenResponse, error) {
+	data := url.Values{}
+	data.Set("code", code)
+	data.Set("client_id", clientID)
+	data.Set("client_secret", clientSecret)
+	data.Set("redirect_uri", redirectURI)
+	data.Set("grant_type", "authorization_code")
+
+	req, err := http.NewRequest("POST", googleTokenURL, bytes.NewBufferString(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("antigravity: failed to build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("antigravity: token exchange request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	var t OAuthTokenResponse
+	if err := json.Unmarshal(body, &t); err != nil {
+		return nil, fmt.Errorf("antigravity: failed to parse token response: %w", err)
+	}
+	if t.Error != "" {
+		return nil, fmt.Errorf("antigravity: token exchange failed: %s — %s", t.Error, t.ErrorDesc)
+	}
+	if t.AccessToken == "" {
+		return nil, fmt.Errorf("antigravity: no access_token in response: %s", string(body))
+	}
+	return &t, nil
+}
+
+// RefreshAccessToken exchanges a refresh token for a new access token.
+func RefreshAccessToken(clientID, clientSecret, refreshToken string) (*OAuthTokenResponse, error) {
+	data := url.Values{}
+	data.Set("client_id", clientID)
+	data.Set("client_secret", clientSecret)
+	data.Set("refresh_token", refreshToken)
+	data.Set("grant_type", "refresh_token")
+
+	req, err := http.NewRequest("POST", googleTokenURL, bytes.NewBufferString(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("antigravity: failed to build refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("antigravity: refresh request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	var t OAuthTokenResponse
+	if err := json.Unmarshal(body, &t); err != nil {
+		return nil, fmt.Errorf("antigravity: failed to parse refresh response: %w", err)
+	}
+	if t.Error != "" {
+		return nil, fmt.Errorf("antigravity: token refresh failed: %s — %s", t.Error, t.ErrorDesc)
+	}
+	if t.AccessToken == "" {
+		return nil, fmt.Errorf("antigravity: no access_token in refresh response: %s", string(body))
+	}
+	return &t, nil
+}

--- a/internal/providers/antigravity/provider.go
+++ b/internal/providers/antigravity/provider.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const defaultBaseURL = "https://daily-cloudcode-pa.googleapis.com"
+const defaultBaseURL = ProductionBaseURL
 
 // Shared HTTP client for Antigravity (only used for streaming).
 var antigravityStreamClient = &http.Client{
@@ -98,7 +98,9 @@ func Stream(ctx context.Context, token, baseURL, projectID string, request *cif.
 		for _, tool := range request.Tools {
 			decl := map[string]interface{}{
 				"name":       tool.Name,
-				"parameters": shared.SanitizeGeminiSchema(tool.ParametersSchema),
+			}
+			if params := shared.SanitizeGeminiSchema(tool.ParametersSchema); params != nil {
+				decl["parameters"] = params
 			}
 			if tool.Description != nil {
 				decl["description"] = *tool.Description

--- a/internal/providers/antigravity/provider_test.go
+++ b/internal/providers/antigravity/provider_test.go
@@ -3,6 +3,9 @@ package antigravity
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"omnillm/internal/cif"
 	"strings"
 	"testing"
@@ -45,6 +48,71 @@ func TestGetModels(t *testing.T) {
 		if m.Provider != "antigravity-1" {
 			t.Errorf("model %q has provider %q, want antigravity-1", m.ID, m.Provider)
 		}
+	}
+}
+
+func TestStreamBuildsConservativeGeminiPayload(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	maxTokens := 128
+	request := &cif.CanonicalRequest{
+		Model:    "claude-sonnet-4-6",
+		Messages: []cif.CIFMessage{cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "ping"}}}},
+		MaxTokens: &maxTokens,
+		Tools: []cif.CIFTool{{
+			Name: "Read",
+		}},
+	}
+
+	ch, err := Stream(t.Context(), "token", server.URL, "", request)
+	if err != nil {
+		t.Fatalf("Stream returned error: %v", err)
+	}
+	for range ch {
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(gotBody, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	requestMap, ok := payload["request"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("missing request envelope: %#v", payload)
+	}
+	if _, ok := requestMap["generationConfig"].(map[string]interface{}); !ok {
+		t.Fatalf("missing generationConfig: %#v", requestMap)
+	}
+	tools, ok := requestMap["tools"].([]interface{})
+	if !ok || len(tools) != 1 {
+		t.Fatalf("unexpected tools payload: %#v", requestMap["tools"])
+	}
+	toolGroup, ok := tools[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("unexpected tool group: %#v", tools[0])
+	}
+	decls, ok := toolGroup["functionDeclarations"].([]interface{})
+	if !ok || len(decls) != 1 {
+		t.Fatalf("unexpected functionDeclarations: %#v", toolGroup["functionDeclarations"])
+	}
+	decl, ok := decls[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("unexpected declaration: %#v", decls[0])
+	}
+	if _, ok := decl["parameters"]; ok {
+		t.Fatal("expected nil tool schema to omit parameters field")
+	}
+	if decl["name"] != "Read" {
+		t.Fatalf("unexpected tool name: %#v", decl["name"])
 	}
 }
 

--- a/internal/providers/generic/generic.go
+++ b/internal/providers/generic/generic.go
@@ -50,7 +50,7 @@ var providerModels = map[string][]types.Model{
 }
 
 var providerBaseURLs = map[string]string{
-	"antigravity":  "https://daily-cloudcode-pa.googleapis.com",
+	"antigravity":  antigravitypkg.ProductionBaseURL,
 	"alibaba":      "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
 	"azure-openai": "",
 	"kimi":         "https://api.moonshot.cn/v1",

--- a/internal/providers/generic/generic.go
+++ b/internal/providers/generic/generic.go
@@ -206,6 +206,11 @@ func (p *GenericProvider) InitiateGoogleDeviceCode() (verificationURL, userCode,
 	}
 
 	// Google device authorization endpoint.
+	log.Info().
+		Str("provider", p.instanceID).
+		Bool("has_client_id", clientID != "").
+		Bool("has_client_secret", clientSecret != "").
+		Msg("Antigravity: requesting Google device code")
 	data := url.Values{}
 	data.Set("client_id", clientID)
 	data.Set("scope", "https://www.googleapis.com/auth/cloud-platform openid email")
@@ -233,11 +238,19 @@ func (p *GenericProvider) InitiateGoogleDeviceCode() (verificationURL, userCode,
 		DeviceCode      string `json:"device_code"`
 		UserCode        string `json:"user_code"`
 		VerificationURL string `json:"verification_url"`
+		VerificationURI string `json:"verification_uri"`
 		ExpiresIn       int    `json:"expires_in"`
 		Interval        int    `json:"interval"`
 	}
 	if jsonErr := json.Unmarshal(body, &dc); jsonErr != nil {
 		return "", "", "", 0, fmt.Errorf("antigravity: failed to parse device-code response: %w", jsonErr)
+	}
+	verificationURL = dc.VerificationURL
+	if verificationURL == "" {
+		verificationURL = dc.VerificationURI
+	}
+	if dc.DeviceCode == "" || dc.UserCode == "" || verificationURL == "" {
+		return "", "", "", 0, fmt.Errorf("antigravity: incomplete device-code response: %s", string(body))
 	}
 
 	log.Info().Str("provider", p.instanceID).Str("user_code", dc.UserCode).Msg("Antigravity: Google device-code flow initiated")
@@ -245,7 +258,7 @@ func (p *GenericProvider) InitiateGoogleDeviceCode() (verificationURL, userCode,
 	if interval == 0 {
 		interval = 5
 	}
-	return dc.VerificationURL, dc.UserCode, dc.DeviceCode, interval, nil
+	return verificationURL, dc.UserCode, dc.DeviceCode, interval, nil
 }
 
 // PollGoogleDeviceCode polls Google's token endpoint until the user completes
@@ -662,6 +675,14 @@ func (p *GenericProvider) LoadFromDB() error {
 
 	log.Debug().Str("provider", p.instanceID).Bool("has_token", p.token != "").Msg("Loaded generic provider token")
 	return nil
+}
+
+// ApplyTokenFromDB reloads the saved token from the database into the
+// in-memory provider. It is the public equivalent of LoadFromDB and is
+// called by route handlers after saving a new token (e.g. after an OAuth
+// callback) to ensure the provider is immediately usable without a restart.
+func (p *GenericProvider) ApplyTokenFromDB() {
+	_ = p.LoadFromDB()
 }
 
 // ─── GenericAdapter ───────────────────────────────────────────────────────────

--- a/internal/providers/generic/generic.go
+++ b/internal/providers/generic/generic.go
@@ -127,6 +127,8 @@ func (p *GenericProvider) SetupAuth(options *types.AuthOptions) error {
 	switch p.id {
 	case "alibaba":
 		return p.setupAlibabaAuth(options)
+	case "antigravity":
+		return p.setupAntigravityAuth(options)
 	case "azure-openai":
 		return p.setupAzureAuth(options)
 	case "google":
@@ -153,6 +155,169 @@ func (p *GenericProvider) setupAlibabaAuth(options *types.AuthOptions) error {
 
 	default:
 		return fmt.Errorf("alibaba: unsupported auth method: %s (only api-key is supported)", options.Method)
+	}
+}
+
+// setupAntigravityAuth stores Google OAuth client credentials and initiates a
+// Google device-code flow. The access token is obtained asynchronously; the
+// route handler is responsible for polling and completing the flow.
+func (p *GenericProvider) setupAntigravityAuth(options *types.AuthOptions) error {
+	clientID := strings.TrimSpace(options.ClientID)
+	clientSecret := strings.TrimSpace(options.ClientSecret)
+	if clientID == "" || clientSecret == "" {
+		return fmt.Errorf("antigravity: OAuth client_id and client_secret are required")
+	}
+
+	// Persist the credentials so the device-code poll goroutine can retrieve them.
+	tokenStore := database.NewTokenStore()
+	tokenData := map[string]interface{}{
+		"client_id":     clientID,
+		"client_secret": clientSecret,
+	}
+	if err := tokenStore.Save(p.instanceID, "antigravity", tokenData); err != nil {
+		return fmt.Errorf("antigravity: failed to save client credentials: %w", err)
+	}
+
+	p.baseURL = providerBaseURLs["antigravity"]
+	suffix := shared.ShortTokenSuffix(clientID)
+	p.name = "Antigravity (" + suffix + ")"
+
+	log.Info().Str("provider", p.instanceID).Msg("Antigravity: client credentials saved, device-code flow will be initiated")
+	return nil
+}
+
+// InitiateGoogleDeviceCode starts Google's OAuth2 device-code flow for Antigravity.
+// Returns the verification URL and user code so the frontend can show them to the user.
+func (p *GenericProvider) InitiateGoogleDeviceCode() (verificationURL, userCode, deviceCode string, interval int, err error) {
+	// Load credentials from DB.
+	tokenStore := database.NewTokenStore()
+	record, dbErr := tokenStore.Get(p.instanceID)
+	if dbErr != nil || record == nil {
+		return "", "", "", 0, fmt.Errorf("antigravity: client credentials not found — set them first")
+	}
+	var saved map[string]interface{}
+	if jsonErr := json.Unmarshal([]byte(record.TokenData), &saved); jsonErr != nil {
+		return "", "", "", 0, fmt.Errorf("antigravity: failed to read saved credentials: %w", jsonErr)
+	}
+	clientID, _ := saved["client_id"].(string)
+	clientSecret, _ := saved["client_secret"].(string)
+	if clientID == "" || clientSecret == "" {
+		return "", "", "", 0, fmt.Errorf("antigravity: client_id/client_secret not set")
+	}
+
+	// Google device authorization endpoint.
+	data := url.Values{}
+	data.Set("client_id", clientID)
+	data.Set("scope", "https://www.googleapis.com/auth/cloud-platform openid email")
+
+	req, reqErr := http.NewRequest("POST", "https://oauth2.googleapis.com/device/code",
+		bytes.NewBufferString(data.Encode()))
+	if reqErr != nil {
+		return "", "", "", 0, fmt.Errorf("antigravity: failed to build device-code request: %w", reqErr)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, respErr := client.Do(req)
+	if respErr != nil {
+		return "", "", "", 0, fmt.Errorf("antigravity: device-code request failed: %w", respErr)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", "", 0, fmt.Errorf("antigravity: device-code endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var dc struct {
+		DeviceCode      string `json:"device_code"`
+		UserCode        string `json:"user_code"`
+		VerificationURL string `json:"verification_url"`
+		ExpiresIn       int    `json:"expires_in"`
+		Interval        int    `json:"interval"`
+	}
+	if jsonErr := json.Unmarshal(body, &dc); jsonErr != nil {
+		return "", "", "", 0, fmt.Errorf("antigravity: failed to parse device-code response: %w", jsonErr)
+	}
+
+	log.Info().Str("provider", p.instanceID).Str("user_code", dc.UserCode).Msg("Antigravity: Google device-code flow initiated")
+	interval = dc.Interval
+	if interval == 0 {
+		interval = 5
+	}
+	return dc.VerificationURL, dc.UserCode, dc.DeviceCode, interval, nil
+}
+
+// PollGoogleDeviceCode polls Google's token endpoint until the user completes
+// authorization, then stores the access and refresh tokens.
+func (p *GenericProvider) PollGoogleDeviceCode(deviceCode string) error {
+	tokenStore := database.NewTokenStore()
+	record, dbErr := tokenStore.Get(p.instanceID)
+	if dbErr != nil || record == nil {
+		return fmt.Errorf("antigravity: client credentials not found")
+	}
+	var saved map[string]interface{}
+	if jsonErr := json.Unmarshal([]byte(record.TokenData), &saved); jsonErr != nil {
+		return fmt.Errorf("antigravity: failed to read saved credentials: %w", jsonErr)
+	}
+	clientID, _ := saved["client_id"].(string)
+	clientSecret, _ := saved["client_secret"].(string)
+
+	tokenURL := "https://oauth2.googleapis.com/token"
+	for {
+		data := url.Values{}
+		data.Set("client_id", clientID)
+		data.Set("client_secret", clientSecret)
+		data.Set("device_code", deviceCode)
+		data.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+
+		req, _ := http.NewRequest("POST", tokenURL, bytes.NewBufferString(data.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		client := &http.Client{Timeout: 30 * time.Second}
+		resp, respErr := client.Do(req)
+		if respErr != nil {
+			return fmt.Errorf("antigravity: token poll failed: %w", respErr)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		var tokenResp struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+			ExpiresIn    int64  `json:"expires_in"`
+			Error        string `json:"error"`
+		}
+		if jsonErr := json.Unmarshal(body, &tokenResp); jsonErr != nil {
+			return fmt.Errorf("antigravity: failed to parse token response: %w", jsonErr)
+		}
+
+		switch tokenResp.Error {
+		case "":
+			if tokenResp.AccessToken == "" {
+				return fmt.Errorf("antigravity: no access_token in response")
+			}
+			p.token = tokenResp.AccessToken
+			// Persist the final tokens alongside the credentials.
+			saved["access_token"] = tokenResp.AccessToken
+			if tokenResp.RefreshToken != "" {
+				saved["refresh_token"] = tokenResp.RefreshToken
+			}
+			if err := tokenStore.Save(p.instanceID, "antigravity", saved); err != nil {
+				return fmt.Errorf("antigravity: failed to save token: %w", err)
+			}
+			log.Info().Str("provider", p.instanceID).Msg("Antigravity: Google OAuth completed")
+			return nil
+		case "authorization_pending", "slow_down":
+			time.Sleep(5 * time.Second)
+			continue
+		case "expired_token":
+			return fmt.Errorf("antigravity: device code expired — please restart authentication")
+		case "access_denied":
+			return fmt.Errorf("antigravity: access denied by user")
+		default:
+			return fmt.Errorf("antigravity: token error: %s — %s", tokenResp.Error, string(body))
+		}
 	}
 }
 

--- a/internal/providers/types/types.go
+++ b/internal/providers/types/types.go
@@ -3,6 +3,7 @@ package types
 
 import (
 	"context"
+	"encoding/json"
 	"omnillm/internal/cif"
 )
 
@@ -19,6 +20,9 @@ const (
 	ProviderOpenAICompatible ProviderID = "openai-compatible"
 )
 
+// AuthOptions is decoded from JSON request bodies.  Fields accept both
+// camelCase (frontend convention) and snake_case (legacy) names via a custom
+// UnmarshalJSON that normalises keys before decoding.
 type AuthOptions struct {
 	Method              string `json:"method,omitempty"`
 	Force               bool   `json:"force,omitempty"`
@@ -36,6 +40,38 @@ type AuthOptions struct {
 	APIVersion          string `json:"apiVersion,omitempty"`  // e.g. "2024-02-01", used by azure-openai
 	AllowLocalEndpoints bool   `json:"allowLocalEndpoints,omitempty"`
 	OAuthProvider       string `json:"oauthProvider,omitempty"` // "github" (default) or "google" for Codex
+}
+
+// UnmarshalJSON normalises camelCase aliases sent by the frontend before
+// decoding into AuthOptions.
+func (a *AuthOptions) UnmarshalJSON(data []byte) error {
+	// Decode into a raw map first so we can rename keys.
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	// camelCase → snake_case / canonical aliases.
+	aliases := map[string]string{
+		"clientId":     "client_id",
+		"clientSecret": "client_secret",
+		"githubToken":  "github_token",
+	}
+	for camel, canonical := range aliases {
+		if v, ok := raw[camel]; ok {
+			if _, exists := raw[canonical]; !exists {
+				raw[canonical] = v
+			}
+			delete(raw, camel)
+		}
+	}
+	// Re-encode the normalised map and decode into a plain alias type to
+	// avoid infinite recursion.
+	type plain AuthOptions
+	normalised, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(normalised, (*plain)(a))
 }
 
 type Model struct {

--- a/internal/routes/admin.go
+++ b/internal/routes/admin.go
@@ -151,6 +151,10 @@ func SetupAdminRoutes(router *gin.RouterGroup, port int) {
 	router.POST("/providers/add/:type", handleAddProviderInstance)
 	router.POST("/providers/auth-and-create/:type", handleAuthAndCreateProvider)
 
+	// Antigravity Google OAuth2 authorization-code flow
+	router.POST("/providers/antigravity/start-oauth", handleAntigravityStartOAuth)
+	router.GET("/providers/antigravity/oauth-callback", handleAntigravityOAuthCallback)
+
 	// System info and status
 	router.GET("/status", handleGetStatus)
 	router.GET("/auth-status", handleGetAuthStatus)
@@ -940,82 +944,14 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 			},
 		})
 
-	// ── Antigravity (Google OAuth device-code flow) ──────────────────────────
+	// ── Antigravity — delegates to the authorization-code OAuth flow ─────────
 	case "antigravity":
-		canonicalID := providerRegistry.NextInstanceID("antigravity")
-		gen := generic.NewGenericProvider("antigravity", canonicalID, "")
-
-		// Save client credentials and prepare for device-code flow.
-		if err := gen.SetupAuth(&req); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"success": false,
-				"message": fmt.Sprintf("Failed to save Antigravity credentials: %v", err),
-			})
-			return
-		}
-
-		// Initiate Google device-code flow.
-		verificationURL, userCode, deviceCode, interval, err := gen.InitiateGoogleDeviceCode()
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"success": false,
-				"message": fmt.Sprintf("Failed to initiate Google OAuth: %v", err),
-			})
-			return
-		}
-
-		const pendingID = "antigravity-pending"
-		agCtx, agCancel := context.WithCancel(context.Background())
-		activeAuthFlowMu.Lock()
-		activeAuthFlow = &authFlowState{
-			ProviderID:     pendingID,
-			Status:         "awaiting_user",
-			InstructionURL: verificationURL,
-			UserCode:       userCode,
-			deviceCode:     deviceCode,
-			cancelFn:       agCancel,
-		}
-		activeAuthFlowMu.Unlock()
-
-		_ = interval
-		go func() {
-			defer agCancel()
-			if err := gen.PollGoogleDeviceCode(deviceCode); err != nil {
-				if agCtx.Err() != nil {
-					return
-				}
-				activeAuthFlowMu.Lock()
-				if activeAuthFlow != nil && activeAuthFlow.ProviderID == pendingID {
-					activeAuthFlow.Status = "error"
-					activeAuthFlow.Error = err.Error()
-				}
-				activeAuthFlowMu.Unlock()
-				log.Error().Err(err).Str("type", "antigravity").Msg("Auth-and-create: Google OAuth failed")
-				return
-			}
-
-			gen.SetInstanceID(canonicalID)
-			if err := providerRegistry.Register(gen, true); err != nil {
-				log.Warn().Err(err).Str("provider", canonicalID).Msg("Auth-and-create: failed to register Antigravity provider")
-			}
-
-			activeAuthFlowMu.Lock()
-			if activeAuthFlow != nil && activeAuthFlow.ProviderID == pendingID {
-				activeAuthFlow.ProviderID = canonicalID
-				activeAuthFlow.Status = "complete"
-			}
-			activeAuthFlowMu.Unlock()
-
-			log.Info().Str("provider", canonicalID).Msg("Auth-and-create: Antigravity Google OAuth completed")
-		}()
-
-		c.JSON(http.StatusOK, gin.H{
-			"success":          false,
-			"requiresAuth":     true,
-			"pending_id":       pendingID,
-			"user_code":        userCode,
-			"verification_uri": verificationURL,
-			"message":          fmt.Sprintf("Visit %s and enter code: %s", verificationURL, userCode),
+		// The auth-and-create path is no longer used for Antigravity;
+		// the frontend calls POST /providers/antigravity/start-oauth directly.
+		// Return a clear error so any stale callers know which endpoint to use.
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"message": "Use POST /api/admin/providers/antigravity/start-oauth to begin Google OAuth",
 		})
 
 	// ── API-key based providers ────────────────────────────────────────────────

--- a/internal/routes/admin.go
+++ b/internal/routes/admin.go
@@ -940,8 +940,86 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 			},
 		})
 
+	// ── Antigravity (Google OAuth device-code flow) ──────────────────────────
+	case "antigravity":
+		canonicalID := providerRegistry.NextInstanceID("antigravity")
+		gen := generic.NewGenericProvider("antigravity", canonicalID, "")
+
+		// Save client credentials and prepare for device-code flow.
+		if err := gen.SetupAuth(&req); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"success": false,
+				"message": fmt.Sprintf("Failed to save Antigravity credentials: %v", err),
+			})
+			return
+		}
+
+		// Initiate Google device-code flow.
+		verificationURL, userCode, deviceCode, interval, err := gen.InitiateGoogleDeviceCode()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"success": false,
+				"message": fmt.Sprintf("Failed to initiate Google OAuth: %v", err),
+			})
+			return
+		}
+
+		const pendingID = "antigravity-pending"
+		agCtx, agCancel := context.WithCancel(context.Background())
+		activeAuthFlowMu.Lock()
+		activeAuthFlow = &authFlowState{
+			ProviderID:     pendingID,
+			Status:         "awaiting_user",
+			InstructionURL: verificationURL,
+			UserCode:       userCode,
+			deviceCode:     deviceCode,
+			cancelFn:       agCancel,
+		}
+		activeAuthFlowMu.Unlock()
+
+		_ = interval
+		go func() {
+			defer agCancel()
+			if err := gen.PollGoogleDeviceCode(deviceCode); err != nil {
+				if agCtx.Err() != nil {
+					return
+				}
+				activeAuthFlowMu.Lock()
+				if activeAuthFlow != nil && activeAuthFlow.ProviderID == pendingID {
+					activeAuthFlow.Status = "error"
+					activeAuthFlow.Error = err.Error()
+				}
+				activeAuthFlowMu.Unlock()
+				log.Error().Err(err).Str("type", "antigravity").Msg("Auth-and-create: Google OAuth failed")
+				return
+			}
+
+			gen.SetInstanceID(canonicalID)
+			if err := providerRegistry.Register(gen, true); err != nil {
+				log.Warn().Err(err).Str("provider", canonicalID).Msg("Auth-and-create: failed to register Antigravity provider")
+			}
+
+			activeAuthFlowMu.Lock()
+			if activeAuthFlow != nil && activeAuthFlow.ProviderID == pendingID {
+				activeAuthFlow.ProviderID = canonicalID
+				activeAuthFlow.Status = "complete"
+			}
+			activeAuthFlowMu.Unlock()
+
+			log.Info().Str("provider", canonicalID).Msg("Auth-and-create: Antigravity Google OAuth completed")
+		}()
+
+		c.JSON(http.StatusOK, gin.H{
+			"success":          false,
+			"requiresAuth":     true,
+			"pending_id":       pendingID,
+			"user_code":        userCode,
+			"verification_uri": verificationURL,
+			"message":          fmt.Sprintf("Visit %s and enter code: %s", verificationURL, userCode),
+		})
+
 	// ── API-key based providers ────────────────────────────────────────────────
-	case "azure-openai", "antigravity", "google", "kimi":
+	case "azure-openai", "google", "kimi":
 		instanceID := providerRegistry.NextInstanceID(providerType)
 		gen := generic.NewGenericProvider(providerType, instanceID, "")
 

--- a/internal/routes/admin.go
+++ b/internal/routes/admin.go
@@ -152,8 +152,8 @@ func SetupAdminRoutes(router *gin.RouterGroup, port int) {
 	router.POST("/providers/auth-and-create/:type", handleAuthAndCreateProvider)
 
 	// Antigravity Google OAuth2 authorization-code flow
+	// Note: oauth-callback and oauth-status are registered on the public group in server.go
 	router.POST("/providers/antigravity/start-oauth", handleAntigravityStartOAuth)
-	router.GET("/providers/antigravity/oauth-callback", handleAntigravityOAuthCallback)
 
 	// System info and status
 	router.GET("/status", handleGetStatus)

--- a/internal/routes/admin_antigravity_oauth.go
+++ b/internal/routes/admin_antigravity_oauth.go
@@ -168,12 +168,17 @@ func handleAntigravityOAuthCallback(c *gin.Context) {
 		return
 	}
 
-	// Persist credentials + tokens.
+	// Discover the user's Cloud Code project ID (required for API calls).
+	projectID := antigravitypkg.DiscoverProject(tokenResp.AccessToken)
+	log.Info().Str("provider", state.ProviderID).Str("project_id", projectID).Msg("Antigravity: discovered project")
+
+	// Persist credentials + tokens + project_id.
 	tokenStore := database.NewTokenStore()
 	tokenData := map[string]interface{}{
 		"access_token":  tokenResp.AccessToken,
 		"client_id":     state.ClientID,
 		"client_secret": state.ClientSecret,
+		"project_id":    projectID,
 	}
 	if tokenResp.RefreshToken != "" {
 		tokenData["refresh_token"] = tokenResp.RefreshToken

--- a/internal/routes/admin_antigravity_oauth.go
+++ b/internal/routes/admin_antigravity_oauth.go
@@ -3,7 +3,6 @@ package routes
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -28,7 +27,7 @@ type antigravityOAuthState struct {
 	RedirectURI   string
 	State         string
 	Expiry        time.Time
-	IsNewProvider bool   // true = auth-and-create, false = re-auth existing
+	IsNewProvider bool // true = auth-and-create, false = re-auth existing
 	Done          bool
 	Error         string
 }
@@ -36,7 +35,21 @@ type antigravityOAuthState struct {
 var (
 	agOAuthMu     sync.Mutex
 	agOAuthStates = map[string]*antigravityOAuthState{} // keyed by state nonce
+
+	// agOAuthResults holds completed OAuth results keyed by provider_id so the
+	// frontend can poll for completion instead of relying on window.opener
+	// (which is severed by Google's Cross-Origin-Opener-Policy header).
+	agOAuthResultsMu sync.Mutex
+	agOAuthResults   = map[string]*antigravityOAuthResult{} // keyed by provider_id
 )
+
+type antigravityOAuthResult struct {
+	Done       bool
+	Error      string
+	ProviderID string
+	IsNew      bool
+	Expiry     time.Time
+}
 
 func newAntigravityOAuthState(providerID, clientID, clientSecret, redirectURI string, isNew bool) *antigravityOAuthState {
 	b := make([]byte, 16)
@@ -120,7 +133,11 @@ func handleAntigravityStartOAuth(c *gin.Context) {
 
 // ─── Route: GET /providers/antigravity/oauth-callback ────────────────────────
 // Google redirects here with ?code=…&state=…
-// On success renders a small HTML page that closes the popup and notifies the opener.
+// This route must be public (no auth) — Google's redirect carries no Authorization header.
+
+// HandleAntigravityOAuthCallbackPublic is the exported handler for server.go to register
+// on the public router group.
+var HandleAntigravityOAuthCallbackPublic = handleAntigravityOAuthCallback
 
 func handleAntigravityOAuthCallback(c *gin.Context) {
 	code := c.Query("code")
@@ -128,17 +145,17 @@ func handleAntigravityOAuthCallback(c *gin.Context) {
 	errParam := c.Query("error")
 
 	if errParam != "" {
-		renderOAuthResult(c, false, "Google denied access: "+errParam, "")
+		renderOAuthResult(c, false, "Google denied access: "+errParam)
 		return
 	}
 	if code == "" || nonce == "" {
-		renderOAuthResult(c, false, "Missing code or state parameter", "")
+		renderOAuthResult(c, false, "Missing code or state parameter")
 		return
 	}
 
 	state := getAntigravityOAuthState(nonce)
 	if state == nil || time.Now().After(state.Expiry) {
-		renderOAuthResult(c, false, "OAuth state expired or not found — please try again", "")
+		renderOAuthResult(c, false, "OAuth state expired or not found — please try again")
 		return
 	}
 	deleteAntigravityOAuthState(nonce)
@@ -147,7 +164,7 @@ func handleAntigravityOAuthCallback(c *gin.Context) {
 	tokenResp, err := antigravitypkg.ExchangeCode(state.ClientID, state.ClientSecret, code, state.RedirectURI)
 	if err != nil {
 		log.Error().Err(err).Str("provider", state.ProviderID).Msg("Antigravity: OAuth code exchange failed")
-		renderOAuthResult(c, false, fmt.Sprintf("Token exchange failed: %v", err), "")
+		renderOAuthResult(c, false, fmt.Sprintf("Token exchange failed: %v", err))
 		return
 	}
 
@@ -163,7 +180,7 @@ func handleAntigravityOAuthCallback(c *gin.Context) {
 	}
 	if err := tokenStore.Save(state.ProviderID, "antigravity", tokenData); err != nil {
 		log.Error().Err(err).Str("provider", state.ProviderID).Msg("Antigravity: failed to save tokens")
-		renderOAuthResult(c, false, "Failed to save credentials — please try again", "")
+		renderOAuthResult(c, false, "Failed to save credentials — please try again")
 		return
 	}
 
@@ -184,41 +201,72 @@ func handleAntigravityOAuthCallback(c *gin.Context) {
 		}
 	}
 
-	// Encode minimal provider info so the opener can update the UI.
-	info, _ := json.Marshal(map[string]interface{}{
-		"id":         state.ProviderID,
-		"type":       "antigravity",
-		"name":       "Antigravity",
-		"authStatus": "authenticated",
-		"isNew":      state.IsNewProvider,
-	})
+	// Store the completed result so the frontend can poll for it.
+	agOAuthResultsMu.Lock()
+	agOAuthResults[state.ProviderID] = &antigravityOAuthResult{
+		Done:       true,
+		ProviderID: state.ProviderID,
+		IsNew:      state.IsNewProvider,
+		Expiry:     time.Now().Add(5 * time.Minute),
+	}
+	agOAuthResultsMu.Unlock()
 
 	log.Info().Str("provider", state.ProviderID).Msg("Antigravity: Google OAuth completed successfully")
-	renderOAuthResult(c, true, "", string(info))
+	renderOAuthResult(c, true, "")
 }
 
 // renderOAuthResult writes a small self-closing HTML page.
-// On success it posts a message to window.opener and closes itself.
-// On failure it shows the error and lets the user close manually.
-func renderOAuthResult(c *gin.Context, success bool, errMsg, providerJSON string) {
+// It no longer uses window.opener (severed by Google's COOP header).
+// The frontend polls /oauth-status instead.
+func renderOAuthResult(c *gin.Context, success bool, errMsg string) {
 	c.Header("Content-Type", "text/html; charset=utf-8")
 	if success {
 		c.String(http.StatusOK, `<!DOCTYPE html><html><head><title>Antigravity — Authenticated</title></head><body>
 <p>Authenticated successfully. This window will close…</p>
-<script>
-try {
-  window.opener && window.opener.postMessage({type:"antigravity_oauth_complete",provider:`+providerJSON+`},"*");
-} catch(e){}
-setTimeout(function(){ window.close(); }, 1000);
-</script></body></html>`)
+<script>setTimeout(function(){ window.close(); }, 1000);</script>
+</body></html>`)
 	} else {
 		c.String(http.StatusOK, `<!DOCTYPE html><html><head><title>Antigravity — Error</title></head><body>
 <p style="color:red">OAuth failed: `+errMsg+`</p>
 <p><button onclick="window.close()">Close</button></p>
-<script>
-try {
-  window.opener && window.opener.postMessage({type:"antigravity_oauth_error",error:`+"`"+errMsg+"`"+`},"*");
-} catch(e){}
-</script></body></html>`)
+</body></html>`)
 	}
+}
+
+// ─── Route: GET /providers/antigravity/oauth-status ──────────────────────────
+// Frontend polls this to learn when the OAuth flow completes.
+// This route must be public (no auth) — the frontend polls it before auth is established.
+// Query param: provider_id
+
+// HandleAntigravityOAuthStatusPublic is the exported handler for server.go to register
+// on the public router group.
+var HandleAntigravityOAuthStatusPublic = handleAntigravityOAuthStatus
+
+func handleAntigravityOAuthStatus(c *gin.Context) {
+	providerID := strings.TrimSpace(c.Query("provider_id"))
+	if providerID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "provider_id is required"})
+		return
+	}
+
+	agOAuthResultsMu.Lock()
+	result, ok := agOAuthResults[providerID]
+	if ok && result.Done {
+		delete(agOAuthResults, providerID) // consume once
+	}
+	agOAuthResultsMu.Unlock()
+
+	if !ok {
+		c.JSON(http.StatusOK, gin.H{"done": false})
+		return
+	}
+	if result.Error != "" {
+		c.JSON(http.StatusOK, gin.H{"done": true, "error": result.Error})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"done":        true,
+		"provider_id": result.ProviderID,
+		"is_new":      result.IsNew,
+	})
 }

--- a/internal/routes/admin_antigravity_oauth.go
+++ b/internal/routes/admin_antigravity_oauth.go
@@ -1,0 +1,224 @@
+package routes
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+
+	antigravitypkg "omnillm/internal/providers/antigravity"
+	"omnillm/internal/database"
+	"omnillm/internal/providers/generic"
+	"omnillm/internal/registry"
+)
+
+// ─── Pending OAuth state ──────────────────────────────────────────────────────
+
+type antigravityOAuthState struct {
+	ProviderID    string
+	ClientID      string
+	ClientSecret  string
+	RedirectURI   string
+	State         string
+	Expiry        time.Time
+	IsNewProvider bool   // true = auth-and-create, false = re-auth existing
+	Done          bool
+	Error         string
+}
+
+var (
+	agOAuthMu     sync.Mutex
+	agOAuthStates = map[string]*antigravityOAuthState{} // keyed by state nonce
+)
+
+func newAntigravityOAuthState(providerID, clientID, clientSecret, redirectURI string, isNew bool) *antigravityOAuthState {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	nonce := hex.EncodeToString(b)
+	s := &antigravityOAuthState{
+		ProviderID:    providerID,
+		ClientID:      clientID,
+		ClientSecret:  clientSecret,
+		RedirectURI:   redirectURI,
+		State:         nonce,
+		Expiry:        time.Now().Add(10 * time.Minute),
+		IsNewProvider: isNew,
+	}
+	agOAuthMu.Lock()
+	agOAuthStates[nonce] = s
+	agOAuthMu.Unlock()
+	return s
+}
+
+func getAntigravityOAuthState(nonce string) *antigravityOAuthState {
+	agOAuthMu.Lock()
+	defer agOAuthMu.Unlock()
+	return agOAuthStates[nonce]
+}
+
+func deleteAntigravityOAuthState(nonce string) {
+	agOAuthMu.Lock()
+	delete(agOAuthStates, nonce)
+	agOAuthMu.Unlock()
+}
+
+// ─── Route: POST /providers/antigravity/start-oauth ──────────────────────────
+// Body: { "client_id": "…", "client_secret": "…", "provider_id": "…" (optional for re-auth) }
+// Returns: { "auth_url": "…", "state": "…" }
+
+func handleAntigravityStartOAuth(c *gin.Context) {
+	var req struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+		ProviderID   string `json:"provider_id"` // empty = create new
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	req.ClientID = strings.TrimSpace(req.ClientID)
+	req.ClientSecret = strings.TrimSpace(req.ClientSecret)
+	if req.ClientID == "" || req.ClientSecret == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "client_id and client_secret are required"})
+		return
+	}
+
+	// Determine provider ID — use an existing one or allocate a new one.
+	isNew := req.ProviderID == ""
+	providerID := req.ProviderID
+	if isNew {
+		reg := registry.GetProviderRegistry()
+		providerID = reg.NextInstanceID("antigravity")
+	}
+
+	// Build redirect URI pointing back to this server.
+	scheme := "http"
+	host := c.Request.Host
+	redirectURI := fmt.Sprintf("%s://%s/api/admin/providers/antigravity/oauth-callback", scheme, host)
+
+	state := newAntigravityOAuthState(providerID, req.ClientID, req.ClientSecret, redirectURI, isNew)
+	authURL := antigravitypkg.BuildAuthURL(req.ClientID, redirectURI, state.State)
+
+	log.Info().
+		Str("provider", providerID).
+		Bool("is_new", isNew).
+		Msg("Antigravity: Google OAuth flow started")
+
+	c.JSON(http.StatusOK, gin.H{
+		"auth_url":    authURL,
+		"state":       state.State,
+		"provider_id": providerID,
+	})
+}
+
+// ─── Route: GET /providers/antigravity/oauth-callback ────────────────────────
+// Google redirects here with ?code=…&state=…
+// On success renders a small HTML page that closes the popup and notifies the opener.
+
+func handleAntigravityOAuthCallback(c *gin.Context) {
+	code := c.Query("code")
+	nonce := c.Query("state")
+	errParam := c.Query("error")
+
+	if errParam != "" {
+		renderOAuthResult(c, false, "Google denied access: "+errParam, "")
+		return
+	}
+	if code == "" || nonce == "" {
+		renderOAuthResult(c, false, "Missing code or state parameter", "")
+		return
+	}
+
+	state := getAntigravityOAuthState(nonce)
+	if state == nil || time.Now().After(state.Expiry) {
+		renderOAuthResult(c, false, "OAuth state expired or not found — please try again", "")
+		return
+	}
+	deleteAntigravityOAuthState(nonce)
+
+	// Exchange authorization code for tokens.
+	tokenResp, err := antigravitypkg.ExchangeCode(state.ClientID, state.ClientSecret, code, state.RedirectURI)
+	if err != nil {
+		log.Error().Err(err).Str("provider", state.ProviderID).Msg("Antigravity: OAuth code exchange failed")
+		renderOAuthResult(c, false, fmt.Sprintf("Token exchange failed: %v", err), "")
+		return
+	}
+
+	// Persist credentials + tokens.
+	tokenStore := database.NewTokenStore()
+	tokenData := map[string]interface{}{
+		"access_token":  tokenResp.AccessToken,
+		"client_id":     state.ClientID,
+		"client_secret": state.ClientSecret,
+	}
+	if tokenResp.RefreshToken != "" {
+		tokenData["refresh_token"] = tokenResp.RefreshToken
+	}
+	if err := tokenStore.Save(state.ProviderID, "antigravity", tokenData); err != nil {
+		log.Error().Err(err).Str("provider", state.ProviderID).Msg("Antigravity: failed to save tokens")
+		renderOAuthResult(c, false, "Failed to save credentials — please try again", "")
+		return
+	}
+
+	// Register provider (or update existing).
+	reg := registry.GetProviderRegistry()
+	if state.IsNewProvider {
+		gen := generic.NewGenericProvider("antigravity", state.ProviderID, "")
+		gen.ApplyTokenFromDB()
+		if err := reg.Register(gen, true); err != nil {
+			log.Warn().Err(err).Str("provider", state.ProviderID).Msg("Antigravity: failed to register after OAuth")
+		}
+	} else {
+		// Update existing — reload token from DB so in-memory state is fresh.
+		if prov, provErr := reg.GetProvider(state.ProviderID); provErr == nil {
+			if gp, ok := prov.(*generic.GenericProvider); ok {
+				gp.ApplyTokenFromDB()
+			}
+		}
+	}
+
+	// Encode minimal provider info so the opener can update the UI.
+	info, _ := json.Marshal(map[string]interface{}{
+		"id":         state.ProviderID,
+		"type":       "antigravity",
+		"name":       "Antigravity",
+		"authStatus": "authenticated",
+		"isNew":      state.IsNewProvider,
+	})
+
+	log.Info().Str("provider", state.ProviderID).Msg("Antigravity: Google OAuth completed successfully")
+	renderOAuthResult(c, true, "", string(info))
+}
+
+// renderOAuthResult writes a small self-closing HTML page.
+// On success it posts a message to window.opener and closes itself.
+// On failure it shows the error and lets the user close manually.
+func renderOAuthResult(c *gin.Context, success bool, errMsg, providerJSON string) {
+	c.Header("Content-Type", "text/html; charset=utf-8")
+	if success {
+		c.String(http.StatusOK, `<!DOCTYPE html><html><head><title>Antigravity — Authenticated</title></head><body>
+<p>Authenticated successfully. This window will close…</p>
+<script>
+try {
+  window.opener && window.opener.postMessage({type:"antigravity_oauth_complete",provider:`+providerJSON+`},"*");
+} catch(e){}
+setTimeout(function(){ window.close(); }, 1000);
+</script></body></html>`)
+	} else {
+		c.String(http.StatusOK, `<!DOCTYPE html><html><head><title>Antigravity — Error</title></head><body>
+<p style="color:red">OAuth failed: `+errMsg+`</p>
+<p><button onclick="window.close()">Close</button></p>
+<script>
+try {
+  window.opener && window.opener.postMessage({type:"antigravity_oauth_error",error:`+"`"+errMsg+"`"+`},"*");
+} catch(e){}
+</script></body></html>`)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -214,6 +214,10 @@ func buildRouter(port int, apiKey string, chatOptions routes.ChatCompletionOptio
 	// Admin routes
 	adminPublic := r.Group("/api/admin")
 	adminPublic.GET("/info", routes.MakePublicInfoHandler(port))
+	// OAuth callback and status must be public — Google's redirect carries no auth header,
+	// and the status polling happens before the user has completed the flow.
+	adminPublic.GET("/providers/antigravity/oauth-callback", routes.HandleAntigravityOAuthCallbackPublic)
+	adminPublic.GET("/providers/antigravity/oauth-status", routes.HandleAntigravityOAuthStatusPublic)
 
 	adminAPI := r.Group("/api/admin", auth.middleware())
 	routes.SetupAdminRoutes(adminAPI, port)


### PR DESCRIPTION
## Summary

Fixes #13

Two bugs combined to break the antigravity Google OAuth flow completely:

- **`{"error":"unauthorized"}` on callback**: The `oauth-callback` and `oauth-status` routes were registered under the `auth.middleware()` group. When Google redirects back after login, the request carries no `Authorization` header, so the middleware rejected it before the handler could run.
- **Silent completion failure (COOP)**: Google's OAuth pages set `Cross-Origin-Opener-Policy: same-origin`, which severs the `window.opener` reference as the popup navigates through Google's login flow. The callback page's `window.opener.postMessage(...)` call silently failed, so the frontend never learned that OAuth had completed.

## Changes

**Backend**
- Move `oauth-callback` and `oauth-status` routes to the public router group (no auth middleware)
- Replace `window.opener.postMessage` with a server-side result store: on callback success, store the result keyed by `provider_id`; expose `GET /api/admin/providers/antigravity/oauth-status?provider_id=…` for the frontend to poll

**Frontend**
- Replace `window.addEventListener("message", ...)` with backend polling every 1.5s against `/oauth-status`
- Open the OAuth flow in a new tab (`_blank`) instead of a named popup to avoid browser extension interference with the message channel
- Stop polling on success, error, tab close, or 10-minute timeout