### PR TITLE
fix: skip temperature/top_p for reasoning models (o-series, gpt-5+)

### DIFF
--- a/internal/providers/azure/chat.go
+++ b/internal/providers/azure/chat.go
@@ -50,10 +50,14 @@ func BuildOpenAIPayload(model string, messages []map[string]interface{}, request
 	}
 
 	if request.Temperature != nil {
-		payload["temperature"] = *request.Temperature
+		if !shared.IsReasoningModel(model) {
+			payload["temperature"] = *request.Temperature
+		}
 	}
 	if request.TopP != nil {
-		payload["top_p"] = *request.TopP
+		if !shared.IsReasoningModel(model) {
+			payload["top_p"] = *request.TopP
+		}
 	}
 	if request.MaxTokens != nil {
 		modelLower := strings.ToLower(model)

--- a/internal/providers/azure/responses.go
+++ b/internal/providers/azure/responses.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"omnillm/internal/cif"
+	"omnillm/internal/providers/shared"
 	"strings"
 	"time"
 )
@@ -65,11 +66,8 @@ func BuildResponsesPayload(request *cif.CanonicalRequest, model string) map[stri
 		payload["instructions"] = *request.SystemPrompt
 	}
 
-	// gpt-5.4-pro and gpt-5.1-codex-max do not support temperature
-	modelLower := strings.ToLower(model)
-	supportsTemperature := !strings.Contains(modelLower, "gpt-5.4-pro") &&
-		!strings.Contains(modelLower, "gpt-5.1-codex-max")
-	if supportsTemperature {
+	// o-series and gpt-5+ reasoning models do not support temperature.
+	if !shared.IsReasoningModel(model) {
 		if request.Temperature != nil {
 			payload["temperature"] = *request.Temperature
 		} else {

--- a/internal/providers/copilot/payload.go
+++ b/internal/providers/copilot/payload.go
@@ -71,10 +71,14 @@ func (a *CopilotAdapter) convertCIFToOpenAI(request *cif.CanonicalRequest, toolN
 	}
 
 	if request.Temperature != nil {
-		payload["temperature"] = *request.Temperature
+		if !shared.IsReasoningModel(payload["model"].(string)) {
+			payload["temperature"] = *request.Temperature
+		}
 	}
 	if request.TopP != nil {
-		payload["top_p"] = *request.TopP
+		if !shared.IsReasoningModel(payload["model"].(string)) {
+			payload["top_p"] = *request.TopP
+		}
 	}
 	if request.MaxTokens != nil {
 		if copilotModelUsesMaxCompletionTokens(payload["model"].(string)) {

--- a/internal/providers/shared/helpers.go
+++ b/internal/providers/shared/helpers.go
@@ -33,3 +33,24 @@ func ShortTokenSuffix(token string) string {
 	}
 	return trimmed
 }
+
+// IsReasoningModel returns true for models that do not support the temperature
+// or top_p sampling parameters (OpenAI o-series, gpt-5 family, and Azure
+// Responses API-only models like gpt-5.4-pro / gpt-5.1-codex-max).
+// These models use internal reasoning and reject temperature/top_p with a 400.
+func IsReasoningModel(model string) bool {
+	lower := strings.ToLower(strings.TrimSpace(model))
+	// o-series reasoning models: o1, o1-mini, o3, o3-mini, o4-mini, …
+	if strings.HasPrefix(lower, "o1") || strings.HasPrefix(lower, "o3") || strings.HasPrefix(lower, "o4") {
+		return true
+	}
+	// gpt-5 family and later generations reject temperature
+	if strings.HasPrefix(lower, "gpt-5") || strings.HasPrefix(lower, "gpt-6") {
+		return true
+	}
+	// Azure Responses API-specific models known to reject temperature
+	if strings.Contains(lower, "gpt-5.4-pro") || strings.Contains(lower, "gpt-5.1-codex-max") {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Reasoning models (OpenAI o-series, gpt-5 family) reject `temperature` and `top_p` parameters with a 400 error. OmniLLM was unconditionally sending these parameters in the Azure and Copilot payload builders.

## Changes

- **`internal/providers/shared/helpers.go`** — added `IsReasoningModel(model string) bool` as a single shared predicate
- **`internal/providers/azure/chat.go`** — skip temperature/top_p for reasoning models
- **`internal/providers/azure/responses.go`** — replace hardcoded model list with shared predicate
- **`internal/providers/copilot/payload.go`** — skip temperature/top_p for reasoning models

## Related

Closes #20

## Test plan

- `go build ./...` succeeds
- `go test ./... -count=1` passes all 24 packages