### PR TITLE
Preserve user-customized provider names/subtitles across server restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ omnillm.exe
 
 # local tool artifacts
 .playwright-mcp/
+.gocache/
 .tmp-gocache/
 .tmp-gomodcache/
 

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -90,13 +90,13 @@ var AuthCmd = &cobra.Command{
 			}
 		}
 
-		if err := tokenStore.Save(instanceID, "github-copilot", tokenData); err != nil {
+		if err := tokenStore.Save(instanceID, tokenData); err != nil {
 			return fmt.Errorf("failed to save token: %w", err)
 		}
 
 		// Register provider in registry
 		providerRegistry := registry.GetProviderRegistry()
-		copilotProvider := copilot.NewGitHubCopilotProvider(instanceID)
+		copilotProvider := copilot.NewGitHubCopilotProvider(instanceID, "")
 		if err := copilotProvider.SetupAuth(&types.AuthOptions{GithubToken: copilotToken.Token}); err != nil {
 			return fmt.Errorf("failed to configure provider auth: %w", err)
 		}

--- a/internal/commands/debug.go
+++ b/internal/commands/debug.go
@@ -63,7 +63,7 @@ var DebugCmd = &cobra.Command{
 				fmt.Println("  No tokens stored. Run 'omnillm auth' to authenticate.")
 			}
 			for _, t := range tokens {
-				fmt.Printf("  Instance: %s (provider: %s)\n", t.InstanceID, t.ProviderID)
+				fmt.Printf("  Instance: %s\n", t.InstanceID)
 			}
 		}
 		fmt.Println()

