### PR TITLE
refactor: use identifiable metadata (email, name) for provider display names

### DIFF
--- a/internal/commands/sync-names.go
+++ b/internal/commands/sync-names.go
@@ -1,0 +1,145 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	antigravitypkg "omnillm/internal/providers/antigravity"
+	"omnillm/internal/database"
+	ghservice "omnillm/internal/services/github"
+
+	"github.com/spf13/cobra"
+)
+
+// SyncNamesCmd refreshes every provider instance's display name in the database
+// by calling each provider's live API, so names immediately reflect in the UI
+// without requiring a re-authentication.
+var SyncNamesCmd = &cobra.Command{
+	Use:   "sync-names",
+	Short: "Refresh provider display names in the database from live API metadata",
+	Long: `Calls each provider's user-info API to fetch the most up-to-date
+identifiable metadata (email, real name, login) and updates the display name
+stored in the database.  Changes take effect immediately in the UI — no server
+restart required.
+
+Supported providers: github-copilot, antigravity`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
+		configDir := filepath.Join(homeDir, ".config", "omnillm")
+
+		if err := database.InitializeDatabase(configDir); err != nil {
+			return fmt.Errorf("failed to initialise database: %w", err)
+		}
+
+		instanceStore := database.NewProviderInstanceStore()
+		tokenStore := database.NewTokenStore()
+
+		instances, err := instanceStore.GetAll()
+		if err != nil {
+			return fmt.Errorf("failed to list provider instances: %w", err)
+		}
+
+		updated, skipped, failed := 0, 0, 0
+
+		for _, inst := range instances {
+			rec, err := tokenStore.Get(inst.InstanceID)
+			if err != nil || rec == nil {
+				fmt.Printf("  %-40s  skipped (no token record)\n", inst.InstanceID)
+				skipped++
+				continue
+			}
+
+			var td map[string]interface{}
+			if err := json.Unmarshal([]byte(rec.TokenData), &td); err != nil {
+				fmt.Printf("  %-40s  skipped (token parse error: %v)\n", inst.InstanceID, err)
+				skipped++
+				continue
+			}
+
+			var newName string
+
+			switch inst.ProviderID {
+
+			case "github-copilot":
+				githubToken, _ := td["github_token"].(string)
+				if githubToken == "" {
+					fmt.Printf("  %-40s  skipped (no github_token)\n", inst.InstanceID)
+					skipped++
+					continue
+				}
+				user, err := ghservice.GetUser(githubToken)
+				if err != nil {
+					fmt.Printf("  %-40s  FAILED  (%v)\n", inst.InstanceID, err)
+					failed++
+					continue
+				}
+				newName = ghservice.CopilotProviderName(user)
+				// Persist name into token_data so LoadFromDB restores it on restart.
+				td["name"] = newName
+				_ = tokenStore.Save(inst.InstanceID, inst.ProviderID, td)
+
+			case "antigravity":
+				// Try stored email first; otherwise refresh the token and call userinfo.
+				email, _ := td["email"].(string)
+				if email == "" {
+					accessToken, _ := td["access_token"].(string)
+					// Attempt a token refresh if we have credentials.
+					if rt, ok := td["refresh_token"].(string); ok && rt != "" {
+						if cid, ok2 := td["client_id"].(string); ok2 {
+							if cs, ok3 := td["client_secret"].(string); ok3 {
+								if refreshed, err := antigravitypkg.RefreshAccessToken(cid, cs, rt); err == nil {
+									accessToken = refreshed.AccessToken
+									td["access_token"] = accessToken
+								}
+							}
+						}
+					}
+					if accessToken != "" {
+						email = antigravitypkg.FetchUserEmail(accessToken)
+						if email != "" {
+							td["email"] = email
+							_ = tokenStore.Save(inst.InstanceID, inst.ProviderID, td)
+						}
+					}
+				}
+				if email == "" {
+					fmt.Printf("  %-40s  skipped (could not determine email)\n", inst.InstanceID)
+					skipped++
+					continue
+				}
+				newName = fmt.Sprintf("Antigravity (%s)", email)
+
+			default:
+				// Provider type not handled by this command.
+				skipped++
+				continue
+			}
+
+			if newName == "" || newName == inst.Name {
+				fmt.Printf("  %-40s  unchanged  %q\n", inst.InstanceID, inst.Name)
+				skipped++
+				continue
+			}
+
+			oldName := inst.Name
+			inst.Name = newName
+			if err := instanceStore.Save(&inst); err != nil {
+				fmt.Printf("  %-40s  FAILED  (db save: %v)\n", inst.InstanceID, err)
+				failed++
+				continue
+			}
+
+			fmt.Printf("  %-40s  %q  →  %q\n", inst.InstanceID, oldName, newName)
+			updated++
+		}
+
+		fmt.Println()
+		fmt.Printf("Done — %d updated, %d unchanged/skipped, %d failed.\n", updated, skipped, failed)
+		return nil
+	},
+}

--- a/internal/providers/antigravity/oauth.go
+++ b/internal/providers/antigravity/oauth.go
@@ -120,6 +120,35 @@ func RefreshAccessToken(clientID, clientSecret, refreshToken string) (*OAuthToke
 	return &t, nil
 }
 
