### PR TITLE
Fix virtual model routing when /models API is unavailable; preserve Alibaba base_url from token

### DIFF
--- a/internal/lib/modelrouting/modelrouting.go
+++ b/internal/lib/modelrouting/modelrouting.go
@@ -156,6 +156,24 @@ func ResolveProvidersForModel(requestedModel, normalizedModel, providerID string
 		return nil, fmt.Errorf("no active providers available")
 	}
 
+	// When a specific provider is pinned (e.g. from a virtual model upstream), skip
+	// the model-list check entirely. The /models API may be unavailable or may not
+	// list the model (e.g. DeepSeek stripped from the Alibaba hardcoded fallback when
+	// /models returns 401), but the provider can still serve the model. Synthesise a
+	// passthrough entry so the request proceeds.
+	if providerID != "" && len(activeProviders) == 1 {
+		provider := activeProviders[0]
+		pinned := types.Model{
+			ID:       requestedModel,
+			Name:     requestedModel,
+			Provider: provider.GetInstanceID(),
+		}
+		return &ResolvedModelRoute{
+			SelectedModel:      &pinned,
+			CandidateProviders: []types.Provider{provider},
+		}, nil
+	}
+
 	modelsByProvider, err := GetEnabledModelsByProvider(activeProviders, cache)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get models by provider: %w", err)

--- a/internal/providers/alibaba/provider.go
+++ b/internal/providers/alibaba/provider.go
@@ -151,7 +151,7 @@ func (p *Provider) GetAdapter() types.ProviderAdapter {
 
 // LoadFromDB restores persisted credentials and config from the database.
 func (p *Provider) LoadFromDB() error {
-	token, _, _, err := LoadTokenFromDB(p.instanceID)
+	token, tokenBaseURL, _, err := LoadTokenFromDB(p.instanceID)
 	if err != nil {
 		return err
 	}
@@ -179,6 +179,14 @@ func (p *Provider) LoadFromDB() error {
 					p.token = at
 				}
 			}
+		}
+	} else {
+		// No provider_configs row — legacy provider that only has a tokens row.
+		// The token record may carry a base_url (stored by old auth flows); use
+		// it so the correct regional endpoint is preserved instead of falling
+		// back to the hardcoded global default.
+		if tokenBaseURL != "" {
+			p.baseURL = EnsureBaseURL(tokenBaseURL)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Two fixes for virtual model routing reliability and Alibaba provider migration:

1. **Virtual model routing bypasses model-list check** — When a virtual model has an explicit `provider_id` + `model_id` upstream, `ResolveProvidersForModel` now skips the model-list check and synthesises a passthrough model entry. This prevents 502 errors when the provider's `/models` API is unavailable or doesn't list the model (e.g. DeepSeek stripped from the Alibaba hardcoded fallback on 401).

2. **Alibaba LoadFromDB preserves token base_url** — Legacy Alibaba providers that stored `base_url` in the `tokens` table but not in `provider_configs` no longer lose their regional endpoint on restart. Previously the `base_url` return value from `LoadTokenFromDB` was discarded (`token, _, _, err`), causing `p.baseURL` to fall back to the global default and 401 on China-region keys.

## Test plan

- [x] `go test ./...` — all 24 packages pass
- [x] `go build ./...` — compiles cleanly

Fixes #34