--- a/internal/commands/sync-names.go
+++ b/internal/commands/sync-names.go
@@ -81,7 +81,7 @@ Supported providers: github-copilot, antigravity`,
 				newName = ghservice.CopilotProviderName(user)
 				// Persist name into token_data so LoadFromDB restores it on restart.
 				td["name"] = newName
-				_ = tokenStore.Save(inst.InstanceID, inst.ProviderID, td)
+				_ = tokenStore.Save(inst.InstanceID, td)
 
 			case "antigravity":
 				// Try stored email first; otherwise refresh the token and call userinfo.
@@ -103,7 +103,7 @@ Supported providers: github-copilot, antigravity`,
 						email = antigravitypkg.FetchUserEmail(accessToken)
 						if email != "" {
 							td["email"] = email
-							_ = tokenStore.Save(inst.InstanceID, inst.ProviderID, td)
+							_ = tokenStore.Save(inst.InstanceID, td)
 						}
 					}
 				}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,9 +1,13 @@
 package database
 
 import (
+	"database/sql"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestMain(m *testing.M) {
@@ -93,16 +97,23 @@ func TestProviderInstanceStoreCRUD(t *testing.T) {
 }
 
 func TestTokenStoreCRUD(t *testing.T) {
+	// Insert a provider_instances row so the FK and JOIN in GetAllByProvider work.
+	instanceStore := NewProviderInstanceStore()
+	if err := instanceStore.Save(&ProviderInstanceRecord{
+		InstanceID: "provider-1",
+		ProviderID: "mock",
+		Name:       "Mock Provider",
+	}); err != nil {
+		t.Fatalf("setup provider instance: %v", err)
+	}
+
 	store := NewTokenStore()
-	if err := store.Save("provider-1", "mock", map[string]any{"token": "abc", "expires": 123}); err != nil {
+	if err := store.Save("provider-1", map[string]any{"token": "abc", "expires": 123}); err != nil {
 		t.Fatalf("save failed: %v", err)
 	}
 	got, err := store.Get("provider-1")
 	if err != nil || got == nil {
 		t.Fatalf("get failed: %#v err=%v", got, err)
-	}
-	if got.ProviderID != "mock" {
-		t.Fatalf("unexpected provider id: %#v", got)
 	}
 	all, err := store.GetAllByProvider("mock")
 	if err != nil || len(all) == 0 {
@@ -220,6 +231,98 @@ func TestCreateTablesIsIdempotentForBackfill(t *testing.T) {
 	}
 	if err := db.createTables(); err != nil {
 		t.Fatalf("second createTables call failed: %v", err)
+	}
+}
+
+func TestCreateTablesMigratesLegacyProviderModelsCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	rawDB, err := sql.Open("sqlite", filepath.Join(tmpDir, "legacy.sqlite"))
+	if err != nil {
+		t.Fatalf("open legacy database: %v", err)
+	}
+	defer rawDB.Close()
+
+	legacy := &Database{db: rawDB}
+	statements := []string{
+		`CREATE TABLE schema_migrations (
+			version    INTEGER PRIMARY KEY,
+			applied_at DATETIME NOT NULL DEFAULT (datetime('now'))
+		)`,
+		`CREATE TABLE provider_instances (
+			instance_id TEXT PRIMARY KEY,
+			provider_id TEXT NOT NULL,
+			name        TEXT NOT NULL,
+			priority    INTEGER NOT NULL DEFAULT 0,
+			activated   INTEGER NOT NULL DEFAULT 0 CHECK (activated IN (0, 1)),
+			created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+			updated_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+		)`,
+		`CREATE TABLE tokens (
+			instance_id TEXT PRIMARY KEY,
+			token_data  TEXT NOT NULL,
+			created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+			updated_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+			FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE
+		)`,
+		`CREATE TABLE virtual_models (
+			virtual_model_id TEXT    PRIMARY KEY,
+			name             TEXT    NOT NULL,
+			description      TEXT    NOT NULL DEFAULT '',
+			api_shape        TEXT    NOT NULL DEFAULT 'openai',
+			lb_strategy      TEXT    NOT NULL DEFAULT 'round-robin'
+			                         CHECK (lb_strategy IN ('round-robin','random','priority','weighted')),
+			enabled          INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+			created_at       DATETIME NOT NULL DEFAULT (datetime('now')),
+			updated_at       DATETIME NOT NULL DEFAULT (datetime('now'))
+		)`,
+		`CREATE TABLE virtual_model_upstreams (
+			id               INTEGER PRIMARY KEY AUTOINCREMENT,
+			virtual_model_id TEXT    NOT NULL,
+			model_id         TEXT    NOT NULL,
+			weight           INTEGER NOT NULL DEFAULT 1,
+			priority         INTEGER NOT NULL DEFAULT 0,
+			created_at       DATETIME NOT NULL DEFAULT (datetime('now')),
+			FOREIGN KEY (virtual_model_id) REFERENCES virtual_models (virtual_model_id) ON DELETE CASCADE
+		)`,
+		`CREATE TABLE provider_models_cache (
+			instance_id TEXT PRIMARY KEY,
+			models_data TEXT    NOT NULL,
+			cached_at   DATETIME NOT NULL DEFAULT (datetime('now')),
+			FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE
+		)`,
+		`INSERT INTO schema_migrations (version) VALUES (1), (2), (3)`,
+		`INSERT INTO provider_instances (instance_id, provider_id, name) VALUES ('legacy-provider', 'mock', 'Legacy Provider')`,
+		`INSERT INTO provider_models_cache (instance_id, models_data, cached_at) VALUES ('legacy-provider', '{}', '2026-04-25 12:34:56')`,
+	}
+
+	for _, statement := range statements {
+		if _, err := rawDB.Exec(statement); err != nil {
+			t.Fatalf("seed legacy schema: %v", err)
+		}
+	}
+
+	if err := legacy.createTables(); err != nil {
+		t.Fatalf("migrate legacy schema: %v", err)
+	}
+
+	var updatedAt sql.NullString
+	if err := rawDB.QueryRow(`SELECT updated_at FROM provider_models_cache WHERE instance_id = ?`, "legacy-provider").Scan(&updatedAt); err != nil {
+		t.Fatalf("read migrated updated_at: %v", err)
+	}
+	if !updatedAt.Valid || !parseTime(updatedAt.String).Equal(time.Date(2026, 4, 25, 12, 34, 56, 0, time.UTC)) {
+		t.Fatalf("expected updated_at to be backfilled from cached_at, got %#v", updatedAt)
+	}
+
+	cacheStore := &ProviderModelsCacheStore{db: legacy}
+	if err := cacheStore.Save("legacy-provider", `{"models":["x"]}`); err != nil {
+		t.Fatalf("save migrated cache row: %v", err)
+	}
+
+	if err := rawDB.QueryRow(`SELECT updated_at FROM provider_models_cache WHERE instance_id = ?`, "legacy-provider").Scan(&updatedAt); err != nil {
+		t.Fatalf("read updated cache row: %v", err)
+	}
+	if !updatedAt.Valid || parseTime(updatedAt.String).Equal(time.Date(2026, 4, 25, 12, 34, 56, 0, time.UTC)) {
+		t.Fatalf("expected save to refresh updated_at, got %#v", updatedAt)
 	}
 }
 

--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -26,7 +26,7 @@ func InitializeDatabase(configDir string) error {
 	dbPath := filepath.Join(configDir, "database.sqlite")
 	log.Debug().Str("path", dbPath).Msg("Initializing SQLite database")
 
-	db, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	db, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=ON")
 	if err != nil {
 		return fmt.Errorf("failed to open database: %w", err)
 	}
@@ -55,157 +55,220 @@ func GetDatabase() *Database {
 }
 
 func (db *Database) createTables() error {
-	queries := []string{
-		// Configuration table
+	// Core tables — never modified after creation; schema changes go through migrations below.
+	tables := []string{
+		// Schema migrations — tracks which migrations have been applied.
+		`CREATE TABLE IF NOT EXISTS schema_migrations (
+			version    INTEGER PRIMARY KEY,
+			applied_at DATETIME NOT NULL DEFAULT (datetime('now'))
+		)`,
+
+		// Key-value application configuration.
 		`CREATE TABLE IF NOT EXISTS config (
-			key TEXT PRIMARY KEY,
-			value TEXT NOT NULL,
+			key        TEXT PRIMARY KEY,
+			value      TEXT NOT NULL,
 			created_at DATETIME NOT NULL DEFAULT (datetime('now')),
 			updated_at DATETIME NOT NULL DEFAULT (datetime('now'))
 		)`,
 
-		// Provider instances table
+		// Provider instances — root entity for every configured AI provider.
 		`CREATE TABLE IF NOT EXISTS provider_instances (
-			instance_id TEXT PRIMARY KEY,
-			provider_id TEXT NOT NULL,
-			name TEXT NOT NULL,
-			priority INTEGER NOT NULL DEFAULT 0,
-			activated INTEGER NOT NULL DEFAULT 0 CHECK (activated IN (0, 1)),
-			created_at DATETIME NOT NULL DEFAULT (datetime('now')),
-			updated_at DATETIME NOT NULL DEFAULT (datetime('now'))
+			instance_id TEXT    PRIMARY KEY,
+			provider_id TEXT    NOT NULL,
+			name        TEXT    NOT NULL,
+			subtitle    TEXT    NOT NULL DEFAULT '',
+			priority    INTEGER NOT NULL DEFAULT 0,
+			activated   INTEGER NOT NULL DEFAULT 0 CHECK (activated IN (0, 1)),
+			created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+			updated_at  DATETIME NOT NULL DEFAULT (datetime('now'))
 		)`,
 
-		// Tokens table
+		// Credentials for each provider instance (one row per instance).
+		// provider_id is intentionally omitted — join provider_instances for that.
 		`CREATE TABLE IF NOT EXISTS tokens (
 			instance_id TEXT PRIMARY KEY,
-			provider_id TEXT NOT NULL,
-			token_data TEXT NOT NULL,
-			created_at DATETIME NOT NULL DEFAULT (datetime('now')),
-			updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+			token_data  TEXT NOT NULL,
+			created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+			updated_at  DATETIME NOT NULL DEFAULT (datetime('now')),
 			FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE
 		)`,
 
-		// Provider model states table
+		// Per-model enabled/disabled overrides for a provider instance.
 		`CREATE TABLE IF NOT EXISTS provider_model_states (
-			instance_id TEXT NOT NULL,
-			model_id TEXT NOT NULL,
-			enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
-			created_at DATETIME NOT NULL DEFAULT (datetime('now')),
-			updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+			instance_id TEXT    NOT NULL,
+			model_id    TEXT    NOT NULL,
+			enabled     INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+			created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+			updated_at  DATETIME NOT NULL DEFAULT (datetime('now')),
 			PRIMARY KEY (instance_id, model_id),
 			FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE
 		)`,
 
-		// Provider configurations table
+		// Provider-level configuration blob (one row per instance).
 		`CREATE TABLE IF NOT EXISTS provider_configs (
 			instance_id TEXT PRIMARY KEY,
 			config_data TEXT NOT NULL,
-			created_at DATETIME NOT NULL DEFAULT (datetime('now')),
-			updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+			created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+			updated_at  DATETIME NOT NULL DEFAULT (datetime('now')),
 			FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE
 		)`,
 
-		// Model configurations table
+		// Per-model configuration and version tracking.
+		// version is INTEGER so numeric ordering works correctly.
 		`CREATE TABLE IF NOT EXISTS model_configs (
-			instance_id TEXT NOT NULL,
-			model_id TEXT NOT NULL,
-			version TEXT NOT NULL DEFAULT '1',
-			config_data TEXT NOT NULL DEFAULT '{}',
-			created_at DATETIME NOT NULL DEFAULT (datetime('now')),
-			updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+			instance_id TEXT    NOT NULL,
+			model_id    TEXT    NOT NULL,
+			version     INTEGER NOT NULL DEFAULT 1,
+			config_data TEXT    NOT NULL DEFAULT '{}',
+			created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+			updated_at  DATETIME NOT NULL DEFAULT (datetime('now')),
 			PRIMARY KEY (instance_id, model_id),
 			FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE
 		)`,
 
-		// Provider models cache table
+		// Cached model list returned by each provider's /models endpoint.
 		`CREATE TABLE IF NOT EXISTS provider_models_cache (
 			instance_id TEXT PRIMARY KEY,
-			models_data TEXT NOT NULL,
-			cached_at DATETIME NOT NULL DEFAULT (datetime('now')),
+			models_data TEXT    NOT NULL,
+			cached_at   DATETIME NOT NULL DEFAULT (datetime('now')),
+			updated_at  DATETIME NOT NULL DEFAULT (datetime('now')),
 			FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE
 		)`,
 
-		// Chat sessions table
+		// Chat sessions.
 		`CREATE TABLE IF NOT EXISTS chat_sessions (
 			session_id TEXT PRIMARY KEY,
-			title TEXT NOT NULL,
-			model_id TEXT NOT NULL,
-			api_shape TEXT NOT NULL DEFAULT 'openai',
+			title      TEXT NOT NULL,
+			model_id   TEXT NOT NULL,
+			api_shape  TEXT NOT NULL DEFAULT 'openai',
 			created_at DATETIME NOT NULL DEFAULT (datetime('now')),
 			updated_at DATETIME NOT NULL DEFAULT (datetime('now'))
 		)`,
 
-		// Chat messages table
+		// Chat messages — role is enforced at the DB level.
 		`CREATE TABLE IF NOT EXISTS chat_messages (
 			message_id TEXT PRIMARY KEY,
 			session_id TEXT NOT NULL,
-			role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
-			content TEXT NOT NULL,
+			role       TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
+			content    TEXT NOT NULL,
 			created_at DATETIME NOT NULL DEFAULT (datetime('now')),
 			FOREIGN KEY (session_id) REFERENCES chat_sessions (session_id) ON DELETE CASCADE
 		)`,
 
-		// Virtual models table
+		// Virtual (load-balanced) models.
 		`CREATE TABLE IF NOT EXISTS virtual_models (
-			virtual_model_id TEXT PRIMARY KEY,
-			name             TEXT NOT NULL,
-			description      TEXT NOT NULL DEFAULT '',
-			api_shape        TEXT NOT NULL DEFAULT 'openai',
-			lb_strategy      TEXT NOT NULL DEFAULT 'round-robin'
-			                 CHECK (lb_strategy IN ('round-robin','random','priority','weighted')),
+			virtual_model_id TEXT    PRIMARY KEY,
+			name             TEXT    NOT NULL,
+			description      TEXT    NOT NULL DEFAULT '',
+			api_shape        TEXT    NOT NULL DEFAULT 'openai',
+			lb_strategy      TEXT    NOT NULL DEFAULT 'round-robin'
+			                         CHECK (lb_strategy IN ('round-robin','random','priority','weighted')),
 			enabled          INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
 			created_at       DATETIME NOT NULL DEFAULT (datetime('now')),
 			updated_at       DATETIME NOT NULL DEFAULT (datetime('now'))
 		)`,
 
-		// Virtual model upstreams table
+		// Upstream provider+model entries for each virtual model.
 		`CREATE TABLE IF NOT EXISTS virtual_model_upstreams (
 			id               INTEGER PRIMARY KEY AUTOINCREMENT,
-			virtual_model_id TEXT NOT NULL,
-			provider_id      TEXT NOT NULL DEFAULT '',
-			model_id         TEXT NOT NULL,
+			virtual_model_id TEXT    NOT NULL,
+			provider_id      TEXT    NOT NULL DEFAULT '',
+			model_id         TEXT    NOT NULL,
 			weight           INTEGER NOT NULL DEFAULT 1,
 			priority         INTEGER NOT NULL DEFAULT 0,
 			created_at       DATETIME NOT NULL DEFAULT (datetime('now')),
-			FOREIGN KEY (virtual_model_id)
-				REFERENCES virtual_models(virtual_model_id) ON DELETE CASCADE
+			FOREIGN KEY (virtual_model_id) REFERENCES virtual_models (virtual_model_id) ON DELETE CASCADE
 		)`,
-		// Backfill newer columns for existing databases
-		`ALTER TABLE virtual_model_upstreams ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`,
-		`ALTER TABLE provider_instances ADD COLUMN subtitle TEXT NOT NULL DEFAULT ''`,
 	}
 
-	for _, query := range queries {
-		if _, err := db.db.Exec(query); err != nil {
-			if strings.Contains(query, "ALTER TABLE") && strings.Contains(err.Error(), "duplicate column name") {
-				continue
-			}
-			return fmt.Errorf("failed to execute query: %w", err)
+	for _, q := range tables {
+		if _, err := db.db.Exec(q); err != nil {
+			return fmt.Errorf("failed to create table: %w", err)
 		}
 	}
 
-	// Create indexes
+	// Indexes — IF NOT EXISTS makes these idempotent on every startup.
+	// Note: idx_provider_model_states_instance_id is intentionally absent —
+	// the composite PK (instance_id, model_id) already covers instance_id lookups.
+	// idx_provider_models_cache_cached_at is intentionally absent — TTL checks
+	// always go through the PK; there is no bulk-expiry sweep.
 	indexes := []string{
-		`CREATE INDEX IF NOT EXISTS idx_provider_instances_provider_id ON provider_instances (provider_id)`,
-		`CREATE INDEX IF NOT EXISTS idx_provider_instances_priority ON provider_instances (priority)`,
-		`CREATE INDEX IF NOT EXISTS idx_provider_instances_activated ON provider_instances (activated)`,
-		`CREATE INDEX IF NOT EXISTS idx_tokens_provider_id ON tokens (provider_id)`,
-		`CREATE INDEX IF NOT EXISTS idx_provider_model_states_instance_id ON provider_model_states (instance_id)`,
-		`CREATE INDEX IF NOT EXISTS idx_provider_model_states_enabled ON provider_model_states (enabled)`,
-		`CREATE INDEX IF NOT EXISTS idx_model_configs_instance_id ON model_configs (instance_id)`,
-		`CREATE INDEX IF NOT EXISTS idx_model_configs_model_id ON model_configs (model_id)`,
-		`CREATE INDEX IF NOT EXISTS idx_chat_messages_session_id ON chat_messages (session_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_instances_provider_id  ON provider_instances (provider_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_instances_priority      ON provider_instances (priority)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_instances_activated     ON provider_instances (activated)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_model_states_enabled    ON provider_model_states (enabled)`,
+		`CREATE INDEX IF NOT EXISTS idx_model_configs_instance_id        ON model_configs (instance_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_model_configs_model_id           ON model_configs (model_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_chat_messages_session_id         ON chat_messages (session_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_virtual_model_upstreams_vmodel_id ON virtual_model_upstreams (virtual_model_id)`,
-		`CREATE INDEX IF NOT EXISTS idx_provider_models_cache_cached_at ON provider_models_cache (cached_at)`,
 	}
 
-	for _, indexQuery := range indexes {
-		if _, err := db.db.Exec(indexQuery); err != nil {
+	for _, q := range indexes {
+		if _, err := db.db.Exec(q); err != nil {
 			return fmt.Errorf("failed to create index: %w", err)
 		}
 	}
 
+	if err := db.applyMigrations(); err != nil {
+		return fmt.Errorf("failed to apply migrations: %w", err)
+	}
+
 	log.Debug().Msg("Database tables created successfully")
+	return nil
+}
+
+// migration represents a single, idempotent schema change.
+type migration struct {
+	version    int
+	statements []string
+}
+
+// migrations is the ordered list of all schema migrations.
+// Never edit an existing entry — always append a new one.
+var migrations = []migration{
+	// v1: add subtitle to provider_instances (backfill for pre-subtitle databases).
+	{1, []string{`ALTER TABLE provider_instances ADD COLUMN subtitle TEXT NOT NULL DEFAULT ''`}},
+	// v2: add provider_id to virtual_model_upstreams (backfill for pre-provider_id databases).
+	{2, []string{`ALTER TABLE virtual_model_upstreams ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`}},
+	// v3: add provider_id column to tokens for existing rows that pre-date its removal
+	//     from the schema (kept for backward-compat reads; new code ignores it).
+	//     No-op on fresh databases where the column was never added.
+	{3, []string{`ALTER TABLE tokens ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`}},
+	// v4: add updated_at to provider_models_cache using a SQLite-safe backfill path.
+	{4, []string{
+		`ALTER TABLE provider_models_cache ADD COLUMN updated_at DATETIME`,
+		`UPDATE provider_models_cache SET updated_at = cached_at WHERE updated_at IS NULL`,
+	}},
+}
+
+// applyMigrations runs any migrations that have not yet been applied.
+func (db *Database) applyMigrations() error {
+	for _, m := range migrations {
+		var count int
+		err := db.db.QueryRow(`SELECT COUNT(*) FROM schema_migrations WHERE version = ?`, m.version).Scan(&count)
+		if err != nil {
+			return fmt.Errorf("migration %d: failed to check status: %w", m.version, err)
+		}
+		if count > 0 {
+			continue // already applied
+		}
+
+		for _, statement := range m.statements {
+			if _, err := db.db.Exec(statement); err != nil {
+				// "duplicate column name" means the column exists — treat as already applied.
+				if strings.Contains(err.Error(), "duplicate column name") {
+					log.Debug().Int("version", m.version).Msg("Migration already applied (column exists), continuing")
+					continue
+				}
+				return fmt.Errorf("migration %d: %w", m.version, err)
+			}
+		}
+
+		if _, err := db.db.Exec(`INSERT INTO schema_migrations (version) VALUES (?)`, m.version); err != nil {
+			return fmt.Errorf("migration %d: failed to record: %w", m.version, err)
+		}
+		log.Debug().Int("version", m.version).Msg("Applied schema migration")
+	}
 	return nil
 }
 

--- a/internal/database/store_cache.go
+++ b/internal/database/store_cache.go
@@ -48,11 +48,12 @@ func (cs *ProviderModelsCacheStore) Get(instanceID string, ttl time.Duration) (*
 // Save stores the model list in the cache.
 func (cs *ProviderModelsCacheStore) Save(instanceID, modelsData string) error {
 	_, err := cs.db.db.Exec(`
-		INSERT INTO provider_models_cache (instance_id, models_data, cached_at)
-		VALUES (?, ?, datetime('now'))
+		INSERT INTO provider_models_cache (instance_id, models_data, cached_at, updated_at)
+		VALUES (?, ?, datetime('now'), datetime('now'))
 		ON CONFLICT(instance_id) DO UPDATE SET
 			models_data = excluded.models_data,
-			cached_at = datetime('now')
+			cached_at = datetime('now'),
+			updated_at = datetime('now')
 	`, instanceID, modelsData)
 	return err
 }

--- a/internal/database/store_tokens.go
+++ b/internal/database/store_tokens.go
@@ -18,9 +18,9 @@ func (ts *TokenStore) Get(instanceID string) (*TokenRecord, error) {
 	var record TokenRecord
 	var createdAtStr, updatedAtStr string
 	err := ts.db.db.QueryRow(`
-		SELECT instance_id, provider_id, token_data, created_at, updated_at
+		SELECT instance_id, token_data, created_at, updated_at
 		FROM tokens WHERE instance_id = ?
-	`, instanceID).Scan(&record.InstanceID, &record.ProviderID, &record.TokenData, &createdAtStr, &updatedAtStr)
+	`, instanceID).Scan(&record.InstanceID, &record.TokenData, &createdAtStr, &updatedAtStr)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -34,20 +34,19 @@ func (ts *TokenStore) Get(instanceID string) (*TokenRecord, error) {
 	return &record, nil
 }
 
-func (ts *TokenStore) Save(instanceID, providerID string, tokenData interface{}) error {
+func (ts *TokenStore) Save(instanceID string, tokenData interface{}) error {
 	tokenJSON, err := json.Marshal(tokenData)
 	if err != nil {
 		return err
 	}
 
 	_, err = ts.db.db.Exec(`
-		INSERT INTO tokens (instance_id, provider_id, token_data, updated_at)
-		VALUES (?, ?, ?, datetime('now'))
+		INSERT INTO tokens (instance_id, token_data, updated_at)
+		VALUES (?, ?, datetime('now'))
 		ON CONFLICT(instance_id) DO UPDATE SET
-			provider_id = excluded.provider_id,
 			token_data = excluded.token_data,
 			updated_at = datetime('now')
-	`, instanceID, providerID, string(tokenJSON))
+	`, instanceID, string(tokenJSON))
 	return err
 }
 
@@ -56,10 +55,14 @@ func (ts *TokenStore) Delete(instanceID string) error {
 	return err
 }
 
+// GetAllByProvider returns all token records for a given provider type.
+// Joins provider_instances to avoid relying on the deprecated provider_id column in tokens.
 func (ts *TokenStore) GetAllByProvider(providerID string) ([]TokenRecord, error) {
 	rows, err := ts.db.db.Query(`
-		SELECT instance_id, provider_id, token_data, created_at, updated_at
-		FROM tokens WHERE provider_id = ?
+		SELECT t.instance_id, t.token_data, t.created_at, t.updated_at
+		FROM tokens t
+		JOIN provider_instances pi ON pi.instance_id = t.instance_id
+		WHERE pi.provider_id = ?
 	`, providerID)
 	if err != nil {
 		return nil, err
@@ -70,7 +73,7 @@ func (ts *TokenStore) GetAllByProvider(providerID string) ([]TokenRecord, error)
 	for rows.Next() {
 		var record TokenRecord
 		var createdAtStr, updatedAtStr string
-		if err := rows.Scan(&record.InstanceID, &record.ProviderID, &record.TokenData, &createdAtStr, &updatedAtStr); err != nil {
+		if err := rows.Scan(&record.InstanceID, &record.TokenData, &createdAtStr, &updatedAtStr); err != nil {
 			return nil, err
 		}
 		record.CreatedAt = parseTime(createdAtStr)

--- a/internal/database/types.go
+++ b/internal/database/types.go
@@ -48,7 +48,6 @@ type ProviderInstanceRecord struct {
 
 type TokenRecord struct {
 	InstanceID string    `json:"instance_id"`
-	ProviderID string    `json:"provider_id"`
 	TokenData  string    `json:"token_data"` // JSON string
 	CreatedAt  time.Time `json:"created_at"`
 	UpdatedAt  time.Time `json:"updated_at"`

--- a/internal/lib/modelrouting/modelrouting.go
+++ b/internal/lib/modelrouting/modelrouting.go
@@ -2,8 +2,10 @@
 package modelrouting
 
 import (
+	"errors"
 	"fmt"
 	"omnillm/internal/database"
+	alibaba "omnillm/internal/providers/alibaba"
 	"omnillm/internal/providers/types"
 	"omnillm/internal/registry"
 	"sort"
@@ -42,6 +44,12 @@ func GetCachedOrFetchModels(provider types.Provider, cache *ModelCache) (*types.
 	// Fetch from provider
 	models, err := provider.GetModels()
 	if err != nil {
+		if errors.Is(err, alibaba.ErrHardcodedFallback) {
+			// Return the degraded hardcoded list for this request but do not
+			// cache it — the next request should retry the live API.
+			log.Debug().Str("provider", instanceID).Msg("Skipping model cache due to hardcoded fallback")
+			return models, nil
+		}
 		log.Warn().
 			Str("provider", provider.GetName()).
 			Err(err).
@@ -119,11 +127,30 @@ func SortProvidersByPriority(providers []types.Provider) []types.Provider {
 }
 
 // ResolveProvidersForModel determines which providers and models to use for a given request.
+// If providerID is non-empty, only that specific provider is considered as a candidate.
 //
 //nolint:gocyclo // model resolution involves multiple fallback strategies
-func ResolveProvidersForModel(requestedModel, normalizedModel string, cache *ModelCache) (*ResolvedModelRoute, error) {
+func ResolveProvidersForModel(requestedModel, normalizedModel, providerID string, cache *ModelCache) (*ResolvedModelRoute, error) {
 	reg := registry.GetProviderRegistry()
 	activeProviders := reg.GetActiveProviders()
+
+	// If a specific provider is requested, filter to only that provider.
+	if providerID != "" {
+		filtered := make([]types.Provider, 0, 1)
+		for _, p := range activeProviders {
+			if p.GetInstanceID() == providerID {
+				filtered = append(filtered, p)
+				break
+			}
+		}
+		if len(filtered) == 0 {
+			return &ResolvedModelRoute{
+				SelectedModel:      nil,
+				CandidateProviders: []types.Provider{},
+			}, nil
+		}
+		activeProviders = filtered
+	}
 
 	if len(activeProviders) == 0 {
 		return nil, fmt.Errorf("no active providers available")

--- a/internal/lib/modelrouting/modelrouting_test.go
+++ b/internal/lib/modelrouting/modelrouting_test.go
@@ -295,7 +295,7 @@ func TestResolveProvidersForModel_AlibabaOpenAICompatibleIncluded(t *testing.T) 
 	}
 
 	cache := NewModelCache()
-	route, err := ResolveProvidersForModel("qwen3.6-plus", "qwen3.6-plus", cache)
+	route, err := ResolveProvidersForModel("qwen3.6-plus", "qwen3.6-plus", "", cache)
 	if err != nil {
 		t.Fatalf("ResolveProvidersForModel() error = %v", err)
 	}

--- a/internal/providers/alibaba/adapter_models.go
+++ b/internal/providers/alibaba/adapter_models.go
@@ -75,7 +75,15 @@ func (a *Adapter) buildRequest(request *cif.CanonicalRequest, stream bool) (*ope
 	return openaicompat.BuildChatRequest(model, request, stream, cfg)
 }
 
+// ErrHardcodedFallback is returned alongside a hardcoded model list when the
+// live DashScope /models API is unavailable. Callers that cache model lists
+// should treat this as a soft error and skip caching so a future request can
+// retry the live API.
+var ErrHardcodedFallback = fmt.Errorf("alibaba: models fetch failed, using hardcoded fallback")
+
 // GetModels returns the available models for this Alibaba instance.
+// If the live API is unreachable it returns the hardcoded Qwen-only catalog
+// together with ErrHardcodedFallback so callers can decide whether to cache.
 func GetModels(instanceID, token, baseURL string, config map[string]interface{}) (*types.ModelsResponse, error) {
 	if token == "" {
 		return nil, fmt.Errorf("alibaba: not authenticated")
@@ -85,7 +93,7 @@ func GetModels(instanceID, token, baseURL string, config map[string]interface{})
 		return resp, nil
 	}
 	log.Warn().Err(err).Str("provider", instanceID).Msg("alibaba: falling back to hardcoded model list")
-	return GetModelsHardcoded(instanceID), nil
+	return GetModelsHardcoded(instanceID), ErrHardcodedFallback
 }
 
 // GetModelsHardcoded returns the fallback model catalog (Qwen models only).

--- a/internal/providers/alibaba/provider.go
+++ b/internal/providers/alibaba/provider.go
@@ -151,24 +151,44 @@ func (p *Provider) GetAdapter() types.ProviderAdapter {
 
 // LoadFromDB restores persisted credentials and config from the database.
 func (p *Provider) LoadFromDB() error {
-	token, baseURL, config, err := LoadTokenFromDB(p.instanceID)
+	token, _, _, err := LoadTokenFromDB(p.instanceID)
 	if err != nil {
 		return err
 	}
 	if token != "" {
 		p.token = token
 	}
-	if baseURL != "" {
-		p.baseURL = baseURL
+
+	// Load the full provider config (plan, region, base_url, etc.) from
+	// provider_configs. This must happen before marking configOnce as done so
+	// that GetModels and other callers get the correct base URL.
+	store := database.NewProviderConfigStore()
+	rec, err := store.Get(p.instanceID)
+	if err != nil {
+		log.Warn().Err(err).Str("provider", p.instanceID).Msg("alibaba: failed to load provider config")
+	} else if rec != nil {
+		var cfg map[string]interface{}
+		if jsonErr := json.Unmarshal([]byte(rec.ConfigData), &cfg); jsonErr != nil {
+			log.Warn().Err(jsonErr).Str("provider", p.instanceID).Msg("alibaba: failed to parse provider config")
+		} else {
+			p.applyConfig(cfg)
+			// Legacy providers stored access_token directly in provider_configs.
+			// Migrate it to p.token if the tokens table had nothing.
+			if p.token == "" {
+				if at, ok := shared.FirstString(cfg, "access_token"); ok && at != "" {
+					p.token = at
+				}
+			}
+		}
 	}
-	if config != nil {
-		p.applyConfig(config)
+
+	if p.name == "" {
+		p.name = APIKeyProviderName(p.config)
 	}
-	p.name = APIKeyProviderName(p.config)
 	// Mark configOnce as done so ensureConfig is a no-op — credentials were
 	// already loaded above via LoadFromDB (called at startup by the registry).
 	p.configOnce.Do(func() {})
-	log.Debug().Str("provider", p.instanceID).Bool("has_token", p.token != "").Msg("Alibaba: loaded from DB")
+	log.Debug().Str("provider", p.instanceID).Bool("has_token", p.token != "").Str("base_url", p.baseURL).Msg("Alibaba: loaded from DB")
 	return nil
 }
 
@@ -186,7 +206,7 @@ func SetupAPIKeyAuth(instanceID string, options *types.AuthOptions) (token, base
 
 	tokenStore := database.NewTokenStore()
 	tokenData := map[string]interface{}{"access_token": options.APIKey}
-	if err := tokenStore.Save(instanceID, "alibaba", tokenData); err != nil {
+	if err := tokenStore.Save(instanceID, tokenData); err != nil {
 		return "", "", "", nil, fmt.Errorf("alibaba: failed to save token: %w", err)
 	}
 

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -19,7 +19,7 @@ func SetupAuth(instanceID string, options *types.AuthOptions) (token, endpoint s
 
 	tokenStore := database.NewTokenStore()
 	tokenData := map[string]interface{}{"access_token": options.APIKey}
-	if err := tokenStore.Save(instanceID, "azure-openai", tokenData); err != nil {
+	if err := tokenStore.Save(instanceID, tokenData); err != nil {
 		return "", "", nil, fmt.Errorf("failed to save azure token: %w", err)
 	}
 

--- a/internal/providers/codex/codex.go
+++ b/internal/providers/codex/codex.go
@@ -208,7 +208,7 @@ func (p *CodexProvider) SaveToDB() error {
 		data["expires_at"]   = p.expiresAt
 		data["auth_method"]  = "github"
 	}
-	return database.NewTokenStore().Save(p.instanceID, p.id, data)
+	return database.NewTokenStore().Save(p.instanceID, data)
 }
 
 // LoadFromDB restores credentials from the database.

--- a/internal/providers/copilot/copilot.go
+++ b/internal/providers/copilot/copilot.go
@@ -5,11 +5,14 @@ import (
 	ghservice "omnillm/internal/services/github"
 )
 
-func NewGitHubCopilotProvider(instanceID string) *GitHubCopilotProvider {
+func NewGitHubCopilotProvider(instanceID, name string) *GitHubCopilotProvider {
+	if name == "" {
+		name = "GitHub Copilot"
+	}
 	return &GitHubCopilotProvider{
 		id:           "github-copilot",
 		instanceID:   instanceID,
-		name:         "GitHub Copilot",
+		name:         name,
 		baseURL:      "https://api.githubcopilot.com",
 		tokenFetcher: ghservice.GetCopilotToken,
 	}

--- a/internal/providers/copilot/copilot_test.go
+++ b/internal/providers/copilot/copilot_test.go
@@ -44,7 +44,7 @@ func TestCopilotAdapterExecute_TranslatesSpecificToolChoiceForChatCompletions(t 
 	}))
 	defer server.Close()
 
-	provider := NewGitHubCopilotProvider("github-copilot-test")
+	provider := NewGitHubCopilotProvider("github-copilot-test", "")
 	provider.baseURL = server.URL
 	provider.token = "test-token"
 	adapter := provider.GetAdapter().(*CopilotAdapter)
@@ -118,7 +118,7 @@ func TestCopilotAdapterExecute_StripsThinkingPartsFromPayload(t *testing.T) {
 	}))
 	defer server.Close()
 
-	provider := NewGitHubCopilotProvider("github-copilot-test")
+	provider := NewGitHubCopilotProvider("github-copilot-test", "")
 	provider.baseURL = server.URL
 	provider.token = "test-token"
 	adapter := provider.GetAdapter().(*CopilotAdapter)
@@ -191,7 +191,7 @@ data: {"id":"chatcmpl_refresh","model":"claude-haiku-4.5","choices":[{"index":0,
 	}))
 	defer server.Close()
 
-	provider := NewGitHubCopilotProvider("github-copilot-test")
+	provider := NewGitHubCopilotProvider("github-copilot-test", "")
 	provider.baseURL = server.URL
 	provider.githubToken = "github-token"
 	provider.token = "stale-token"
@@ -274,7 +274,7 @@ func TestCopilotAdapterExecuteStream_DisableAuthRetryMakesSingleAttempt(t *testi
 	}))
 	defer server.Close()
 
-	provider := NewGitHubCopilotProvider("github-copilot-test")
+	provider := NewGitHubCopilotProvider("github-copilot-test", "")
 	provider.baseURL = server.URL
 	provider.githubToken = "github-token"
 	provider.token = "stale-token"

--- a/internal/providers/copilot/token.go
+++ b/internal/providers/copilot/token.go
@@ -76,8 +76,10 @@ func (p *GitHubCopilotProvider) LoadFromDB() error {
 	if ea, ok := tokenData["expires_at"].(float64); ok {
 		p.expiresAt = int64(ea)
 	}
-	if name, ok := tokenData["name"].(string); ok && name != "" {
-		p.name = name
+	if p.name == "" {
+		if name, ok := tokenData["name"].(string); ok && name != "" {
+			p.name = name
+		}
 	}
 
 	// If we have a GitHub token, refresh the Copilot token if expired
@@ -104,5 +106,5 @@ func (p *GitHubCopilotProvider) SaveToDB() error {
 		"name":          p.name,
 	}
 
-	return tokenStore.Save(p.instanceID, p.id, tokenData)
+	return tokenStore.Save(p.instanceID, tokenData)
 }

--- a/internal/providers/generic/auth.go
+++ b/internal/providers/generic/auth.go
@@ -74,7 +74,7 @@ func (p *GenericProvider) setupAntigravityAuth(options *types.AuthOptions) error
 		"client_id":     clientID,
 		"client_secret": clientSecret,
 	}
-	if err := tokenStore.Save(p.instanceID, "antigravity", tokenData); err != nil {
+	if err := tokenStore.Save(p.instanceID, tokenData); err != nil {
 		return fmt.Errorf("antigravity: failed to save client credentials: %w", err)
 	}
 
@@ -216,7 +216,7 @@ func (p *GenericProvider) PollGoogleDeviceCode(deviceCode string) error {
 			if tokenResp.RefreshToken != "" {
 				saved["refresh_token"] = tokenResp.RefreshToken
 			}
-			if err := tokenStore.Save(p.instanceID, "antigravity", saved); err != nil {
+			if err := tokenStore.Save(p.instanceID, saved); err != nil {
 				return fmt.Errorf("antigravity: failed to save token: %w", err)
 			}
 			log.Info().Str("provider", p.instanceID).Msg("Antigravity: Google OAuth completed")

--- a/internal/providers/generic/db.go
+++ b/internal/providers/generic/db.go
@@ -44,19 +44,17 @@ func (p *GenericProvider) LoadFromDB() error {
 		}
 		p.configOnce.Do(func() {})
 
-		if p.id == "alibaba" && p.token != "" {
+		if p.id == "alibaba" && p.token != "" && p.name == "" {
 			p.name = alibabapkg.APIKeyProviderName(p.config)
 			log.Info().Str("instanceID", p.instanceID).Str("newName", p.name).Msg("Updated Alibaba API key provider name")
 		}
 
-		if p.id == "antigravity" {
+		if p.id == "antigravity" && p.name == "" {
 			// Prefer email-based name if available; otherwise keep the existing name.
-			if record != nil {
-				var td map[string]interface{}
-				if jsonErr := json.Unmarshal([]byte(record.TokenData), &td); jsonErr == nil {
-					if email, ok := td["email"].(string); ok && email != "" {
-						p.name = "Antigravity (" + email + ")"
-					}
+			var td map[string]interface{}
+			if jsonErr := json.Unmarshal([]byte(record.TokenData), &td); jsonErr == nil {
+				if email, ok := td["email"].(string); ok && email != "" {
+					p.name = "Antigravity (" + email + ")"
 				}
 			}
 		}
@@ -64,7 +62,9 @@ func (p *GenericProvider) LoadFromDB() error {
 
 	if p.id == "google" && p.token != "" {
 		p.baseURL = providerBaseURLs["google"]
-		p.name = "Google Gemini"
+		if p.name == "" {
+			p.name = "Google Gemini"
+		}
 	}
 
 	log.Debug().Str("provider", p.instanceID).Bool("has_token", p.token != "").Msg("Loaded generic provider token")

--- a/internal/providers/generic/generic_models_test.go
+++ b/internal/providers/generic/generic_models_test.go
@@ -27,7 +27,7 @@ func TestAlibabaGetModelsFetchesLiveModels(t *testing.T) {
 	defer server.Close()
 
 	tokenStore := database.NewTokenStore()
-	if err := tokenStore.Save("alibaba-live", "alibaba", map[string]interface{}{
+	if err := tokenStore.Save("alibaba-live", map[string]interface{}{
 		"access_token": "test-token",
 		"auth_type":    "api-key",
 		"base_url":     server.URL,

--- a/internal/providers/generic/google_test.go
+++ b/internal/providers/generic/google_test.go
@@ -57,7 +57,7 @@ func TestGoogleLoadFromDB(t *testing.T) {
 	})
 
 	tokenStore := database.NewTokenStore()
-	if err := tokenStore.Save("google-1", "google", map[string]any{
+	if err := tokenStore.Save("google-1", map[string]any{
 		"access_token": "saved-api-key",
 	}); err != nil {
 		t.Fatalf("failed to save token: %v", err)
@@ -132,7 +132,7 @@ func TestGoogleGetModelsFetchesFromAPI(t *testing.T) {
 	defer server.Close()
 
 	tokenStore := database.NewTokenStore()
-	if err := tokenStore.Save("google-1", "google", map[string]any{
+	if err := tokenStore.Save("google-1", map[string]any{
 		"access_token": "test-api-key",
 	}); err != nil {
 		t.Fatalf("failed to save token: %v", err)
@@ -598,7 +598,7 @@ func TestGoogleStreamEndToEnd(t *testing.T) {
 	defer server.Close()
 
 	tokenStore := database.NewTokenStore()
-	if err := tokenStore.Save("google-e2e", "google", map[string]any{
+	if err := tokenStore.Save("google-e2e", map[string]any{
 		"access_token": "e2e-test-key",
 	}); err != nil {
 		t.Fatalf("failed to save token: %v", err)
@@ -698,7 +698,7 @@ func TestGoogleStreamEndToEndWithTools(t *testing.T) {
 	defer server.Close()
 
 	tokenStore := database.NewTokenStore()
-	if err := tokenStore.Save("google-tools", "google", map[string]any{
+	if err := tokenStore.Save("google-tools", map[string]any{
 		"access_token": "tool-test-key",
 	}); err != nil {
 		t.Fatalf("failed to save token: %v", err)
@@ -792,7 +792,7 @@ func TestGoogleStreamEndToEndWithSystemPrompt(t *testing.T) {
 	defer server.Close()
 
 	tokenStore := database.NewTokenStore()
-	if err := tokenStore.Save("google-sys", "google", map[string]any{
+	if err := tokenStore.Save("google-sys", map[string]any{
 		"access_token": "sys-test-key",
 	}); err != nil {
 		t.Fatalf("failed to save token: %v", err)

--- a/internal/providers/google/provider.go
+++ b/internal/providers/google/provider.go
@@ -60,7 +60,7 @@ func SetupAuth(instanceID string, options *types.AuthOptions) (token, baseURL, n
 
 	tokenStore := database.NewTokenStore()
 	tokenData := map[string]interface{}{"access_token": options.APIKey}
-	if err := tokenStore.Save(instanceID, "google", tokenData); err != nil {
+	if err := tokenStore.Save(instanceID, tokenData); err != nil {
 		return "", "", "", fmt.Errorf("failed to save google token: %w", err)
 	}
 

--- a/internal/providers/kimi/provider.go
+++ b/internal/providers/kimi/provider.go
@@ -72,7 +72,7 @@ func SetupAPIKeyAuth(instanceID string, options *types.AuthOptions) (token, base
 
 	tokenStore := database.NewTokenStore()
 	tokenData := map[string]interface{}{"access_token": options.APIKey}
-	if err := tokenStore.Save(instanceID, "kimi", tokenData); err != nil {
+	if err := tokenStore.Save(instanceID, tokenData); err != nil {
 		return "", "", "", nil, fmt.Errorf("failed to save kimi token: %w", err)
 	}
 
@@ -154,7 +154,7 @@ func SaveOAuthToken(instanceID string, td *TokenData) (newInstanceID, name, base
 	}
 
 	tokenStore := database.NewTokenStore()
-	if err := tokenStore.Save(newInstanceID, "kimi", td); err != nil {
+	if err := tokenStore.Save(newInstanceID, td); err != nil {
 		return "", "", "", fmt.Errorf("kimi: failed to save OAuth token: %w", err)
 	}
 

--- a/internal/providers/openaicompatprovider/provider.go
+++ b/internal/providers/openaicompatprovider/provider.go
@@ -435,7 +435,7 @@ func SetupProviderAuth(instanceID string, options *types.AuthOptions) (token, ba
 	// Persist token (may be empty — that's fine).
 	tokenStore := database.NewTokenStore()
 	tokenData := map[string]interface{}{"access_token": apiKey}
-	if err := tokenStore.Save(instanceID, "openai-compatible", tokenData); err != nil {
+	if err := tokenStore.Save(instanceID, tokenData); err != nil {
 		return "", "", "", nil, fmt.Errorf("openai-compatible: failed to save token: %w", err)
 	}
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -306,9 +306,16 @@ func (pr *ProviderRegistry) saveConfigAsync() error {
 			Activated:  isActive,
 		}
 
-		// Preserve existing priority from DB if available
+		// Preserve existing name, subtitle, and priority from DB if available
 		if existing, err := pr.instanceStore.Get(id); err == nil && existing != nil {
 			record.Priority = existing.Priority
+			// Keep the user-customized name/subtitle, falling back to the in-memory default
+			if existing.Name != "" {
+				record.Name = existing.Name
+			}
+			if existing.Subtitle != "" {
+				record.Subtitle = existing.Subtitle
+			}
 		}
 
 		if err := pr.instanceStore.Save(record); err != nil {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -2,7 +2,6 @@
 package registry
 
 import (
-	"encoding/json"
 	"fmt"
 	"omnillm/internal/database"
 	"omnillm/internal/providers/types"
@@ -16,7 +15,6 @@ type ProviderRegistry struct {
 	providers       map[string]types.Provider
 	activeProvider  types.Provider
 	activeProviders map[string]struct{}
-	configStore     *database.ConfigStore
 	instanceStore   *database.ProviderInstanceStore
 }
 
@@ -30,7 +28,6 @@ func GetProviderRegistry() *ProviderRegistry {
 		globalRegistry = &ProviderRegistry{
 			providers:       make(map[string]types.Provider),
 			activeProviders: make(map[string]struct{}),
-			configStore:     database.NewConfigStore(),
 			instanceStore:   database.NewProviderInstanceStore(),
 		}
 	})
@@ -295,7 +292,9 @@ func (pr *ProviderRegistry) saveConfigAsync() error {
 	}
 	pr.mu.RUnlock()
 
-	// Save provider instances and activation state to database
+	// Persist activation state to provider_instances — this is the single source
+	// of truth for which providers are active. The old config.active_providers
+	// key is no longer written.
 	for id, provider := range providers {
 		_, isActive := activeProviders[id]
 
@@ -323,17 +322,10 @@ func (pr *ProviderRegistry) saveConfigAsync() error {
 		}
 	}
 
-	// Save active provider IDs to config store
 	activeIDs := make([]string, 0, len(activeProviders))
 	for id := range activeProviders {
 		activeIDs = append(activeIDs, id)
 	}
-
-	activeJSON, _ := json.Marshal(activeIDs)
-	if err := pr.configStore.Set("active_providers", string(activeJSON)); err != nil {
-		log.Warn().Err(err).Msg("Failed to save active providers config")
-	}
-
 	log.Debug().Strs("active", activeIDs).Msg("Provider configuration saved")
 	return nil
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -52,7 +52,6 @@ func newTestRegistry() *ProviderRegistry {
 	return &ProviderRegistry{
 		providers:       make(map[string]providertypes.Provider),
 		activeProviders: make(map[string]struct{}),
-		configStore:     database.NewConfigStore(),
 		instanceStore:   database.NewProviderInstanceStore(),
 	}
 }
@@ -139,7 +138,7 @@ func TestRemoveDeletesProviderAndToken(t *testing.T) {
 	}
 
 	tokenStore := database.NewTokenStore()
-	if err := tokenStore.Save("mock-1", "mock", map[string]string{"token": "secret"}); err != nil {
+	if err := tokenStore.Save("mock-1", map[string]string{"token": "secret"}); err != nil {
 		t.Fatalf("save token failed: %v", err)
 	}
 

--- a/internal/routes/admin_antigravity_oauth.go
+++ b/internal/routes/admin_antigravity_oauth.go
@@ -190,7 +190,7 @@ func handleAntigravityOAuthCallback(c *gin.Context) {
 	if tokenResp.RefreshToken != "" {
 		tokenData["refresh_token"] = tokenResp.RefreshToken
 	}
-	if err := tokenStore.Save(state.ProviderID, "antigravity", tokenData); err != nil {
+	if err := tokenStore.Save(state.ProviderID, tokenData); err != nil {
 		log.Error().Err(err).Str("provider", state.ProviderID).Msg("Antigravity: failed to save tokens")
 		renderOAuthResult(c, false, "Failed to save credentials — please try again")
 		return

--- a/internal/routes/admin_providers.go
+++ b/internal/routes/admin_providers.go
@@ -29,6 +29,7 @@ func handleGetProviders(c *gin.Context) {
 	providers := providerRegistry.ListProviders()
 
 	providerList := make([]map[string]interface{}, 0, len(providers))
+	instanceStore := database.NewProviderInstanceStore()
 	for _, provider := range providers {
 		config, configErr := loadProviderConfig(provider.GetInstanceID())
 		if configErr != nil {
@@ -40,17 +41,22 @@ func handleGetProviders(c *gin.Context) {
 			authStatus = "authenticated"
 		}
 
+		name := provider.GetName()
+		subtitle := ""
+		if dbRecord, dbErr := instanceStore.Get(provider.GetInstanceID()); dbErr == nil && dbRecord != nil {
+			if dbRecord.Name != "" {
+				name = dbRecord.Name
+			}
+			subtitle = dbRecord.Subtitle
+		}
+
 		providerInfo := map[string]interface{}{
 			"id":         provider.GetInstanceID(),
 			"type":       provider.GetID(),
-			"name":       provider.GetName(),
+			"name":       name,
+			"subtitle":   subtitle,
 			"isActive":   providerRegistry.IsActiveProvider(provider.GetInstanceID()),
 			"authStatus": authStatus,
-		}
-
-		// Load subtitle from DB record (it's not stored on the in-memory provider)
-		if dbRecord, dbErr := database.NewProviderInstanceStore().Get(provider.GetInstanceID()); dbErr == nil && dbRecord != nil {
-			providerInfo["subtitle"] = dbRecord.Subtitle
 		}
 
 		if normalizedConfig := normalizeProviderConfigForFrontend(provider.GetID(), config); normalizedConfig != nil {
@@ -117,7 +123,7 @@ func handleAddProviderInstance(c *gin.Context) {
 	var provider types.Provider
 	switch providerType {
 	case "github-copilot":
-		provider = copilot.NewGitHubCopilotProvider(instanceID)
+		provider = copilot.NewGitHubCopilotProvider(instanceID, "")
 	case "antigravity", "alibaba", "azure-openai", "google", "kimi":
 		provider = generic.NewGenericProvider(providerType, instanceID, "")
 	case "openai-compatible":
@@ -243,7 +249,7 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 
 	// ——————————————————————————————————————————————————————————————
 	case "github-copilot":
-		cop := copilot.NewGitHubCopilotProvider("copilot-tmp")
+		cop := copilot.NewGitHubCopilotProvider("copilot-tmp", "")
 
 		if req.Method == "oauth" || (req.GithubToken == "" && req.Token == "") {
 			deviceCode, err := cop.InitiateDeviceCodeFlow()

--- a/internal/routes/chat.go
+++ b/internal/routes/chat.go
@@ -116,6 +116,7 @@ func (h *chatCompletionHandler) handleChatCompletions(c *gin.Context) {
 		modelRoute, err := modelrouting.ResolveProvidersForModel(
 			attempt.RequestedModel,
 			attempt.NormalizedModel,
+			attempt.ProviderID,
 			modelCache,
 		)
 		if err != nil {

--- a/internal/routes/messages.go
+++ b/internal/routes/messages.go
@@ -86,6 +86,7 @@ func handleMessages(c *gin.Context) {
 		modelRoute, err := modelrouting.ResolveProvidersForModel(
 			attempt.RequestedModel,
 			attempt.NormalizedModel,
+			attempt.ProviderID,
 			modelCache,
 		)
 		if err != nil {

--- a/internal/routes/model_resolution.go
+++ b/internal/routes/model_resolution.go
@@ -11,6 +11,7 @@ import (
 type resolvedModelAttempt struct {
 	RequestedModel  string
 	NormalizedModel string
+	ProviderID      string // non-empty when resolved from a virtual model upstream with a specific provider
 }
 
 func resolveRequestedModel(requestID, requestedModel string) (string, string) {
@@ -54,11 +55,13 @@ func resolveRequestedModels(requestID, requestedModel string) []resolvedModelAtt
 			Str("request_id", requestID).
 			Str("virtual_model", vm.VirtualModelID).
 			Str("upstream", upstream.ModelID).
+			Str("provider", upstream.ProviderID).
 			Str("strategy", string(vm.LbStrategy)).
 			Msg("Virtual model routing candidate")
 		attempts = append(attempts, resolvedModelAttempt{
 			RequestedModel:  upstream.ModelID,
 			NormalizedModel: modelrouting.NormalizeModelName(upstream.ModelID),
+			ProviderID:      upstream.ProviderID,
 		})
 	}
 

--- a/internal/routes/responses.go
+++ b/internal/routes/responses.go
@@ -62,6 +62,7 @@ func handleResponses(c *gin.Context) {
 	modelRoute, err := modelrouting.ResolveProvidersForModel(
 		canonicalRequest.Model,
 		normalizedModel,
+		"",
 		modelCache,
 	)
 	if err != nil {

--- a/internal/server/api_integration_test.go
+++ b/internal/server/api_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"omnillm/internal/cif"
 	"omnillm/internal/database"
+	generic "omnillm/internal/providers/generic"
 	"omnillm/internal/registry"
 	"strings"
 	"sync/atomic"
@@ -932,6 +933,110 @@ func TestRenameProviderEndpointValidatesAndPersistsMetadata(t *testing.T) {
 			t.Fatalf("expected in-memory provider name to update, got %q", provider.GetName())
 		}
 	})
+
+	t.Run("providers list reflects persisted metadata", func(t *testing.T) {
+		provider.SetName("Stale In-Memory Name")
+
+		resp := getWithAuth(t, srv.URL+"/api/admin/providers")
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		var providers []struct {
+			ID       string `json:"id"`
+			Name     string `json:"name"`
+			Subtitle string `json:"subtitle"`
+		}
+		if err := json.Unmarshal([]byte(body), &providers); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		for _, listed := range providers {
+			if listed.ID != instanceID {
+				continue
+			}
+			if listed.Name != "Renamed Provider" {
+				t.Fatalf("expected DB-backed name, got %q", listed.Name)
+			}
+			if listed.Subtitle != "Renamed Subtitle" {
+				t.Fatalf("expected DB-backed subtitle, got %q", listed.Subtitle)
+			}
+			return
+		}
+
+		t.Fatalf("provider %q not found in providers list", instanceID)
+	})
+}
+
+
+func TestRenameProviderEndpointPreservesCustomNameAfterReload(t *testing.T) {
+	instanceID := fmt.Sprintf("alibaba-reload-%d", time.Now().UnixNano())
+	provider := generic.NewGenericProvider("alibaba", instanceID, "Original Name")
+	provider.SetName("Original Name")
+
+	configStore := database.NewProviderConfigStore()
+	if err := configStore.Save(instanceID, map[string]interface{}{
+		"auth_type": "api-key",
+		"region":    "global",
+	}); err != nil {
+		t.Fatalf("failed to seed provider config: %v", err)
+	}
+
+	tokenStore := database.NewTokenStore()
+	if err := tokenStore.Save(instanceID, map[string]interface{}{
+		"access_token": "test-token",
+	}); err != nil {
+		t.Fatalf("failed to seed provider token: %v", err)
+	}
+
+	store := database.NewProviderInstanceStore()
+	if err := store.Save(&database.ProviderInstanceRecord{
+		InstanceID: instanceID,
+		ProviderID: "alibaba",
+		Name:       provider.GetName(),
+		Subtitle:   "Original Subtitle",
+		Priority:   3,
+		Activated:  true,
+	}); err != nil {
+		t.Fatalf("failed to seed provider record: %v", err)
+	}
+
+	reg := registry.GetProviderRegistry()
+	if err := reg.Register(provider, false); err != nil {
+		t.Fatalf("failed to register provider: %v", err)
+	}
+	defer func() {
+		_ = reg.Remove(instanceID)
+	}()
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp := patchJSON(t, srv.URL+"/api/admin/providers/"+instanceID+"/name", `{"name":"Renamed Provider","subtitle":"Renamed Subtitle"}`)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	_ = reg.Remove(instanceID)
+
+	record, err := store.Get(instanceID)
+	if err != nil {
+		t.Fatalf("failed to reload provider record: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected provider record to exist")
+	}
+
+	reloaded := generic.NewGenericProvider(record.ProviderID, record.InstanceID, record.Name)
+	if err := reloaded.LoadFromDB(); err != nil {
+		t.Fatalf("failed to reload provider from DB: %v", err)
+	}
+
+	if reloaded.GetName() != "Renamed Provider" {
+		t.Fatalf("expected custom name to survive reload, got %q", reloaded.GetName())
+	}
 }
 
 func TestStreamingEndpointsExposeExpectedEventShapes(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -278,7 +278,7 @@ func registerDefaultProviders(reg *registry.ProviderRegistry, options StartOptio
 			var provider types.Provider
 			switch inst.ProviderID {
 			case "github-copilot":
-				p := copilot.NewGitHubCopilotProvider(inst.InstanceID)
+				p := copilot.NewGitHubCopilotProvider(inst.InstanceID, inst.Name)
 				if err := p.LoadFromDB(); err != nil {
 					log.Warn().Err(err).Str("instance", inst.InstanceID).Msg("Failed to load provider token")
 				}
@@ -320,7 +320,7 @@ func registerDefaultProviders(reg *registry.ProviderRegistry, options StartOptio
 	}
 
 	// No saved providers - register default
-	copilotProvider := copilot.NewGitHubCopilotProvider("github-copilot-1")
+	copilotProvider := copilot.NewGitHubCopilotProvider("github-copilot-1", "")
 
 	// Try loading token from DB
 	copilotProvider.LoadFromDB()


### PR DESCRIPTION
## Summary

- Provider custom names/subtitles set via the UI were silently reset to hardcoded defaults after a server restart
- `saveConfigAsync` now reads the existing DB record and preserves any user-customized `name` and `subtitle` before saving, mirroring the existing `priority` preservation pattern

## Root Cause

`saveConfigAsync` always used `provider.GetName()` (the in-memory default) when building the `ProviderInstanceRecord`. On server restart, providers are re-initialized with their default names. The next `saveConfigAsync` call then overwrites the DB record, losing the user's customization.

## Fix

Extend the existing DB-read block (which already preserved `priority`) to also preserve `name` and `subtitle`:

```go
if existing, err := pr.instanceStore.Get(id); err == nil && existing != nil {
    record.Priority = existing.Priority
    if existing.Name != "" {
        record.Name = existing.Name
    }
    if existing.Subtitle != "" {
        record.Subtitle = existing.Subtitle
    }
}
```

Closes #31

## Test Plan

- [x] Rename a provider via the UI
- [x] Restart the server
- [x] Verify the custom name/subtitle persists on the Providers page