+// FetchUserEmail calls Google's userinfo endpoint to retrieve the authenticated
+// user's email address. Returns an empty string if the call fails.
+func FetchUserEmail(accessToken string) string {
+	req, err := http.NewRequest("GET", "https://www.googleapis.com/oauth2/v3/userinfo", nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var info struct {
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return ""
+	}
+	return info.Email
+}
+
 // DiscoverProject calls the Cloud Code loadCodeAssist endpoint to find or
 // provision a project ID for the authenticated user. Falls back to
 // DefaultProjectID if the endpoint is unreachable or returns no project.

--- a/internal/providers/codex/codex.go
+++ b/internal/providers/codex/codex.go
@@ -120,8 +120,8 @@ func (p *CodexProvider) SetupAuth(options *types.AuthOptions) error {
 	}
 	user, err := ghservice.GetUser(p.githubToken)
 	if err == nil {
-		if login, ok := user["login"].(string); ok {
-			p.name = fmt.Sprintf("Codex (%s)", login)
+		if name := codexProviderName(user); name != "" {
+			p.name = name
 		}
 	}
 	return nil
@@ -149,9 +149,9 @@ func (p *CodexProvider) PollAndCompleteDeviceCodeFlow(dc *ghservice.DeviceCodeRe
 	p.githubToken = accessToken
 	user, err := ghservice.GetUser(accessToken)
 	if err == nil {
-		if login, ok := user["login"].(string); ok {
-			p.name = fmt.Sprintf("Codex (%s)", login)
-			log.Info().Str("login", login).Msg("Codex: authenticated via device code")
+		if name := codexProviderName(user); name != "" {
+			p.name = name
+			log.Info().Str("name", name).Msg("Codex: authenticated via device code")
 		}
 	}
 	if err := p.RefreshToken(); err != nil {
@@ -485,4 +485,28 @@ func (a *CodexAdapter) buildPayload(request *cif.CanonicalRequest, stream bool) 
 
 func (a *CodexAdapter) convertResponseToCIF(resp map[string]interface{}) *cif.CanonicalResponse {
 	return shared.OpenAIRespToCIF(resp)
+}
+
+// codexProviderName builds a human-friendly display name from a GitHub /user response.
+// Priority: "name · email" > "name · login" > "email" > "login".
+func codexProviderName(user map[string]interface{}) string {
+	login, _ := user["login"].(string)
+	email, _ := user["email"].(string)
+	if email == "" {
+		email, _ = user["notification_email"].(string)
+	}
+	realName, _ := user["name"].(string)
+
+	switch {
+	case realName != "" && email != "":
+		return fmt.Sprintf("Codex (%s · %s)", realName, email)
+	case realName != "" && login != "":
+		return fmt.Sprintf("Codex (%s · %s)", realName, login)
+	case email != "":
+		return fmt.Sprintf("Codex (%s)", email)
+	case login != "":
+		return fmt.Sprintf("Codex (%s)", login)
+	default:
+		return ""
+	}
 }

--- a/internal/providers/copilot/copilot.go
+++ b/internal/providers/copilot/copilot.go
@@ -153,10 +153,8 @@ func (p *GitHubCopilotProvider) SetupAuth(options *types.AuthOptions) error {
 		// Fetch user info to get the login
 		user, err := ghservice.GetUser(p.githubToken)
 		if err == nil {
-			if login, ok := user["login"].(string); ok {
-				p.name = fmt.Sprintf("GitHub Copilot (%s)", login)
-				log.Info().Str("provider", p.instanceID).Str("login", login).Msg("GitHub Copilot authenticated")
-			}
+			p.name = ghservice.CopilotProviderName(user)
+			log.Info().Str("provider", p.instanceID).Str("name", p.name).Msg("GitHub Copilot authenticated")
 		}
 
 		return nil
@@ -201,14 +199,11 @@ func (p *GitHubCopilotProvider) PollAndCompleteDeviceCodeFlow(deviceCode *ghserv
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to get user info after OAuth")
 	} else {
-		if login, ok := user["login"].(string); ok {
-			p.name = fmt.Sprintf("GitHub Copilot (%s)", login)
-
-			log.Info().
-				Str("instance_id", p.instanceID).
-				Str("login", login).
-				Msg("GitHub Copilot authenticated via device code")
-		}
+		p.name = ghservice.CopilotProviderName(user)
+		log.Info().
+			Str("instance_id", p.instanceID).
+			Str("name", p.name).
+			Msg("GitHub Copilot authenticated via device code")
 	}
 
 	// Exchange GitHub token for Copilot token

--- a/internal/providers/generic/generic.go
+++ b/internal/providers/generic/generic.go
@@ -666,6 +666,18 @@ func (p *GenericProvider) LoadFromDB() error {
 			p.name = alibabapkg.APIKeyProviderName(p.config)
 			log.Info().Str("instanceID", p.instanceID).Str("newName", p.name).Msg("Updated Alibaba API key provider name")
 		}
+
+		if p.id == "antigravity" {
+			// Prefer email-based name if available; otherwise keep the existing name.
+			if record != nil {
+				var td map[string]interface{}
+				if jsonErr := json.Unmarshal([]byte(record.TokenData), &td); jsonErr == nil {
+					if email, ok := td["email"].(string); ok && email != "" {
+						p.name = "Antigravity (" + email + ")"
+					}
+				}
+			}
+		}
 	}
 
 	if p.id == "google" && p.token != "" {

--- a/internal/routes/admin_antigravity_oauth.go
+++ b/internal/routes/admin_antigravity_oauth.go
@@ -172,6 +172,10 @@ func handleAntigravityOAuthCallback(c *gin.Context) {
 	projectID := antigravitypkg.DiscoverProject(tokenResp.AccessToken)
 	log.Info().Str("provider", state.ProviderID).Str("project_id", projectID).Msg("Antigravity: discovered project")
 
+	// Fetch the authenticated user's email to use as a friendly identifier.
+	email := antigravitypkg.FetchUserEmail(tokenResp.AccessToken)
+	log.Info().Str("provider", state.ProviderID).Str("email", email).Msg("Antigravity: fetched user email")
+
 	// Persist credentials + tokens + project_id.
 	tokenStore := database.NewTokenStore()
 	tokenData := map[string]interface{}{
@@ -179,6 +183,9 @@ func handleAntigravityOAuthCallback(c *gin.Context) {
 		"client_id":     state.ClientID,
 		"client_secret": state.ClientSecret,
 		"project_id":    projectID,
+	}
+	if email != "" {
+		tokenData["email"] = email
 	}
 	if tokenResp.RefreshToken != "" {
 		tokenData["refresh_token"] = tokenResp.RefreshToken

--- a/internal/services/github/github.go
+++ b/internal/services/github/github.go
@@ -176,6 +176,34 @@ func GetCopilotToken(githubToken string) (*CopilotTokenResponse, error) {
 	return &result, nil
 }
 
+// CopilotProviderName returns a human-friendly display name for a GitHub Copilot
+// provider, derived from the /user API response.  Priority:
+//  1. "name (email)"  — when both real name and email are present
+//  2. "name (login)"  — when real name is present but no public email
+//  3. "email"         — when only email is present
+//  4. "login"         — fallback
+func CopilotProviderName(user map[string]interface{}) string {
+	login, _ := user["login"].(string)
+	email, _ := user["email"].(string)
+	if email == "" {
+		email, _ = user["notification_email"].(string)
+	}
+	realName, _ := user["name"].(string)
+
+	switch {
+	case realName != "" && email != "":
+		return fmt.Sprintf("GitHub Copilot (%s · %s)", realName, email)
+	case realName != "" && login != "":
+		return fmt.Sprintf("GitHub Copilot (%s · %s)", realName, login)
+	case email != "":
+		return fmt.Sprintf("GitHub Copilot (%s)", email)
+	case login != "":
+		return fmt.Sprintf("GitHub Copilot (%s)", login)
+	default:
+		return "GitHub Copilot"
+	}
+}
+
 // GetUser returns basic GitHub user info
 func GetUser(githubToken string) (map[string]interface{}, error) {
 	req, err := http.NewRequest("GET", GitHubAPIBaseURL+"/user", nil)

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 	rootCmd.AddCommand(commands.CheckUsageCmd)
 	rootCmd.AddCommand(commands.DebugCmd)
 	rootCmd.AddCommand(commands.ChatCmd)
+	rootCmd.AddCommand(commands.SyncNamesCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)


### PR DESCRIPTION
## Summary

Fixes #17 — Updates provider display names to use identifiable metadata from live APIs instead of opaque identifiers.

- GitHub Copilot: Shows real name + email (e.g., `GitHub Copilot (James Zhu · jzhu@email.com)`)
- Antigravity: Shows email from Google userinfo (e.g., `Antigravity (user@gmail.com)`)
- Added `omnillm sync-names` command to refresh names from live API without restarting the server

## Changes

### New/Updated Files

| File | Change |
|---|---|
| `internal/services/github/github.go` | Added `CopilotProviderName()` helper prioritizing name + email |
| `internal/providers/copilot/copilot.go` | Use `CopilotProviderName()` in auth flows |
| `internal/providers/codex/codex.go` | Added matching `codexProviderName()` helper |
| `internal/providers/antigravity/oauth.go` | Added `FetchUserEmail()` to call Google userinfo API |
| `internal/routes/admin_antigravity_oauth.go` | Fetch and store email on OAuth callback |
| `internal/providers/generic/generic.go` | LoadFromDB restores email-based names on startup |
| `internal/commands/sync-names.go` | New command to sync names from live API |
| `main.go` | Register `sync-names` command |

## Test Plan

- [x] Build passes with no errors
- [x] Existing GitHub Copilot and Antigravity accounts show improved names with real identifiable metadata
- [x] `omnillm sync-names` command updates all provider names in DB without restart
- [x] UI reflects changes immediately after running sync-names
- [x] New authentications use email-based names automatically

## Migration

Run `omnillm sync-names` to update existing provider instance names in the database with current metadata from live APIs.