### PR TITLE
Make GitHub Copilot provider IDs consistent with display names

### DIFF
--- a/internal/routes/admin.go
+++ b/internal/routes/admin.go
@@ -812,8 +812,9 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 					return
 				}
 
-				// Assign a canonical instance ID using the GitHub username embedded in the provider name.
-				canonicalID := providerRegistry.NextInstanceID("github-copilot")
+				// Derive canonical ID from the provider name which now contains the username
+				// e.g., "GitHub Copilot (octocat)" → "github-copilot-octocat"
+				canonicalID := deriveGitHubCopilotID(cop.GetName())
 				cop.SetInstanceID(canonicalID)
 
 				if err := cop.SaveToDB(); err != nil {
@@ -867,7 +868,9 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 			return
 		}
 
-		canonicalID := providerRegistry.NextInstanceID("github-copilot")
+		// Derive canonical ID from the provider name which now contains the username
+		// e.g., "GitHub Copilot (octocat)" → "github-copilot-octocat"
+		canonicalID := deriveGitHubCopilotID(cop.GetName())
 		cop.SetInstanceID(canonicalID)
 
 		if err := cop.SaveToDB(); err != nil {
@@ -1080,6 +1083,43 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 			"error": fmt.Sprintf("Unknown provider type '%s'", providerType),
 		})
 	}
+}
+
+// deriveGitHubCopilotID extracts the GitHub username from the provider name
+// and generates a consistent instance ID.
+// Example: "GitHub Copilot (octocat)" → "github-copilot-octocat"
+func deriveGitHubCopilotID(name string) string {
+	// Look for pattern "GitHub Copilot (username)"
+	start := strings.Index(name, "(")
+	end := strings.Index(name, ")")
+	if start == -1 || end == -1 || end <= start+1 {
+		// Fallback if we can't extract username
+		providerRegistry := registry.GetProviderRegistry()
+		return providerRegistry.NextInstanceID("github-copilot")
+	}
+
+	username := strings.TrimSpace(name[start+1 : end])
+	if username == "" {
+		providerRegistry := registry.GetProviderRegistry()
+		return providerRegistry.NextInstanceID("github-copilot")
+	}
+
+	// Sanitize username: lowercase and replace non-alphanumeric with dashes
+	sanitized := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, strings.ToLower(username))
+
+	// Remove leading/trailing dashes
+	sanitized = strings.Trim(sanitized, "-_")
+	if sanitized == "" {
+		providerRegistry := registry.GetProviderRegistry()
+		return providerRegistry.NextInstanceID("github-copilot")
+	}
+
+	return "github-copilot-" + sanitized
 }
 
 func handleDeleteProvider(c *gin.Context) {

--- a/internal/routes/admin_auth_create_test.go
+++ b/internal/routes/admin_auth_create_test.go
@@ -336,8 +336,9 @@ func TestHandleAuthAndCreateProviderGitHubCopilotTokenUsesCanonicalID(t *testing
 	if !payload.Success {
 		t.Fatal("expected success=true")
 	}
-	if payload.Provider.ID != "github-copilot" {
-		t.Fatalf("expected canonical instance id github-copilot, got %q", payload.Provider.ID)
+	const expectedID = "github-copilot-octocat"
+	if payload.Provider.ID != expectedID {
+		t.Fatalf("expected canonical instance id %q, got %q", expectedID, payload.Provider.ID)
 	}
 	if payload.Provider.Type != "github-copilot" {
 		t.Fatalf("expected provider type github-copilot, got %q", payload.Provider.Type)
@@ -349,7 +350,7 @@ func TestHandleAuthAndCreateProviderGitHubCopilotTokenUsesCanonicalID(t *testing
 		t.Fatalf("expected authenticated status, got %q", payload.Provider.AuthStatus)
 	}
 
-	tokenRecord, err := database.NewTokenStore().Get("github-copilot")
+	tokenRecord, err := database.NewTokenStore().Get(expectedID)
 	if err != nil {
 		t.Fatalf("failed to read saved token: %v", err)
 	}


### PR DESCRIPTION
Fixes #15

## Summary

When adding a GitHub Copilot provider, the instance ID was generated using a counter (github-copilot-2, github-copilot-3, etc.) while the display name included the GitHub username (GitHub Copilot (octocat)). This created an inconsistency in the UI.

This PR derives the instance ID from the provider name, ensuring they are always consistent.

## Changes

- Add `deriveGitHubCopilotID()` helper function to extract username from provider name
- Apply username-based ID generation to both OAuth device-code flow and direct token auth
- Sanitize username: convert to lowercase, replace special characters with dashes
- Fall back to counter-based ID if extraction fails
- Update test expectations

## Example

Before:
- Display: `GitHub Copilot (octocat)`
- ID: `github-copilot-4` ❌

After:
- Display: `GitHub Copilot (octocat)`
- ID: `github-copilot-octocat` ✓

## Testing

- ✅ All auth-and-create tests passing
- ✅ No regressions to other providers
- ✅ Direct token auth tested
- ✅ OAuth device code flow tested