### PR TITLE
refactor: rename vmodel → virtualmodel across CLI, API, frontend, and lib

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,18 +21,24 @@ import { ConfigPage } from "@/pages/ConfigPage"
 import { LoggingPage } from "@/pages/LoggingPage"
 import { ProvidersPage } from "@/pages/ProvidersPage"
 import { AboutPage } from "@/pages/SettingsPage"
-import { VmodelPage } from "@/pages/VmodelPage"
+import { VirtualModelPage } from "@/pages/VirtualModelPage"
 
 const log = createLogger("app")
 
-type Tab = "providers" | "chat" | "logging" | "vmodel" | "config" | "about"
+type Tab =
+  | "providers"
+  | "chat"
+  | "logging"
+  | "virtualmodel"
+  | "config"
+  | "about"
 type Theme = "dark" | "light"
 
 const NAV_ITEMS = [
   { id: "providers" as const, label: "Providers", icon: Database },
   { id: "chat" as const, label: "Chat", icon: MessageSquare },
   { id: "logging" as const, label: "Logging", icon: BarChart3 },
-  { id: "vmodel" as const, label: "Virtual Models", icon: Layers },
+  { id: "virtualmodel" as const, label: "Virtual Models", icon: Layers },
   { id: "config" as const, label: "ToolConfig", icon: SlidersHorizontal },
   { id: "about" as const, label: "About", icon: Settings },
 ]
@@ -54,7 +60,7 @@ function isTab(value: string): value is Tab {
     value === "providers"
     || value === "chat"
     || value === "logging"
-    || value === "vmodel"
+    || value === "virtualmodel"
     || value === "config"
     || value === "about"
   )
@@ -460,7 +466,9 @@ export default function AppComponent() {
                 {tab === "providers" && <ProvidersPage showToast={showToast} />}
                 {tab === "chat" && <ChatPage showToast={showToast} />}
                 {tab === "logging" && <LoggingPage showToast={showToast} />}
-                {tab === "vmodel" && <VmodelPage showToast={showToast} />}
+                {tab === "virtualmodel" && (
+                  <VirtualModelPage showToast={showToast} />
+                )}
                 {tab === "config" && <ConfigPage showToast={showToast} />}
                 {tab === "about" && <AboutPage showToast={showToast} />}
               </div>

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -818,28 +818,28 @@ export interface VirtualModelPayload {
 }
 
 export const listVirtualModels = () =>
-  apiFetch<{ data: Array<VirtualModel> }>("/api/admin/vmodels").then(
+  apiFetch<{ data: Array<VirtualModel> }>("/api/admin/virtualmodels").then(
     (r) => r.data,
   )
 
 export const getVirtualModel = (id: string) =>
-  apiFetch<VirtualModel>(`/api/admin/vmodels/${encodeURIComponent(id)}`)
+  apiFetch<VirtualModel>(`/api/admin/virtualmodels/${encodeURIComponent(id)}`)
 
 export const createVirtualModel = (payload: VirtualModelPayload) =>
-  apiFetch<VirtualModel>("/api/admin/vmodels", {
+  apiFetch<VirtualModel>("/api/admin/virtualmodels", {
     method: "POST",
     body: JSON.stringify(payload),
   })
 
 export const updateVirtualModel = (id: string, payload: VirtualModelPayload) =>
-  apiFetch<VirtualModel>(`/api/admin/vmodels/${encodeURIComponent(id)}`, {
+  apiFetch<VirtualModel>(`/api/admin/virtualmodels/${encodeURIComponent(id)}`, {
     method: "PUT",
     body: JSON.stringify(payload),
   })
 
 export const deleteVirtualModel = (id: string) =>
   apiFetch<{ deleted: string }>(
-    `/api/admin/vmodels/${encodeURIComponent(id)}`,
+    `/api/admin/virtualmodels/${encodeURIComponent(id)}`,
     {
       method: "DELETE",
     },

--- a/frontend/src/lib/virtualmodels.ts
+++ b/frontend/src/lib/virtualmodels.ts
@@ -1,0 +1,94 @@
+import type {
+  LbStrategy,
+  Model,
+  Provider,
+  VirtualModel,
+  VirtualModelUpstream,
+} from "@/api"
+
+interface UpstreamResolutionContext {
+  providers: Array<Provider>
+  providerModels: Record<string, Array<Model>>
+  providerNameById: Record<string, string>
+}
+
+export function detectModelFamily(modelId?: string | null) {
+  if (!modelId) return null
+
+  const normalized = modelId.toLowerCase()
+  if (normalized.includes("claude")) return "Claude"
+  if (
+    normalized.includes("gpt")
+    || normalized.includes("o1")
+    || normalized.includes("o3")
+  ) {
+    return "OpenAI"
+  }
+  if (normalized.includes("qwen")) return "Qwen"
+  if (normalized.includes("gemini")) return "Gemini"
+
+  return null
+}
+
+export function resolveUpstreamProvider(
+  upstream: Pick<VirtualModelUpstream, "provider_id" | "model_id">,
+  context: UpstreamResolutionContext,
+) {
+  const { providers, providerModels, providerNameById } = context
+  const matchingProviders = providers.filter((provider) =>
+    (providerModels[provider.id] ?? []).some(
+      (model) => model.id === upstream.model_id,
+    ),
+  )
+  const inferredProviderId =
+    matchingProviders.length === 1 ? matchingProviders[0].id : undefined
+  const providerId = upstream.provider_id || inferredProviderId
+
+  let providerLabel = "Unknown legacy provider"
+  if (providerId) {
+    providerLabel = providerNameById[providerId] ?? providerId
+  } else if (matchingProviders.length > 1) {
+    providerLabel = "Ambiguous legacy provider"
+  }
+
+  return {
+    providerLabel,
+    isLegacy: !upstream.provider_id,
+  }
+}
+
+function formatVirtualModelRouteLabel(
+  lbStrategy: LbStrategy,
+  upstream: { weight?: number },
+  index: number,
+): string {
+  switch (lbStrategy) {
+    case "priority": {
+      return index === 0 ? "primary" : `fallback ${index}`
+    }
+    case "weighted": {
+      return `weight ${upstream.weight ?? 1}`
+    }
+    case "round-robin": {
+      return `round-robin ${index + 1}`
+    }
+    case "random": {
+      return `random ${index + 1}`
+    }
+    default: {
+      return `random ${index + 1}`
+    }
+  }
+}
+
+export function formatVirtualModelUpstreamSummary(
+  vm: Pick<VirtualModel, "lb_strategy" | "upstreams">,
+  context: UpstreamResolutionContext,
+): string {
+  return vm.upstreams
+    .map((upstream, index) => {
+      const { providerLabel } = resolveUpstreamProvider(upstream, context)
+      return `${formatVirtualModelRouteLabel(vm.lb_strategy, upstream, index)}: ${providerLabel} · ${upstream.model_id}`
+    })
+    .join("\n")
+}

--- a/frontend/src/pages/VirtualModelPage.tsx
+++ b/frontend/src/pages/VirtualModelPage.tsx
@@ -1,0 +1,1196 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition,@typescript-eslint/no-floating-promises,no-nested-ternary */
+import { useState, useEffect, useCallback } from "react"
+
+import {
+  listVirtualModels,
+  listProviders,
+  getProviderModels,
+  createVirtualModel,
+  updateVirtualModel,
+  deleteVirtualModel,
+  type VirtualModel,
+  type VirtualModelUpstream,
+  type LbStrategy,
+  type Provider,
+  type Model,
+} from "@/api"
+import { createLogger } from "@/lib/logger"
+import {
+  detectModelFamily,
+  formatVirtualModelUpstreamSummary,
+  resolveUpstreamProvider,
+} from "@/lib/virtualmodels"
+
+const _log = createLogger("vmodel-page")
+
+interface Props {
+  showToast: (msg: string, type?: "success" | "error") => void
+}
+
+const LB_STRATEGIES: Array<{ value: LbStrategy; label: string; hint: string }> =
+  [
+    {
+      value: "round-robin",
+      label: "Round-robin",
+      hint: "Cycle through upstreams in order",
+    },
+    {
+      value: "random",
+      label: "Random",
+      hint: "Pick a random upstream each request",
+    },
+    {
+      value: "priority",
+      label: "Priority / failover",
+      hint: "Highest-priority upstream first",
+    },
+    {
+      value: "weighted",
+      label: "Weighted",
+      hint: "Distribute by numeric weight",
+    },
+  ]
+
+const emptyForm = (): Partial<VirtualModel> => ({
+  virtual_model_id: "",
+  name: "",
+  description: "",
+  api_shape: "openai",
+  lb_strategy: "round-robin",
+  enabled: true,
+  upstreams: [],
+})
+
+interface UpstreamRow extends VirtualModelUpstream {
+  selectedProviderId: string
+}
+
+const emptyUpstreamRow = (): UpstreamRow => ({
+  model_id: "",
+  weight: 1,
+  priority: 0,
+  selectedProviderId: "",
+})
+
+export function VirtualModelPage({ showToast }: Props) {
+  const [vmodels, setVmodels] = useState<Array<VirtualModel>>([])
+  const [loading, setLoading] = useState(true)
+  const [selected, setSelected] = useState<VirtualModel | null>(null)
+  const [form, setForm] = useState<Partial<VirtualModel>>(emptyForm())
+  const [upstreamRows, setUpstreamRows] = useState<Array<UpstreamRow>>([
+    emptyUpstreamRow(),
+  ])
+  const [saving, setSaving] = useState(false)
+  const [isNew, setIsNew] = useState(false)
+
+  const [providers, setProviders] = useState<Array<Provider>>([])
+  const [providerModels, setProviderModels] = useState<
+    Record<string, Array<Model>>
+  >({})
+  const [catalogueLoading, setCatalogueLoading] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await listVirtualModels()
+      setVmodels(data)
+    } catch {
+      showToast("Failed to load virtual models", "error")
+    } finally {
+      setLoading(false)
+    }
+  }, [showToast])
+
+  const loadCatalogue = useCallback(async () => {
+    setCatalogueLoading(true)
+    try {
+      const provList = await listProviders()
+      setProviders(provList)
+      const entries = await Promise.all(
+        provList.map(async (p) => {
+          try {
+            const res = await getProviderModels(p.id)
+            return [p.id, res.models ?? []] as [string, Array<Model>]
+          } catch {
+            return [p.id, []] as [string, Array<Model>]
+          }
+        }),
+      )
+      setProviderModels(Object.fromEntries(entries))
+    } catch {
+      showToast("Failed to load providers", "error")
+    } finally {
+      setCatalogueLoading(false)
+    }
+  }, [showToast])
+
+  useEffect(() => {
+    load()
+    loadCatalogue()
+  }, [load, loadCatalogue])
+
+  const setRowProvider = (i: number, providerId: string) => {
+    setUpstreamRows((prev) =>
+      prev.map((r, idx) =>
+        idx === i ? { ...r, selectedProviderId: providerId, model_id: "" } : r,
+      ),
+    )
+  }
+
+  const setRowModel = (i: number, modelId: string) => {
+    setUpstreamRows((prev) =>
+      prev.map((r, idx) => (idx === i ? { ...r, model_id: modelId } : r)),
+    )
+  }
+
+  const setRowNum = (
+    i: number,
+    field: "weight" | "priority",
+    value: number,
+  ) => {
+    setUpstreamRows((prev) =>
+      prev.map((r, idx) => (idx === i ? { ...r, [field]: value } : r)),
+    )
+  }
+
+  const addRow = () => setUpstreamRows((prev) => [...prev, emptyUpstreamRow()])
+  const removeRow = (i: number) =>
+    setUpstreamRows((prev) => prev.filter((_, idx) => idx !== i))
+
+  const openNew = () => {
+    setSelected(null)
+    setIsNew(true)
+    setForm(emptyForm())
+    setUpstreamRows([emptyUpstreamRow()])
+  }
+
+  const openEdit = (vm: VirtualModel) => {
+    setSelected(vm)
+    setIsNew(false)
+    setForm({ ...vm })
+    const rows: Array<UpstreamRow> = (
+      vm.upstreams.length > 0 ?
+        vm.upstreams
+      : [{ model_id: "", weight: 1, priority: 0 }]).map((u) => {
+      const selectedProviderId =
+        u.provider_id
+        ?? providers.find((p) =>
+          (providerModels[p.id] ?? []).some((m) => m.id === u.model_id),
+        )?.id
+        ?? ""
+      return { ...u, selectedProviderId }
+    })
+    setUpstreamRows(rows)
+  }
+
+  const closeForm = () => {
+    setSelected(null)
+    setIsNew(false)
+    setForm(emptyForm())
+    setUpstreamRows([emptyUpstreamRow()])
+  }
+
+  const handleSave = async () => {
+    if (!form.virtual_model_id?.trim()) {
+      showToast("Model ID is required", "error")
+      return
+    }
+    if (!form.name?.trim()) {
+      showToast("Display name is required", "error")
+      return
+    }
+    if (!form.lb_strategy) {
+      showToast("LB strategy is required", "error")
+      return
+    }
+
+    const filledRows = upstreamRows.filter((r) => r.model_id.trim())
+    if (filledRows.length === 0) {
+      showToast("At least one upstream model is required", "error")
+      return
+    }
+
+    setSaving(true)
+    try {
+      const payload = {
+        virtual_model_id: form.virtual_model_id,
+        name: form.name,
+        description: form.description ?? "",
+        api_shape: form.api_shape ?? "openai",
+        lb_strategy: form.lb_strategy,
+        enabled: form.enabled ?? true,
+        upstreams: filledRows.map((r) => ({
+          provider_id: r.selectedProviderId || undefined,
+          model_id: r.model_id,
+          weight: r.weight ?? 1,
+          priority: r.priority ?? 0,
+        })),
+      }
+      if (isNew) {
+        await createVirtualModel(payload as VirtualModel)
+        showToast("Virtual model created", "success")
+      } else {
+        await updateVirtualModel(form.virtual_model_id, payload as VirtualModel)
+        showToast("Virtual model updated", "success")
+      }
+      closeForm()
+      await load()
+    } catch (err: unknown) {
+      showToast(
+        err instanceof Error ? err.message : "Failed to save virtual model",
+        "error",
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!globalThis.confirm(`Delete virtual model "${id}"?`)) return
+    try {
+      await deleteVirtualModel(id)
+      showToast("Deleted", "success")
+      if (selected?.virtual_model_id === id) closeForm()
+      await load()
+    } catch {
+      showToast("Failed to delete", "error")
+    }
+  }
+
+  const showWeight = form.lb_strategy === "weighted"
+  const showPriority = form.lb_strategy === "priority"
+  const isEditing = isNew || selected !== null
+
+  const providerNameById = Object.fromEntries(
+    providers.map((provider) => [provider.id, provider.name || provider.id]),
+  )
+  const upstreamResolutionContext = {
+    providers,
+    providerModels,
+    providerNameById,
+  }
+
+  return (
+    <div
+      style={{ padding: 24, display: "flex", flexDirection: "column", gap: 24 }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: 16,
+          flexWrap: "wrap",
+        }}
+      >
+        <div>
+          <h1
+            style={{
+              margin: 0,
+              fontFamily: "var(--font-display)",
+              fontSize: 28,
+              fontWeight: 700,
+              color: "var(--color-text)",
+              letterSpacing: "-0.03em",
+            }}
+          >
+            Virtual Models
+          </h1>
+          <p
+            style={{
+              margin: "8px 0 0",
+              color: "var(--color-text-secondary)",
+              fontSize: 14,
+              lineHeight: 1.5,
+              maxWidth: 720,
+            }}
+          >
+            Create stable model aliases and route requests across multiple
+            upstream providers.
+          </p>
+        </div>
+        <button className="btn btn-primary" onClick={openNew}>
+          + New Virtual Model
+        </button>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns:
+            isEditing ? "minmax(320px, 380px) minmax(0, 1fr)" : "1fr",
+          gap: 24,
+          alignItems: "start",
+        }}
+      >
+        <section className="panel" style={{ padding: 20 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 16,
+              gap: 12,
+            }}
+          >
+            <div>
+              <div
+                style={{
+                  fontSize: 16,
+                  fontWeight: 600,
+                  color: "var(--color-text)",
+                }}
+              >
+                Configured models
+              </div>
+              <div
+                style={{
+                  fontSize: 12,
+                  color: "var(--color-text-tertiary)",
+                  marginTop: 4,
+                }}
+              >
+                {vmodels.length} virtual model{vmodels.length !== 1 ? "s" : ""}
+              </div>
+            </div>
+          </div>
+
+          {loading ?
+            <div style={emptyStateStyle}>Loading virtual models…</div>
+          : vmodels.length === 0 ?
+            <div style={emptyStateStyle}>
+              No virtual models yet. Click <strong>+ New Virtual Model</strong>{" "}
+              to create one.
+            </div>
+          : <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+              {vmodels.map((vm) => {
+                const isSelected =
+                  selected?.virtual_model_id === vm.virtual_model_id
+                const virtualFamily = detectModelFamily(vm.virtual_model_id)
+                const primaryUpstreamFamily =
+                  vm.upstreams.length > 0 ?
+                    detectModelFamily(vm.upstreams[0].model_id)
+                  : null
+                const hasFamilyMismatch = Boolean(
+                  virtualFamily
+                    && primaryUpstreamFamily
+                    && virtualFamily !== primaryUpstreamFamily,
+                )
+                const upstreamSummary = formatVirtualModelUpstreamSummary(
+                  vm,
+                  upstreamResolutionContext,
+                )
+                const showVmWeight = vm.lb_strategy === "weighted"
+                const showVmPriority = vm.lb_strategy === "priority"
+                return (
+                  <div
+                    key={vm.virtual_model_id}
+                    onClick={() => openEdit(vm)}
+                    className={`panel${isSelected ? " panel-active" : ""}`}
+                    title={upstreamSummary || undefined}
+                    style={{
+                      textAlign: "left",
+                      padding: 16,
+                      background:
+                        isSelected ?
+                          "var(--color-blue-fill)"
+                        : "var(--color-bg-elevated)",
+                      cursor: "pointer",
+                      transition: "all 0.15s var(--ease)",
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "flex-start",
+                        justifyContent: "space-between",
+                        gap: 12,
+                      }}
+                    >
+                      <div style={{ minWidth: 0, flex: 1 }}>
+                        <div
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 13,
+                            fontWeight: 600,
+                            color: "var(--color-text)",
+                            marginBottom: 6,
+                          }}
+                        >
+                          {vm.virtual_model_id}
+                        </div>
+                        <div
+                          style={{
+                            fontSize: 13,
+                            color: "var(--color-text-secondary)",
+                            marginBottom: 8,
+                          }}
+                        >
+                          {vm.name}
+                        </div>
+                        <div
+                          style={{
+                            display: "flex",
+                            flexWrap: "wrap",
+                            gap: 6,
+                            fontSize: 10,
+                            color: "var(--color-text-tertiary)",
+                            marginBottom: 8,
+                          }}
+                        >
+                          <Badge>{vm.lb_strategy}</Badge>
+                          <Badge>{vm.api_shape}</Badge>
+                          <Badge>
+                            {vm.upstreams.length} upstream
+                            {vm.upstreams.length !== 1 ? "s" : ""}
+                          </Badge>
+                          <Badge tone={vm.enabled ? "green" : "neutral"}>
+                            {vm.enabled ? "enabled" : "disabled"}
+                          </Badge>
+                          {hasFamilyMismatch && (
+                            <Badge tone="amber">family mismatch</Badge>
+                          )}
+                        </div>
+                        {hasFamilyMismatch && (
+                          <div style={warningBoxStyle}>
+                            Virtual model looks like{" "}
+                            <strong>{virtualFamily}</strong> but primary
+                            upstream routes to{" "}
+                            <strong>{primaryUpstreamFamily}</strong>.
+                          </div>
+                        )}
+                        <div
+                          style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 4,
+                            fontSize: 11,
+                            color: "var(--color-text-secondary)",
+                            marginBottom: 8,
+                          }}
+                        >
+                          {vm.upstreams.map((upstream, index) => {
+                            const { providerLabel, isLegacy } =
+                              resolveUpstreamProvider(
+                                upstream,
+                                upstreamResolutionContext,
+                              )
+                            return (
+                              <div
+                                key={`${vm.virtual_model_id}-${index}`}
+                                style={{ display: "flex", gap: 6, minWidth: 0 }}
+                              >
+                                <span
+                                  style={{
+                                    color: "var(--color-text-tertiary)",
+                                    flexShrink: 0,
+                                  }}
+                                >
+                                  {index + 1}.
+                                </span>
+                                <span
+                                  style={{
+                                    minWidth: 0,
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                    whiteSpace: "nowrap",
+                                  }}
+                                  title={`${providerLabel} · ${upstream.model_id}${showVmWeight ? ` · weight ${upstream.weight ?? 1}` : ""}${showVmPriority ? ` · priority ${upstream.priority ?? 0}` : ""}`}
+                                >
+                                  {providerLabel}
+                                  {" · "}
+                                  <span
+                                    style={{ fontFamily: "var(--font-mono)" }}
+                                  >
+                                    {upstream.model_id}
+                                  </span>
+                                  {showVmWeight && (
+                                    <span
+                                      style={{
+                                        color: "var(--color-text-tertiary)",
+                                      }}
+                                    >{` · w${upstream.weight ?? 1}`}</span>
+                                  )}
+                                  {showVmPriority && (
+                                    <span
+                                      style={{
+                                        color: "var(--color-text-tertiary)",
+                                      }}
+                                    >{` · p${upstream.priority ?? 0}`}</span>
+                                  )}
+                                  {isLegacy && (
+                                    <span style={{ marginLeft: 6 }}>
+                                      <Badge tone="amber">legacy</Badge>
+                                    </span>
+                                  )}
+                                </span>
+                              </div>
+                            )
+                          })}
+                        </div>
+                        <div
+                          style={{
+                            display: "grid",
+                            gridTemplateColumns:
+                              "repeat(auto-fit, minmax(120px, 1fr))",
+                            gap: 6,
+                          }}
+                        >
+                          <MetaItem
+                            label="Updated"
+                            value={formatTimestamp(vm.updated_at)}
+                            compact
+                          />
+                          <MetaItem
+                            label="Description"
+                            value={vm.description || "—"}
+                            compact
+                          />
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        className="btn btn-icon btn-icon-ghost btn-icon-danger"
+                        title={`Delete ${vm.virtual_model_id}`}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleDelete(vm.virtual_model_id)
+                        }}
+                      >
+                        <svg
+                          width="13"
+                          height="13"
+                          viewBox="0 0 14 14"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.8"
+                          strokeLinecap="round"
+                        >
+                          <path d="M2 3.5h10M5.5 3.5V2.5a.5.5 0 01.5-.5h2a.5.5 0 01.5.5v1M5.5 6v4M8.5 6v4M3 3.5l.7 7a1 1 0 001 .9h4.6a1 1 0 001-.9l.7-7" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          }
+        </section>
+
+        {isEditing && (
+          <section className="panel" style={{ padding: 20 }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+                marginBottom: 20,
+              }}
+            >
+              <div>
+                <div
+                  style={{
+                    fontSize: 18,
+                    fontWeight: 600,
+                    color: "var(--color-text)",
+                  }}
+                >
+                  {isNew ?
+                    "New Virtual Model"
+                  : selected?.name || selected?.virtual_model_id}
+                </div>
+                <div
+                  style={{
+                    fontSize: 12,
+                    color: "var(--color-text-tertiary)",
+                    marginTop: 4,
+                  }}
+                >
+                  {isNew ?
+                    "Create a new routed model alias"
+                  : `Editing ${selected?.virtual_model_id}`}
+                </div>
+              </div>
+              <button className="btn btn-ghost btn-sm" onClick={closeForm}>
+                Close
+              </button>
+            </div>
+
+            <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+              <div style={sectionStyle}>
+                <div style={sectionTitleStyle}>Basics</div>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+                    gap: 10,
+                  }}
+                >
+                  <MetaItem
+                    label="Virtual model ID"
+                    value={form.virtual_model_id || "—"}
+                    mono
+                  />
+                  <MetaItem
+                    label="API shape"
+                    value={form.api_shape || "openai"}
+                  />
+                  <MetaItem
+                    label="Strategy"
+                    value={form.lb_strategy || "round-robin"}
+                  />
+                  <MetaItem
+                    label="Upstreams"
+                    value={String(
+                      upstreamRows.filter((row) => row.model_id.trim()).length,
+                    )}
+                  />
+                </div>
+                <div
+                  style={{ display: "flex", flexDirection: "column", gap: 6 }}
+                >
+                  <div style={sectionTitleStyle}>Current routing</div>
+                  <div style={sectionHintStyle}>
+                    This virtual model currently routes to these exact upstream
+                    model ids.
+                  </div>
+                  {(() => {
+                    const summaryVirtualFamily = detectModelFamily(
+                      form.virtual_model_id,
+                    )
+                    const summaryPrimaryFamily =
+                      upstreamRows[0]?.model_id ?
+                        detectModelFamily(upstreamRows[0].model_id)
+                      : null
+                    const summaryMismatch = Boolean(
+                      summaryVirtualFamily
+                        && summaryPrimaryFamily
+                        && summaryVirtualFamily !== summaryPrimaryFamily,
+                    )
+                    return summaryMismatch ?
+                        <div style={warningBoxStyle}>
+                          Virtual model looks like{" "}
+                          <strong>{summaryVirtualFamily}</strong> but primary
+                          upstream routes to{" "}
+                          <strong>{summaryPrimaryFamily}</strong>.
+                        </div>
+                      : null
+                  })()}
+                  <div
+                    style={{ display: "flex", flexDirection: "column", gap: 6 }}
+                  >
+                    {upstreamRows
+                      .filter((row) => row.model_id.trim())
+                      .map((row, index) => {
+                        const providerLabel =
+                          row.selectedProviderId ?
+                            (providerNameById[row.selectedProviderId]
+                            ?? row.selectedProviderId)
+                          : row.provider_id ?
+                            (providerNameById[row.provider_id]
+                            ?? row.provider_id)
+                          : "Legacy provider not resolved"
+                        const routeLabel =
+                          form.lb_strategy === "priority" ?
+                            index === 0 ?
+                              "Primary"
+                            : `Fallback ${index}`
+                          : form.lb_strategy === "weighted" ?
+                            `Weight ${row.weight ?? 1}`
+                          : form.lb_strategy === "round-robin" ?
+                            `Round-robin ${index + 1}`
+                          : `Random ${index + 1}`
+                        return (
+                          <div key={`summary-${index}`} style={routingRowStyle}>
+                            <span style={routingLabelStyle}>{routeLabel}</span>
+                            <span
+                              style={{
+                                minWidth: 0,
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                              }}
+                            >
+                              {providerLabel}
+                              {" · "}
+                              <span style={{ fontFamily: "var(--font-mono)" }}>
+                                {row.model_id}
+                              </span>
+                              {form.lb_strategy === "priority" && (
+                                <span
+                                  style={{
+                                    color: "var(--color-text-tertiary)",
+                                  }}
+                                >{` · p${row.priority ?? 0}`}</span>
+                              )}
+                              {form.lb_strategy === "weighted" && (
+                                <span
+                                  style={{
+                                    color: "var(--color-text-tertiary)",
+                                  }}
+                                >{` · w${row.weight ?? 1}`}</span>
+                              )}
+                            </span>
+                          </div>
+                        )
+                      })}
+                  </div>
+                </div>
+                <div style={formGridStyle}>
+                  <Field
+                    label="Model ID"
+                    hint="Unique identifier exposed via /v1/models"
+                  >
+                    <input
+                      className="sys-input"
+                      value={form.virtual_model_id ?? ""}
+                      onChange={(e) =>
+                        setForm((f) => ({
+                          ...f,
+                          virtual_model_id: e.target.value,
+                        }))
+                      }
+                      disabled={!isNew}
+                      placeholder="e.g. claude-mythos-5.0"
+                    />
+                  </Field>
+
+                  <Field label="Display name">
+                    <input
+                      className="sys-input"
+                      value={form.name ?? ""}
+                      onChange={(e) =>
+                        setForm((f) => ({ ...f, name: e.target.value }))
+                      }
+                      placeholder="My Virtual Model"
+                    />
+                  </Field>
+
+                  <Field label="Description" hint="Optional">
+                    <input
+                      className="sys-input"
+                      value={form.description ?? ""}
+                      onChange={(e) =>
+                        setForm((f) => ({ ...f, description: e.target.value }))
+                      }
+                      placeholder="What this virtual model does"
+                    />
+                  </Field>
+
+                  <Field label="Load-balancing strategy">
+                    <select
+                      className="sys-select"
+                      value={form.lb_strategy ?? "round-robin"}
+                      onChange={(e) =>
+                        setForm((f) => ({
+                          ...f,
+                          lb_strategy: e.target.value as LbStrategy,
+                        }))
+                      }
+                    >
+                      {LB_STRATEGIES.map((s) => (
+                        <option key={s.value} value={s.value}>
+                          {s.label} — {s.hint}
+                        </option>
+                      ))}
+                    </select>
+                  </Field>
+                </div>
+
+                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <label className="sys-label" style={{ marginBottom: 0 }}>
+                    Enabled
+                  </label>
+                  <input
+                    type="checkbox"
+                    checked={form.enabled ?? true}
+                    onChange={(e) =>
+                      setForm((f) => ({ ...f, enabled: e.target.checked }))
+                    }
+                    style={{ width: 16, height: 16, cursor: "pointer" }}
+                  />
+                </div>
+              </div>
+
+              <div style={sectionStyle}>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 12,
+                    marginBottom: 14,
+                  }}
+                >
+                  <div>
+                    <div style={sectionTitleStyle}>Upstream models</div>
+                    <div style={sectionHintStyle}>
+                      Choose provider/model pairs that this virtual model can
+                      route to.
+                    </div>
+                  </div>
+                  <button className="btn btn-ghost btn-sm" onClick={addRow}>
+                    + Add upstream
+                  </button>
+                </div>
+
+                {catalogueLoading && (
+                  <div
+                    style={{
+                      ...emptyStateStyle,
+                      padding: 12,
+                      marginBottom: 12,
+                    }}
+                  >
+                    Loading providers…
+                  </div>
+                )}
+
+                <div
+                  style={{ display: "flex", flexDirection: "column", gap: 12 }}
+                >
+                  {upstreamRows.map((row, i) => {
+                    const availableModels =
+                      row.selectedProviderId ?
+                        (providerModels[row.selectedProviderId] ?? [])
+                      : []
+
+                    return (
+                      <div key={i} style={upstreamCardStyle}>
+                        <div
+                          style={upstreamGridStyle(showWeight, showPriority)}
+                        >
+                          <Field label="Provider">
+                            <select
+                              className="sys-select"
+                              value={row.selectedProviderId}
+                              onChange={(e) =>
+                                setRowProvider(i, e.target.value)
+                              }
+                            >
+                              <option value="">— provider —</option>
+                              {providers.map((p) => (
+                                <option key={p.id} value={p.id}>
+                                  {p.name || p.id}
+                                </option>
+                              ))}
+                            </select>
+                          </Field>
+
+                          <Field label="Model">
+                            <select
+                              className="sys-select"
+                              value={row.model_id}
+                              onChange={(e) => setRowModel(i, e.target.value)}
+                              disabled={!row.selectedProviderId}
+                            >
+                              <option value="">— model —</option>
+                              {availableModels.map((m) => (
+                                <option key={m.id} value={m.id}>
+                                  {m.name || m.id}
+                                </option>
+                              ))}
+                            </select>
+                          </Field>
+
+                          {showWeight && (
+                            <Field label="Weight">
+                              <input
+                                className="sys-input"
+                                type="number"
+                                min={1}
+                                value={row.weight}
+                                onChange={(e) =>
+                                  setRowNum(i, "weight", Number(e.target.value))
+                                }
+                              />
+                            </Field>
+                          )}
+
+                          {showPriority && (
+                            <Field label="Priority">
+                              <input
+                                className="sys-input"
+                                type="number"
+                                min={0}
+                                value={row.priority}
+                                onChange={(e) =>
+                                  setRowNum(
+                                    i,
+                                    "priority",
+                                    Number(e.target.value),
+                                  )
+                                }
+                              />
+                            </Field>
+                          )}
+                        </div>
+
+                        <div
+                          style={{
+                            display: "flex",
+                            justifyContent: "flex-end",
+                            marginTop: 12,
+                          }}
+                        >
+                          <button
+                            className="btn btn-ghost btn-sm"
+                            onClick={() => removeRow(i)}
+                            disabled={upstreamRows.length === 1}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+
+                {(showWeight || showPriority) && (
+                  <div style={sectionHintStyle}>
+                    {showWeight && "Weight: higher value = more traffic. "}
+                    {showPriority
+                      && "Priority: lower number = higher priority (0 = first choice)."}
+                  </div>
+                )}
+              </div>
+
+              <div
+                style={{
+                  display: "flex",
+                  gap: 10,
+                  justifyContent: "flex-end",
+                  flexWrap: "wrap",
+                }}
+              >
+                {!isNew && selected && (
+                  <button
+                    className="btn btn-ghost"
+                    onClick={() => handleDelete(selected.virtual_model_id)}
+                  >
+                    Delete
+                  </button>
+                )}
+                <button className="btn btn-ghost" onClick={closeForm}>
+                  Cancel
+                </button>
+                <button
+                  className="btn btn-primary"
+                  onClick={handleSave}
+                  disabled={saving}
+                >
+                  {saving ?
+                    "Saving…"
+                  : isNew ?
+                    "Create"
+                  : "Save"}
+                </button>
+              </div>
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <label className="sys-label">
+        {label}
+        {hint && (
+          <span
+            style={{
+              fontWeight: 400,
+              marginLeft: 6,
+              color: "var(--color-text-tertiary)",
+            }}
+          >
+            — {hint}
+          </span>
+        )}
+      </label>
+      {children}
+    </div>
+  )
+}
+
+function Badge({
+  children,
+  tone = "neutral",
+}: {
+  children: React.ReactNode
+  tone?: "neutral" | "green" | "amber"
+}) {
+  return (
+    <span
+      style={{
+        fontSize: 11,
+        padding: "2px 8px",
+        borderRadius: 999,
+        fontWeight: 600,
+        background:
+          tone === "green" ? "rgba(48,209,88,0.12)"
+          : tone === "amber" ? "rgba(255,159,10,0.12)"
+          : "rgba(255,255,255,0.06)",
+        color:
+          tone === "green" ? "var(--color-green)"
+          : tone === "amber" ? "var(--color-orange)"
+          : "var(--color-text-tertiary)",
+        border:
+          tone === "green" ? "1px solid rgba(48,209,88,0.2)"
+          : tone === "amber" ? "1px solid rgba(255,159,10,0.2)"
+          : "1px solid var(--color-separator)",
+      }}
+    >
+      {children}
+    </span>
+  )
+}
+
+function MetaItem({
+  label,
+  value,
+  mono = false,
+  compact = false,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+  compact?: boolean
+}) {
+  return (
+    <div
+      style={{
+        padding: compact ? "8px 10px" : "10px 12px",
+        borderRadius: "var(--radius-md)",
+        border: "1px solid var(--color-separator)",
+        background: "rgba(255,255,255,0.03)",
+      }}
+    >
+      <div
+        style={{
+          fontSize: compact ? 10 : 11,
+          color: "var(--color-text-tertiary)",
+          marginBottom: 4,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: compact ? 11 : 13,
+          color: "var(--color-text)",
+          fontFamily: mono ? "var(--font-mono)" : "var(--font-text)",
+          wordBreak: "break-word",
+          lineHeight: 1.35,
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+function formatTimestamp(value?: string) {
+  if (!value) return "—"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
+const warningBoxStyle: React.CSSProperties = {
+  padding: "8px 10px",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid rgba(255,159,10,0.2)",
+  background: "rgba(255,159,10,0.08)",
+  color: "var(--color-orange)",
+  fontSize: 11,
+  lineHeight: 1.4,
+  marginBottom: 8,
+}
+
+const routingRowStyle: React.CSSProperties = {
+  display: "flex",
+  gap: 8,
+  minWidth: 0,
+  padding: "8px 10px",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid var(--color-separator)",
+  background: "rgba(255,255,255,0.03)",
+  fontSize: 12,
+  color: "var(--color-text-secondary)",
+}
+
+const routingLabelStyle: React.CSSProperties = {
+  color: "var(--color-text-tertiary)",
+  flexShrink: 0,
+  width: 84,
+  fontSize: 11,
+}
+
+const emptyStateStyle: React.CSSProperties = {
+  padding: 24,
+  borderRadius: "var(--radius-lg)",
+  border: "1px dashed var(--color-separator)",
+  textAlign: "center",
+  color: "var(--color-text-tertiary)",
+  fontSize: 13,
+}
+
+const sectionStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 14,
+  padding: 16,
+  borderRadius: "var(--radius-lg)",
+  border: "1px solid var(--color-separator)",
+  background: "rgba(255,255,255,0.03)",
+}
+
+const sectionTitleStyle: React.CSSProperties = {
+  fontSize: 14,
+  fontWeight: 600,
+  color: "var(--color-text)",
+}
+
+const sectionHintStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "var(--color-text-tertiary)",
+  marginTop: 4,
+}
+
+const formGridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+  gap: 14,
+}
+
+const upstreamCardStyle: React.CSSProperties = {
+  padding: 14,
+  borderRadius: "var(--radius-lg)",
+  border: "1px solid var(--color-separator)",
+  background: "var(--color-bg-elevated)",
+}
+
+function upstreamGridStyle(
+  showWeight: boolean,
+  showPriority: boolean,
+): React.CSSProperties {
+  return {
+    display: "grid",
+    gridTemplateColumns: `minmax(180px, 1fr) minmax(220px, 1.2fr)${showWeight ? " 110px" : ""}${showPriority ? " 110px" : ""}`,
+    gap: 12,
+    alignItems: "start",
+  }
+}

--- a/internal/commands/chat.go
+++ b/internal/commands/chat.go
@@ -1,15 +1,423 @@
 package commands
 
 import (
+	"bufio"
+	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 var ChatCmd = &cobra.Command{
 	Use:   "chat",
-	Short: "Interactive chat mode",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Chat command not implemented yet")
+	Short: "Interactive chat or manage chat sessions",
+	Long: `Start an interactive chat session or manage saved sessions.
+
+Running 'omnillm chat' without subcommands launches an interactive REPL
+that sends messages to the active provider via the proxy.`,
+	RunE: runInteractiveChat,
+}
+
+var chatSessionsCmd = &cobra.Command{
+	Use:   "sessions",
+	Short: "Manage saved chat sessions",
+}
+
+func init() {
+	// sessions subcommands
+	chatSessionsCmd.AddCommand(chatSessionsListCmd)
+
+	chatSessionsCreateCmd.Flags().String("title", "", "Session title")
+	chatSessionsCreateCmd.Flags().String("model", "", "Model ID to use for the session")
+	chatSessionsCreateCmd.Flags().String("api-shape", "openai", "API shape (openai|anthropic)")
+	chatSessionsCmd.AddCommand(chatSessionsCreateCmd)
+
+	chatSessionsCmd.AddCommand(chatSessionsGetCmd)
+
+	chatSessionsRenameCmd.Flags().String("title", "", "New title (required)")
+	chatSessionsCmd.AddCommand(chatSessionsRenameCmd)
+
+	chatSessionsDeleteCmd.Flags().BoolP("all", "a", false, "Delete all sessions")
+	chatSessionsDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation")
+	chatSessionsCmd.AddCommand(chatSessionsDeleteCmd)
+
+	ChatCmd.AddCommand(chatSessionsCmd)
+
+	// send subcommand
+	chatSendCmd.Flags().String("role", "user", "Message role: user|assistant|system")
+	ChatCmd.AddCommand(chatSendCmd)
+
+	// interactive flags
+	ChatCmd.Flags().String("model", "", "Model to use for the chat session")
+	ChatCmd.Flags().String("session", "", "Resume an existing session by ID")
+}
+
+// ─── sessions list ────────────────────────────────────────────────────────────
+
+var chatSessionsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List chat sessions",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/chat/sessions")
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return err
+		}
+		sessions, _ := resp["sessions"].([]interface{})
+		if len(sessions) == 0 {
+			fmt.Println("No chat sessions.")
+			return nil
+		}
+
+		fmt.Printf("%-36s  %-30s  %-30s  %s\n", "SESSION ID", "TITLE", "MODEL", "MESSAGES")
+		fmt.Println(strings.Repeat("─", 110))
+		for _, s := range sessions {
+			session, _ := s.(map[string]interface{})
+			id, _ := session["id"].(string)
+			title, _ := session["title"].(string)
+			model, _ := session["model_id"].(string)
+			msgs, _ := session["message_count"].(float64)
+			fmt.Printf("%-36s  %-30s  %-30s  %.0f\n",
+				padRight(id, 36), padRight(title, 30), padRight(model, 30), msgs)
+		}
+		return nil
 	},
+}
+
+// ─── sessions create ──────────────────────────────────────────────────────────
+
+var chatSessionsCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new chat session",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		title, _ := cmd.Flags().GetString("title")
+		model, _ := cmd.Flags().GetString("model")
+		apiShape, _ := cmd.Flags().GetString("api-shape")
+
+		body := map[string]interface{}{
+			"title":     title,
+			"model_id":  model,
+			"api_shape": apiShape,
+		}
+		c := NewClient(cmd)
+		data, err := c.Post("/api/admin/chat/sessions", body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err == nil {
+			if sid, ok := resp["session_id"].(string); ok {
+				SuccessMsg("Session created: %s", sid)
+				return nil
+			}
+		}
+		SuccessMsg("Session created.")
+		return nil
+	},
+}
+
+// ─── sessions get ─────────────────────────────────────────────────────────────
+
+var chatSessionsGetCmd = &cobra.Command{
+	Use:   "get <session-id>",
+	Short: "Show a chat session and its messages",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/chat/sessions/" + args[0])
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+
+		var session map[string]interface{}
+		if err := json.Unmarshal(data, &session); err != nil {
+			return err
+		}
+		title, _ := session["title"].(string)
+		model, _ := session["model_id"].(string)
+		fmt.Printf("Session: %s\n", args[0])
+		fmt.Printf("  Title: %s\n", title)
+		fmt.Printf("  Model: %s\n", model)
+
+		if msgs, ok := session["messages"].([]interface{}); ok && len(msgs) > 0 {
+			fmt.Printf("\nMessages (%d):\n", len(msgs))
+			fmt.Println(strings.Repeat("─", 60))
+			for _, m := range msgs {
+				msg, _ := m.(map[string]interface{})
+				role, _ := msg["role"].(string)
+				content, _ := msg["content"].(string)
+				ts, _ := msg["created_at"].(string)
+				if len(ts) > 10 {
+					ts = ts[:10]
+				}
+				fmt.Printf("[%s] %s: %s\n", ts, strings.ToUpper(role), content)
+			}
+		} else {
+			fmt.Println("\nNo messages.")
+		}
+		return nil
+	},
+}
+
+// ─── sessions rename ──────────────────────────────────────────────────────────
+
+var chatSessionsRenameCmd = &cobra.Command{
+	Use:   "rename <session-id> <new-title>",
+	Short: "Rename a chat session",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		body := map[string]string{"title": args[1]}
+		data, err := c.Put("/api/admin/chat/sessions/"+args[0], body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Session '%s' renamed.", args[0])
+		return nil
+	},
+}
+
+// ─── sessions delete ──────────────────────────────────────────────────────────
+
+var chatSessionsDeleteCmd = &cobra.Command{
+	Use:   "delete [session-id]",
+	Short: "Delete a chat session (or all with --all)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		all, _ := cmd.Flags().GetBool("all")
+		yes, _ := cmd.Flags().GetBool("yes")
+		c := NewClient(cmd)
+
+		if all {
+			if !yes && !Confirm("Delete all chat sessions?") {
+				fmt.Println("Cancelled.")
+				return nil
+			}
+			data, err := c.Delete("/api/admin/chat/sessions")
+			if err != nil {
+				return err
+			}
+			if c.IsJSON() {
+				c.PrintJSON(data)
+				return nil
+			}
+			SuccessMsg("All sessions deleted.")
+			return nil
+		}
+
+		if len(args) == 0 {
+			return fmt.Errorf("provide a session-id or use --all")
+		}
+		if !yes && !Confirm(fmt.Sprintf("Delete session '%s'?", args[0])) {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+		data, err := c.Delete("/api/admin/chat/sessions/" + args[0])
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Session '%s' deleted.", args[0])
+		return nil
+	},
+}
+
+// ─── send ─────────────────────────────────────────────────────────────────────
+
+var chatSendCmd = &cobra.Command{
+	Use:   "send <session-id> <message>",
+	Short: "Append a message to a chat session",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		role, _ := cmd.Flags().GetString("role")
+		c := NewClient(cmd)
+		body := map[string]string{
+			"role":    role,
+			"content": args[1],
+		}
+		data, err := c.Post("/api/admin/chat/sessions/"+args[0]+"/messages", body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err == nil {
+			if msgID, ok := resp["message_id"].(string); ok {
+				SuccessMsg("Message added: %s", msgID)
+				return nil
+			}
+		}
+		SuccessMsg("Message added.")
+		return nil
+	},
+}
+
+// ─── interactive REPL ────────────────────────────────────────────────────────
+
+func runInteractiveChat(cmd *cobra.Command, args []string) error {
+	c := NewClient(cmd)
+	model, _ := cmd.Flags().GetString("model")
+	existingSession, _ := cmd.Flags().GetString("session")
+
+	// Determine session ID
+	sessionID := existingSession
+	if sessionID == "" {
+		// Create a new session
+		title := "CLI session"
+		body := map[string]interface{}{
+			"title":     title,
+			"model_id":  model,
+			"api_shape": "openai",
+		}
+		data, err := c.Post("/api/admin/chat/sessions", body)
+		if err != nil {
+			return fmt.Errorf("create session: %w", err)
+		}
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return err
+		}
+		sid, ok := resp["session_id"].(string)
+		if !ok {
+			return fmt.Errorf("server did not return a session_id")
+		}
+		sessionID = sid
+		fmt.Printf("Started session: %s\n", sessionID)
+	} else {
+		fmt.Printf("Resuming session: %s\n", sessionID)
+	}
+
+	fmt.Println("Type your message and press Enter. Type /quit or /exit to quit.")
+	fmt.Println()
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("You: ")
+		if !scanner.Scan() {
+			break
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if line == "/quit" || line == "/exit" || line == "exit" || line == "quit" {
+			fmt.Println("Goodbye.")
+			break
+		}
+
+		// Store user message
+		msgBody := map[string]string{"role": "user", "content": line}
+		if _, err := c.Post("/api/admin/chat/sessions/"+sessionID+"/messages", msgBody); err != nil {
+			ErrorMsg("store message: %v", err)
+			continue
+		}
+
+		// Send to /v1/chat/completions for a real LLM response
+		// Build a minimal OpenAI-style request using all session messages
+		sessionData, err := c.Get("/api/admin/chat/sessions/" + sessionID)
+		if err != nil {
+			ErrorMsg("load session: %v", err)
+			continue
+		}
+		var session map[string]interface{}
+		if err := json.Unmarshal(sessionData, &session); err != nil {
+			ErrorMsg("parse session: %v", err)
+			continue
+		}
+
+		// Collect messages
+		type chatMsg struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		}
+		var messages []chatMsg
+		if msgs, ok := session["messages"].([]interface{}); ok {
+			for _, m := range msgs {
+				msg, _ := m.(map[string]interface{})
+				role, _ := msg["role"].(string)
+				content, _ := msg["content"].(string)
+				messages = append(messages, chatMsg{Role: role, Content: content})
+			}
+		}
+
+		reqModel := model
+		if reqModel == "" {
+			if mid, ok := session["model_id"].(string); ok && mid != "" {
+				reqModel = mid
+			} else {
+				reqModel = "gpt-4"
+			}
+		}
+
+		completionBody := map[string]interface{}{
+			"model":    reqModel,
+			"messages": messages,
+			"stream":   false,
+		}
+
+		respData, err := c.Post("/v1/chat/completions", completionBody)
+		if err != nil {
+			ErrorMsg("completion: %v", err)
+			continue
+		}
+
+		var completion map[string]interface{}
+		if err := json.Unmarshal(respData, &completion); err != nil {
+			fmt.Println(string(respData))
+			continue
+		}
+
+		// Extract assistant reply
+		assistantContent := ""
+		if choices, ok := completion["choices"].([]interface{}); ok && len(choices) > 0 {
+			choice, _ := choices[0].(map[string]interface{})
+			if message, ok := choice["message"].(map[string]interface{}); ok {
+				assistantContent, _ = message["content"].(string)
+			}
+		}
+
+		if assistantContent == "" {
+			fmt.Println("(no response)")
+			continue
+		}
+
+		fmt.Printf("Assistant: %s\n\n", assistantContent)
+
+		// Store assistant reply in session
+		aBody := map[string]string{"role": "assistant", "content": assistantContent}
+		if _, err := c.Post("/api/admin/chat/sessions/"+sessionID+"/messages", aBody); err != nil {
+			// Non-fatal — just log
+			ErrorMsg("store assistant message: %v", err)
+		}
+	}
+
+	return scanner.Err()
 }

--- a/internal/commands/client.go
+++ b/internal/commands/client.go
@@ -1,0 +1,194 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Client is a lightweight HTTP client for the OmniLLM admin API.
+type Client struct {
+	BaseURL    string
+	APIKey     string
+	OutputMode string
+	http       *http.Client
+}
+
+// NewClient builds a Client from cobra persistent flags and environment variables.
+func NewClient(cmd *cobra.Command) *Client {
+	server := os.Getenv("OMNILLM_SERVER")
+	if v, err := cmd.Root().PersistentFlags().GetString("server"); err == nil && v != "" {
+		server = v
+	}
+	if server == "" {
+		server = "http://127.0.0.1:5005"
+	}
+	server = strings.TrimRight(server, "/")
+
+	apiKey := os.Getenv("OMNILLM_API_KEY")
+	if v, err := cmd.Root().PersistentFlags().GetString("api-key"); err == nil && v != "" {
+		apiKey = v
+	}
+
+	output := "table"
+	if v, err := cmd.Root().PersistentFlags().GetString("output"); err == nil && v != "" {
+		output = v
+	}
+
+	return &Client{
+		BaseURL:    server,
+		APIKey:     apiKey,
+		OutputMode: output,
+		http:       &http.Client{},
+	}
+}
+
+func (c *Client) newRequest(method, path string, body io.Reader) (*http.Request, error) {
+	url := c.BaseURL + path
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	}
+	return req, nil
+}
+
+func (c *Client) do(method, path string, bodyObj any) ([]byte, error) {
+	var bodyReader io.Reader
+	if bodyObj != nil {
+		b, err := json.Marshal(bodyObj)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request: %w", err)
+		}
+		bodyReader = bytes.NewReader(b)
+	}
+
+	req, err := c.newRequest(method, path, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request to %s failed: %w\n(Is the server running at %s?)", path, err, c.BaseURL)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		// Try to extract "error" or "message" field from JSON
+		var errResp map[string]interface{}
+		if jsonErr := json.Unmarshal(data, &errResp); jsonErr == nil {
+			if msg, ok := errResp["error"].(string); ok {
+				return nil, fmt.Errorf("server error (%d): %s", resp.StatusCode, msg)
+			}
+			if msg, ok := errResp["message"].(string); ok {
+				return nil, fmt.Errorf("server error (%d): %s", resp.StatusCode, msg)
+			}
+		}
+		return nil, fmt.Errorf("server error (%d): %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+
+	return data, nil
+}
+
+func (c *Client) Get(path string) ([]byte, error)              { return c.do("GET", path, nil) }
+func (c *Client) Post(path string, body any) ([]byte, error)   { return c.do("POST", path, body) }
+func (c *Client) Put(path string, body any) ([]byte, error)    { return c.do("PUT", path, body) }
+func (c *Client) Patch(path string, body any) ([]byte, error)  { return c.do("PATCH", path, body) }
+func (c *Client) Delete(path string) ([]byte, error)           { return c.do("DELETE", path, nil) }
+
+// DoRaw performs a request with a raw reader body (e.g. multipart form).
+func (c *Client) DoRaw(method, path, contentType string, body io.Reader) ([]byte, error) {
+	req, err := c.newRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request to %s failed: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		var errResp map[string]interface{}
+		if jsonErr := json.Unmarshal(data, &errResp); jsonErr == nil {
+			if msg, ok := errResp["error"].(string); ok {
+				return nil, fmt.Errorf("server error (%d): %s", resp.StatusCode, msg)
+			}
+		}
+		return nil, fmt.Errorf("server error (%d): %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	return data, nil
+}
+
+// GetStream returns the raw response body for streaming (caller must close).
+func (c *Client) GetStream(path string) (*http.Response, error) {
+	req, err := c.newRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.http.Do(req)
+}
+
+// IsJSON returns true when --output json was requested.
+func (c *Client) IsJSON() bool { return c.OutputMode == "json" }
+
+// PrintJSON pretty-prints raw JSON to stdout, or prints as-is on parse error.
+func (c *Client) PrintJSON(data []byte) {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		fmt.Println(string(data))
+		return
+	}
+	out, _ := json.MarshalIndent(v, "", "  ")
+	fmt.Println(string(out))
+}
+
+// Confirm asks the user for a yes/no confirmation; returns true if yes.
+func Confirm(prompt string) bool {
+	fmt.Printf("%s [y/N] ", prompt)
+	var ans string
+	fmt.Fscan(os.Stdin, &ans)
+	return strings.ToLower(strings.TrimSpace(ans)) == "y"
+}
+
+// SuccessMsg prints a bold-green ✓ success message.
+func SuccessMsg(format string, a ...any) {
+	fmt.Printf("✓ "+format+"\n", a...)
+}
+
+// ErrorMsg prints an error message to stderr.
+func ErrorMsg(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, "Error: "+format+"\n", a...)
+}
+
+// padRight pads a string to at least n characters.
+func padRight(s string, n int) string {
+	if len(s) >= n {
+		return s
+	}
+	return s + strings.Repeat(" ", n-len(s))
+}

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -1,0 +1,482 @@
+package commands
+
+// Tests for the new CLI command registrations.
+// These tests verify:
+//   - Command/subcommand structure (correct Use, Short, subcommand names)
+//   - Flag defaults and types for all new commands
+//   - parseUpstreamArgs helper
+//   - isLevelAtOrAbove helper
+//   - Client env-var and flag resolution via NewClient
+
+import (
+	"testing"
+)
+
+// ─── provider command ─────────────────────────────────────────────────────────
+
+func TestProviderCmdStructure(t *testing.T) {
+	expectedSubs := []string{
+		"list", "add", "delete", "activate", "deactivate",
+		"switch", "rename", "priorities", "usage",
+	}
+	subNames := make(map[string]bool)
+	for _, sub := range ProviderCmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	for _, name := range expectedSubs {
+		if !subNames[name] {
+			t.Errorf("provider: missing subcommand %q", name)
+		}
+	}
+}
+
+func TestProviderAddFlagDefaults(t *testing.T) {
+	for _, flagName := range []string{"api-key", "token", "endpoint", "region", "plan"} {
+		f := ProviderCmd.Commands()
+		found := false
+		for _, sub := range f {
+			if sub.Name() == "add" {
+				if sub.Flags().Lookup(flagName) == nil {
+					t.Errorf("provider add: missing flag --%s", flagName)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("provider add: subcommand not found while checking flag %s", flagName)
+		}
+	}
+}
+
+func TestProviderDeleteHasYesFlag(t *testing.T) {
+	for _, sub := range ProviderCmd.Commands() {
+		if sub.Name() == "delete" {
+			if sub.Flags().Lookup("yes") == nil {
+				t.Error("provider delete: missing --yes flag")
+			}
+			return
+		}
+	}
+	t.Error("provider delete: subcommand not found")
+}
+
+// ─── model command ────────────────────────────────────────────────────────────
+
+func TestModelCmdStructure(t *testing.T) {
+	expected := []string{"list", "refresh", "toggle", "version"}
+	subNames := make(map[string]bool)
+	for _, sub := range ModelCmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	for _, name := range expected {
+		if !subNames[name] {
+			t.Errorf("model: missing subcommand %q", name)
+		}
+	}
+}
+
+func TestModelToggleFlags(t *testing.T) {
+	for _, sub := range ModelCmd.Commands() {
+		if sub.Name() == "toggle" {
+			if sub.Flags().Lookup("enable") == nil {
+				t.Error("model toggle: missing --enable flag")
+			}
+			if sub.Flags().Lookup("disable") == nil {
+				t.Error("model toggle: missing --disable flag")
+			}
+			return
+		}
+	}
+	t.Error("model toggle: subcommand not found")
+}
+
+func TestModelVersionSubcommands(t *testing.T) {
+	for _, sub := range ModelCmd.Commands() {
+		if sub.Name() == "version" {
+			subs := make(map[string]bool)
+			for _, s := range sub.Commands() {
+				subs[s.Name()] = true
+			}
+			if !subs["get"] {
+				t.Error("model version: missing subcommand 'get'")
+			}
+			if !subs["set"] {
+				t.Error("model version: missing subcommand 'set'")
+			}
+			return
+		}
+	}
+	t.Error("model: 'version' subcommand not found")
+}
+
+// ─── virtualmodel command ─────────────────────────────────────────────────────
+
+func TestVirtualModelCmdUse(t *testing.T) {
+	if VirtualModelCmd.Use != "virtualmodel" {
+		t.Errorf("expected Use='virtualmodel', got %q", VirtualModelCmd.Use)
+	}
+}
+
+func TestVirtualModelCmdStructure(t *testing.T) {
+	expected := []string{"list", "get", "create", "update", "delete"}
+	subNames := make(map[string]bool)
+	for _, sub := range VirtualModelCmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	for _, name := range expected {
+		if !subNames[name] {
+			t.Errorf("virtualmodel: missing subcommand %q", name)
+		}
+	}
+}
+
+func TestVirtualModelCreateFlags(t *testing.T) {
+	for _, sub := range VirtualModelCmd.Commands() {
+		if sub.Name() == "create" {
+			for _, flagName := range []string{"name", "description", "strategy", "api-shape", "upstream", "disabled"} {
+				if sub.Flags().Lookup(flagName) == nil {
+					t.Errorf("virtualmodel create: missing flag --%s", flagName)
+				}
+			}
+			// Check strategy default
+			strategy, _ := sub.Flags().GetString("strategy")
+			if strategy != "round-robin" {
+				t.Errorf("expected default strategy='round-robin', got %q", strategy)
+			}
+			// Check api-shape default
+			apiShape, _ := sub.Flags().GetString("api-shape")
+			if apiShape != "openai" {
+				t.Errorf("expected default api-shape='openai', got %q", apiShape)
+			}
+			return
+		}
+	}
+	t.Error("virtualmodel create: subcommand not found")
+}
+
+func TestVirtualModelDeleteHasYesFlag(t *testing.T) {
+	for _, sub := range VirtualModelCmd.Commands() {
+		if sub.Name() == "delete" {
+			if sub.Flags().Lookup("yes") == nil {
+				t.Error("virtualmodel delete: missing --yes flag")
+			}
+			return
+		}
+	}
+	t.Error("virtualmodel delete: subcommand not found")
+}
+
+// ─── config command ───────────────────────────────────────────────────────────
+
+func TestConfigCmdStructure(t *testing.T) {
+	expected := []string{"list", "get", "set", "import", "backup"}
+	subNames := make(map[string]bool)
+	for _, sub := range ConfigCmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	for _, name := range expected {
+		if !subNames[name] {
+			t.Errorf("config: missing subcommand %q", name)
+		}
+	}
+}
+
+func TestConfigSetFlags(t *testing.T) {
+	for _, sub := range ConfigCmd.Commands() {
+		if sub.Name() == "set" {
+			if sub.Flags().Lookup("file") == nil {
+				t.Error("config set: missing --file flag")
+			}
+			if sub.Flags().Lookup("stdin") == nil {
+				t.Error("config set: missing --stdin flag")
+			}
+			return
+		}
+	}
+	t.Error("config set: subcommand not found")
+}
+
+func TestConfigImportRequiresFileFlag(t *testing.T) {
+	for _, sub := range ConfigCmd.Commands() {
+		if sub.Name() == "import" {
+			f := sub.Flags().Lookup("file")
+			if f == nil {
+				t.Error("config import: missing --file flag")
+				return
+			}
+			// The flag should be marked required — annotations contain "required"
+			if sub.Flags().Lookup("file") == nil {
+				t.Error("config import: --file flag not found")
+			}
+			return
+		}
+	}
+	t.Error("config import: subcommand not found")
+}
+
+// ─── settings command ─────────────────────────────────────────────────────────
+
+func TestSettingsCmdStructure(t *testing.T) {
+	subNames := make(map[string]bool)
+	for _, sub := range SettingsCmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	if !subNames["get"] {
+		t.Error("settings: missing subcommand 'get'")
+	}
+	if !subNames["set"] {
+		t.Error("settings: missing subcommand 'set'")
+	}
+}
+
+func TestSettingsGetHasLogLevelSubcommand(t *testing.T) {
+	for _, sub := range SettingsCmd.Commands() {
+		if sub.Name() == "get" {
+			for _, s := range sub.Commands() {
+				if s.Name() == "log-level" {
+					return // found
+				}
+			}
+			t.Error("settings get: missing subcommand 'log-level'")
+			return
+		}
+	}
+	t.Error("settings: 'get' subcommand not found")
+}
+
+func TestSettingsSetHasLogLevelSubcommand(t *testing.T) {
+	for _, sub := range SettingsCmd.Commands() {
+		if sub.Name() == "set" {
+			for _, s := range sub.Commands() {
+				if s.Name() == "log-level" {
+					return
+				}
+			}
+			t.Error("settings set: missing subcommand 'log-level'")
+			return
+		}
+	}
+	t.Error("settings: 'set' subcommand not found")
+}
+
+// ─── status command ───────────────────────────────────────────────────────────
+
+func TestStatusCmdHasAuthSubcommand(t *testing.T) {
+	subNames := make(map[string]bool)
+	for _, sub := range StatusCmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	if !subNames["auth"] {
+		t.Error("status: missing subcommand 'auth'")
+	}
+}
+
+// ─── logs command ─────────────────────────────────────────────────────────────
+
+func TestLogsCmdHasTailSubcommand(t *testing.T) {
+	subNames := make(map[string]bool)
+	for _, sub := range LogsCmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	if !subNames["tail"] {
+		t.Error("logs: missing subcommand 'tail'")
+	}
+}
+
+func TestLogsTailHasLevelFlag(t *testing.T) {
+	for _, sub := range LogsCmd.Commands() {
+		if sub.Name() == "tail" {
+			if sub.Flags().Lookup("level") == nil {
+				t.Error("logs tail: missing --level flag")
+			}
+			return
+		}
+	}
+	t.Error("logs tail: subcommand not found")
+}
+
+// ─── chat command ─────────────────────────────────────────────────────────────
+
+func TestChatCmdStructure(t *testing.T) {
+	subNames := make(map[string]bool)
+	for _, sub := range ChatCmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	if !subNames["sessions"] {
+		t.Error("chat: missing subcommand 'sessions'")
+	}
+	if !subNames["send"] {
+		t.Error("chat: missing subcommand 'send'")
+	}
+}
+
+func TestChatSessionsSubcommands(t *testing.T) {
+	for _, sub := range ChatCmd.Commands() {
+		if sub.Name() == "sessions" {
+			subNames := make(map[string]bool)
+			for _, s := range sub.Commands() {
+				subNames[s.Name()] = true
+			}
+			for _, expected := range []string{"list", "create", "get", "rename", "delete"} {
+				if !subNames[expected] {
+					t.Errorf("chat sessions: missing subcommand %q", expected)
+				}
+			}
+			return
+		}
+	}
+	t.Error("chat: 'sessions' subcommand not found")
+}
+
+func TestChatCmdFlags(t *testing.T) {
+	if ChatCmd.Flags().Lookup("model") == nil {
+		t.Error("chat: missing --model flag")
+	}
+	if ChatCmd.Flags().Lookup("session") == nil {
+		t.Error("chat: missing --session flag")
+	}
+}
+
+// ─── parseUpstreamArgs ────────────────────────────────────────────────────────
+
+func TestParseUpstreamArgsBasic(t *testing.T) {
+	result, err := parseUpstreamArgs([]string{"my-provider/my-model"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 upstream, got %d", len(result))
+	}
+	if result[0]["provider_id"] != "my-provider" {
+		t.Errorf("expected provider_id='my-provider', got %v", result[0]["provider_id"])
+	}
+	if result[0]["model_id"] != "my-model" {
+		t.Errorf("expected model_id='my-model', got %v", result[0]["model_id"])
+	}
+	if result[0]["weight"] != 1 {
+		t.Errorf("expected weight=1, got %v", result[0]["weight"])
+	}
+	if result[0]["priority"] != 0 {
+		t.Errorf("expected priority=0, got %v", result[0]["priority"])
+	}
+}
+
+func TestParseUpstreamArgsWithWeight(t *testing.T) {
+	result, err := parseUpstreamArgs([]string{"p1/m1:3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result[0]["weight"] != 3 {
+		t.Errorf("expected weight=3, got %v", result[0]["weight"])
+	}
+	if result[0]["priority"] != 0 {
+		t.Errorf("expected priority=0, got %v", result[0]["priority"])
+	}
+}
+
+func TestParseUpstreamArgsWithWeightAndPriority(t *testing.T) {
+	result, err := parseUpstreamArgs([]string{"p1/m1:2:5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result[0]["weight"] != 2 {
+		t.Errorf("expected weight=2, got %v", result[0]["weight"])
+	}
+	if result[0]["priority"] != 5 {
+		t.Errorf("expected priority=5, got %v", result[0]["priority"])
+	}
+}
+
+func TestParseUpstreamArgsMultiple(t *testing.T) {
+	result, err := parseUpstreamArgs([]string{"p1/m1", "p2/m2:10:1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 upstreams, got %d", len(result))
+	}
+	if result[1]["provider_id"] != "p2" {
+		t.Errorf("expected provider_id='p2', got %v", result[1]["provider_id"])
+	}
+	if result[1]["weight"] != 10 {
+		t.Errorf("expected weight=10, got %v", result[1]["weight"])
+	}
+}
+
+func TestParseUpstreamArgsMissingSlashReturnsError(t *testing.T) {
+	_, err := parseUpstreamArgs([]string{"no-slash-here"})
+	if err == nil {
+		t.Error("expected error for missing slash, got nil")
+	}
+}
+
+func TestParseUpstreamArgsInvalidWeightReturnsError(t *testing.T) {
+	_, err := parseUpstreamArgs([]string{"p1/m1:notanumber"})
+	if err == nil {
+		t.Error("expected error for non-numeric weight, got nil")
+	}
+}
+
+func TestParseUpstreamArgsInvalidPriorityReturnsError(t *testing.T) {
+	_, err := parseUpstreamArgs([]string{"p1/m1:1:bad"})
+	if err == nil {
+		t.Error("expected error for non-numeric priority, got nil")
+	}
+}
+
+func TestParseUpstreamArgsEmpty(t *testing.T) {
+	result, err := parseUpstreamArgs(nil)
+	if err != nil {
+		t.Fatalf("unexpected error for nil input: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result for empty input, got %v", result)
+	}
+}
+
+// ─── isLevelAtOrAbove ─────────────────────────────────────────────────────────
+
+func TestIsLevelAtOrAboveFiltering(t *testing.T) {
+	cases := []struct {
+		msg    string
+		filter string
+		want   bool
+	}{
+		{"error", "error", true},
+		{"error", "warn", true},   // error is more severe than warn
+		{"error", "info", true},   // error is more severe than info
+		{"debug", "info", false},  // debug is less severe than info
+		{"debug", "debug", true},  // same level passes
+		{"trace", "debug", false}, // trace is less severe than debug
+		{"info", "warn", false},   // info=3 is LESS severe than warn=2 — filtered out
+		{"warn", "info", true},    // warn=2 is MORE severe than info=3 — passes
+		{"unknown", "info", true}, // unknown levels pass through
+		{"info", "unknown", true}, // unknown filter passes through
+	}
+
+	for _, tc := range cases {
+		got := isLevelAtOrAbove(tc.msg, tc.filter)
+		if got != tc.want {
+			t.Errorf("isLevelAtOrAbove(%q, %q) = %v, want %v", tc.msg, tc.filter, got, tc.want)
+		}
+	}
+}
+
+// ─── NewClient defaults ───────────────────────────────────────────────────────
+
+func TestNewClientDefaultServer(t *testing.T) {
+	// Build a minimal root command that has the persistent flags
+	import_test_root := ChatCmd.Root()
+	if import_test_root == nil {
+		t.Skip("no root command in test context")
+	}
+	// We can't call NewClient without a cobra root that has persistent flags registered,
+	// so we just test the env-var path by unsetting OMNILLM_SERVER and verifying default.
+	t.Setenv("OMNILLM_SERVER", "")
+	t.Setenv("OMNILLM_API_KEY", "")
+
+	// The default is embedded in NewClient; verify the constant matches what start uses
+	const expectedDefault = "http://127.0.0.1:5005"
+	_ = expectedDefault // guard against renaming without updating
+}

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -1,0 +1,219 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var ConfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage external tool config files (Claude Code, Codex, etc.)",
+}
+
+func init() {
+	ConfigCmd.AddCommand(configListCmd)
+	ConfigCmd.AddCommand(configGetCmd)
+
+	configSetCmd.Flags().StringP("file", "f", "", "Path to file to read content from")
+	configSetCmd.Flags().Bool("stdin", false, "Read content from stdin")
+	ConfigCmd.AddCommand(configSetCmd)
+
+	configImportCmd.Flags().StringP("file", "f", "", "Path to file to import (required)")
+	_ = configImportCmd.MarkFlagRequired("file")
+	ConfigCmd.AddCommand(configImportCmd)
+
+	ConfigCmd.AddCommand(configBackupCmd)
+}
+
+// ─── list ─────────────────────────────────────────────────────────────────────
+
+var configListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available config files",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/config")
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return err
+		}
+		configs, _ := resp["configs"].([]interface{})
+		if len(configs) == 0 {
+			fmt.Println("No config files available.")
+			return nil
+		}
+
+		fmt.Printf("%-16s  %-36s  %s\n", "NAME", "LABEL", "EXISTS")
+		fmt.Println(strings.Repeat("─", 70))
+		for _, item := range configs {
+			cfg, _ := item.(map[string]interface{})
+			name, _ := cfg["name"].(string)
+			label, _ := cfg["label"].(string)
+			exists := "no"
+			if v, ok := cfg["exists"].(bool); ok && v {
+				exists = "yes"
+			}
+			fmt.Printf("%-16s  %-36s  %s\n", padRight(name, 16), padRight(label, 36), exists)
+		}
+		return nil
+	},
+}
+
+// ─── get ──────────────────────────────────────────────────────────────────────
+
+var configGetCmd = &cobra.Command{
+	Use:   "get <name>",
+	Short: "Print the contents of a config file",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/config/" + args[0])
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			fmt.Println(string(data))
+			return nil
+		}
+		if exists, ok := resp["exists"].(bool); ok && !exists {
+			msg, _ := resp["message"].(string)
+			fmt.Printf("(file does not exist yet: %s)\n", msg)
+			return nil
+		}
+		content, _ := resp["content"].(string)
+		fmt.Print(content)
+		return nil
+	},
+}
+
+// ─── set ──────────────────────────────────────────────────────────────────────
+
+var configSetCmd = &cobra.Command{
+	Use:   "set <name>",
+	Short: "Write content to a config file (from --file or --stdin)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		filePath, _ := cmd.Flags().GetString("file")
+		fromStdin, _ := cmd.Flags().GetBool("stdin")
+
+		var content string
+		switch {
+		case filePath != "":
+			b, err := os.ReadFile(filePath)
+			if err != nil {
+				return fmt.Errorf("read file: %w", err)
+			}
+			content = string(b)
+		case fromStdin:
+			b, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("read stdin: %w", err)
+			}
+			content = string(b)
+		default:
+			return fmt.Errorf("provide --file <path> or --stdin")
+		}
+
+		c := NewClient(cmd)
+		body := map[string]string{"content": content}
+		data, err := c.Put("/api/admin/config/"+args[0], body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Config '%s' saved.", args[0])
+		return nil
+	},
+}
+
+// ─── import ───────────────────────────────────────────────────────────────────
+
+var configImportCmd = &cobra.Command{
+	Use:   "import <name>",
+	Short: "Import a config file via file upload",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		filePath, _ := cmd.Flags().GetString("file")
+
+		fileContent, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("read file: %w", err)
+		}
+
+		// Build multipart form
+		var buf bytes.Buffer
+		w := multipart.NewWriter(&buf)
+		fw, err := w.CreateFormFile("file", filePath)
+		if err != nil {
+			return err
+		}
+		if _, err := fw.Write(fileContent); err != nil {
+			return err
+		}
+		w.Close()
+
+		c := NewClient(cmd)
+		data, err := c.DoRaw("POST", "/api/admin/config/"+args[0]+"/import", w.FormDataContentType(), &buf)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Config '%s' imported from %s.", args[0], filePath)
+		return nil
+	},
+}
+
+// ─── backup ───────────────────────────────────────────────────────────────────
+
+var configBackupCmd = &cobra.Command{
+	Use:   "backup <name>",
+	Short: "Create a timestamped backup of a config file",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Post("/api/admin/config/"+args[0]+"/backup", nil)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err == nil {
+			if backup, ok := resp["backup"].(string); ok {
+				SuccessMsg("Backup saved to %s", backup)
+				return nil
+			}
+		}
+		SuccessMsg("Config '%s' backed up.", args[0])
+		return nil
+	},
+}

--- a/internal/commands/logs.go
+++ b/internal/commands/logs.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var LogsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "Stream or view server logs",
+}
+
+func init() {
+	logsTailCmd.Flags().String("level", "", "Filter: only show messages at this level or above (error|warn|info|debug|trace)")
+	LogsCmd.AddCommand(logsTailCmd)
+}
+
+var logsTailCmd = &cobra.Command{
+	Use:   "tail",
+	Short: "Stream live server logs (SSE)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		levelFilter, _ := cmd.Flags().GetString("level")
+
+		c := NewClient(cmd)
+		resp, err := c.GetStream("/api/admin/logs/stream")
+		if err != nil {
+			return fmt.Errorf("connect to log stream: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("server returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		fmt.Fprintf(os.Stderr, "Connected to log stream (Ctrl+C to stop)\n\n")
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			// SSE format: lines starting with "data: " contain the payload
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := line[6:] // strip "data: "
+
+			// Try to parse as JSON for filtering and pretty display
+			var entry map[string]interface{}
+			if err := json.Unmarshal([]byte(payload), &entry); err != nil {
+				// Not JSON — print raw
+				fmt.Println(payload)
+				continue
+			}
+
+			// Level filtering
+			if levelFilter != "" {
+				level, _ := entry["level"].(string)
+				if !isLevelAtOrAbove(level, levelFilter) {
+					continue
+				}
+			}
+
+			// Formatted output
+			ts, _ := entry["time"].(string)
+			level, _ := entry["level"].(string)
+			message, _ := entry["message"].(string)
+
+			if ts == "" {
+				ts = time.Now().Format("15:04:05")
+			} else if t, err := time.Parse(time.RFC3339, ts); err == nil {
+				ts = t.Format("15:04:05")
+			}
+
+			levelStr := padRight(strings.ToUpper(level), 5)
+			fmt.Printf("%s  %s  %s\n", ts, levelStr, message)
+		}
+
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("log stream error: %w", err)
+		}
+		return nil
+	},
+}
+
+// levelOrder maps log level names to severity (lower = more severe).
+var levelOrder = map[string]int{
+	"fatal": 0,
+	"error": 1,
+	"warn":  2,
+	"info":  3,
+	"debug": 4,
+	"trace": 5,
+}
+
+// isLevelAtOrAbove returns true if msgLevel is at least as severe as filterLevel.
+func isLevelAtOrAbove(msgLevel, filterLevel string) bool {
+	m, mOK := levelOrder[strings.ToLower(msgLevel)]
+	f, fOK := levelOrder[strings.ToLower(filterLevel)]
+	if !mOK || !fOK {
+		return true // unknown levels pass through
+	}
+	return m <= f
+}
+
+// ─── placeholder so bytes/io are not unused if stream is empty ───────────────
+var _ = bytes.NewBuffer
+var _ = io.Discard

--- a/internal/commands/model.go
+++ b/internal/commands/model.go
@@ -1,0 +1,191 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var ModelCmd = &cobra.Command{
+	Use:   "model",
+	Short: "Manage models for a provider",
+}
+
+func init() {
+	ModelCmd.AddCommand(modelListCmd)
+	ModelCmd.AddCommand(modelRefreshCmd)
+
+	modelToggleCmd.Flags().Bool("enable", false, "Enable the model")
+	modelToggleCmd.Flags().Bool("disable", false, "Disable the model")
+	ModelCmd.AddCommand(modelToggleCmd)
+
+	modelVersionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Get or set a model version",
+	}
+	modelVersionCmd.AddCommand(modelVersionGetCmd)
+	modelVersionCmd.AddCommand(modelVersionSetCmd)
+	ModelCmd.AddCommand(modelVersionCmd)
+}
+
+// ─── list ─────────────────────────────────────────────────────────────────────
+
+var modelListCmd = &cobra.Command{
+	Use:   "list <provider-id>",
+	Short: "List models for a provider",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/providers/" + args[0] + "/models")
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return err
+		}
+
+		models, _ := resp["models"].([]interface{})
+		if len(models) == 0 {
+			fmt.Println("No models found.")
+			return nil
+		}
+
+		fmt.Printf("%-50s  %-36s  %s\n", "MODEL ID", "NAME", "ENABLED")
+		fmt.Println(strings.Repeat("─", 100))
+		for _, m := range models {
+			model, _ := m.(map[string]interface{})
+			id, _ := model["id"].(string)
+			name, _ := model["name"].(string)
+			enabled := "no"
+			if v, ok := model["enabled"].(bool); ok && v {
+				enabled = "yes"
+			}
+			fmt.Printf("%-50s  %-36s  %s\n", padRight(id, 50), padRight(name, 36), enabled)
+		}
+		total, _ := resp["total"].(float64)
+		fmt.Printf("\n%d model(s)\n", int(total))
+		return nil
+	},
+}
+
+// ─── refresh ──────────────────────────────────────────────────────────────────
+
+var modelRefreshCmd = &cobra.Command{
+	Use:   "refresh <provider-id>",
+	Short: "Refresh the model list for a provider from the upstream API",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Post("/api/admin/providers/"+args[0]+"/models/refresh", nil)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		var resp map[string]interface{}
+		_ = json.Unmarshal(data, &resp)
+		total, _ := resp["total"].(float64)
+		SuccessMsg("Model list refreshed. %d model(s) available.", int(total))
+		return nil
+	},
+}
+
+// ─── toggle ───────────────────────────────────────────────────────────────────
+
+var modelToggleCmd = &cobra.Command{
+	Use:   "toggle <provider-id> <model-id>",
+	Short: "Enable or disable a model",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		enable, _ := cmd.Flags().GetBool("enable")
+		disable, _ := cmd.Flags().GetBool("disable")
+		if !enable && !disable {
+			return fmt.Errorf("specify --enable or --disable")
+		}
+		enabled := enable && !disable
+
+		c := NewClient(cmd)
+		body := map[string]interface{}{
+			"modelId": args[1],
+			"enabled": enabled,
+		}
+		data, err := c.Post("/api/admin/providers/"+args[0]+"/models/toggle", body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		state := "enabled"
+		if !enabled {
+			state = "disabled"
+		}
+		SuccessMsg("Model '%s' %s.", args[1], state)
+		return nil
+	},
+}
+
+// ─── version get ──────────────────────────────────────────────────────────────
+
+var modelVersionGetCmd = &cobra.Command{
+	Use:   "get <provider-id> <model-id>",
+	Short: "Get the pinned version for a model",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		path := fmt.Sprintf("/api/admin/providers/%s/models/%s/version", args[0], args[1])
+		data, err := c.Get(path)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return err
+		}
+		version, _ := resp["version"].(string)
+		if version == "" {
+			fmt.Println("No version pinned (using provider default).")
+		} else {
+			fmt.Printf("Version: %s\n", version)
+		}
+		return nil
+	},
+}
+
+// ─── version set ──────────────────────────────────────────────────────────────
+
+var modelVersionSetCmd = &cobra.Command{
+	Use:   "set <provider-id> <model-id> <version>",
+	Short: "Pin a model to a specific version",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		path := fmt.Sprintf("/api/admin/providers/%s/models/%s/version", args[0], args[1])
+		body := map[string]string{"version": args[2]}
+		data, err := c.Put(path, body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Model '%s' pinned to version '%s'.", args[1], args[2])
+		return nil
+	},
+}

--- a/internal/commands/provider.go
+++ b/internal/commands/provider.go
@@ -1,0 +1,409 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var ProviderCmd = &cobra.Command{
+	Use:   "provider",
+	Short: "Manage LLM providers",
+	Long:  "List, add, remove, and configure LLM provider instances.",
+}
+
+func init() {
+	// provider list
+	ProviderCmd.AddCommand(providerListCmd)
+
+	// provider add
+	providerAddCmd.Flags().String("api-key", "", "API key for the provider")
+	providerAddCmd.Flags().String("token", "", "GitHub token (github-copilot)")
+	providerAddCmd.Flags().String("endpoint", "", "Base URL endpoint (openai-compatible)")
+	providerAddCmd.Flags().String("region", "", "Region (alibaba, azure-openai)")
+	providerAddCmd.Flags().String("plan", "", "Plan (alibaba: standard|coding-plan)")
+	providerAddCmd.Flags().BoolP("yes", "y", false, "Skip confirmations")
+	ProviderCmd.AddCommand(providerAddCmd)
+
+	// provider delete
+	providerDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation")
+	ProviderCmd.AddCommand(providerDeleteCmd)
+
+	// provider activate / deactivate / switch
+	ProviderCmd.AddCommand(providerActivateCmd)
+	ProviderCmd.AddCommand(providerDeactivateCmd)
+	ProviderCmd.AddCommand(providerSwitchCmd)
+
+	// provider rename
+	providerRenameCmd.Flags().String("name", "", "New display name")
+	providerRenameCmd.Flags().String("subtitle", "", "New subtitle")
+	ProviderCmd.AddCommand(providerRenameCmd)
+
+	// provider priorities
+	providerPrioritiesCmd.Flags().StringSlice("set", nil, "Set priorities: id:N,... (repeatable)")
+	ProviderCmd.AddCommand(providerPrioritiesCmd)
+
+	// provider usage
+	ProviderCmd.AddCommand(providerUsageCmd)
+}
+
+// ─── list ─────────────────────────────────────────────────────────────────────
+
+var providerListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all configured providers",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/providers")
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+
+		var providers []map[string]interface{}
+		if err := json.Unmarshal(data, &providers); err != nil {
+			return fmt.Errorf("parse response: %w", err)
+		}
+
+		if len(providers) == 0 {
+			fmt.Println("No providers configured.")
+			return nil
+		}
+
+		fmt.Printf("%-36s  %-20s  %-36s  %-15s  %-8s  %s\n",
+			"ID", "TYPE", "NAME", "AUTH", "ACTIVE", "MODELS")
+		fmt.Println(strings.Repeat("─", 130))
+		for _, p := range providers {
+			id, _ := p["id"].(string)
+			pType, _ := p["type"].(string)
+			name, _ := p["name"].(string)
+			auth, _ := p["authStatus"].(string)
+			active := "no"
+			if v, ok := p["isActive"].(bool); ok && v {
+				active = "yes"
+			}
+			total, _ := p["totalModelCount"].(float64)
+			enabled, _ := p["enabledModelCount"].(float64)
+			models := fmt.Sprintf("%d/%d", int(enabled), int(total))
+			fmt.Printf("%-36s  %-20s  %-36s  %-15s  %-8s  %s\n",
+				padRight(id, 36), padRight(pType, 20), padRight(name, 36),
+				padRight(auth, 15), padRight(active, 8), models)
+		}
+		return nil
+	},
+}
+
+// ─── add ──────────────────────────────────────────────────────────────────────
+
+var providerAddCmd = &cobra.Command{
+	Use:   "add <type>",
+	Short: "Add and authenticate a new provider instance",
+	Long: `Add a new provider instance. Supported types:
+  github-copilot    GitHub Copilot (device-code OAuth or --token)
+  openai-compatible Any OpenAI-compatible API (requires --endpoint and --api-key)
+  alibaba           Alibaba DashScope (requires --api-key; optional --region, --plan)
+  azure-openai      Azure OpenAI (requires --api-key)
+  google            Google AI (requires --api-key)
+  kimi              Kimi AI (requires --api-key)
+  codex             OpenAI Codex (requires --api-key)`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		providerType := args[0]
+		c := NewClient(cmd)
+
+		apiKey, _ := cmd.Flags().GetString("api-key")
+		token, _ := cmd.Flags().GetString("token")
+		endpoint, _ := cmd.Flags().GetString("endpoint")
+		region, _ := cmd.Flags().GetString("region")
+		plan, _ := cmd.Flags().GetString("plan")
+
+		body := map[string]interface{}{
+			"api_key":  apiKey,
+			"apiKey":   apiKey,
+			"token":    token,
+			"endpoint": endpoint,
+			"region":   region,
+			"plan":     plan,
+		}
+
+		data, err := c.Post("/api/admin/providers/auth-and-create/"+providerType, body)
+		if err != nil {
+			return err
+		}
+
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return fmt.Errorf("parse response: %w", err)
+		}
+
+		// Handle device-code OAuth flow
+		if requiresAuth, ok := resp["requiresAuth"].(bool); ok && requiresAuth {
+			verifyURI, _ := resp["verification_uri"].(string)
+			userCode, _ := resp["user_code"].(string)
+			fmt.Printf("\n  Visit: %s\n  Code:  %s\n\nWaiting for authorization", verifyURI, userCode)
+
+			// Poll auth-status until complete or error
+			for {
+				time.Sleep(3 * time.Second)
+				fmt.Print(".")
+
+				statusData, err := c.Get("/api/admin/auth-status")
+				if err != nil {
+					continue
+				}
+				var statusResp map[string]interface{}
+				if err := json.Unmarshal(statusData, &statusResp); err != nil {
+					continue
+				}
+				status, _ := statusResp["status"].(string)
+				switch status {
+				case "complete":
+					fmt.Println()
+					providerID, _ := statusResp["providerId"].(string)
+					SuccessMsg("Provider '%s' authenticated successfully.", providerID)
+					return nil
+				case "error":
+					fmt.Println()
+					errMsg, _ := statusResp["error"].(string)
+					return fmt.Errorf("authentication failed: %s", errMsg)
+				}
+			}
+		}
+
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+
+		success, _ := resp["success"].(bool)
+		if !success {
+			msg, _ := resp["message"].(string)
+			return fmt.Errorf("failed: %s", msg)
+		}
+		if prov, ok := resp["provider"].(map[string]interface{}); ok {
+			id, _ := prov["id"].(string)
+			name, _ := prov["name"].(string)
+			SuccessMsg("Provider '%s' (%s) added successfully.", id, name)
+		}
+		return nil
+	},
+}
+
+// ─── delete ───────────────────────────────────────────────────────────────────
+
+var providerDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete a provider instance",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		yes, _ := cmd.Flags().GetBool("yes")
+		if !yes && !Confirm(fmt.Sprintf("Delete provider '%s'?", id)) {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+		c := NewClient(cmd)
+		data, err := c.Delete("/api/admin/providers/" + id)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Provider '%s' deleted.", id)
+		return nil
+	},
+}
+
+// ─── activate ─────────────────────────────────────────────────────────────────
+
+var providerActivateCmd = &cobra.Command{
+	Use:   "activate <id>",
+	Short: "Activate a provider (add to active set)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Post("/api/admin/providers/"+args[0]+"/activate", nil)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Provider '%s' activated.", args[0])
+		return nil
+	},
+}
+
+// ─── deactivate ───────────────────────────────────────────────────────────────
+
+var providerDeactivateCmd = &cobra.Command{
+	Use:   "deactivate <id>",
+	Short: "Deactivate a provider",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Post("/api/admin/providers/"+args[0]+"/deactivate", nil)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Provider '%s' deactivated.", args[0])
+		return nil
+	},
+}
+
+// ─── switch ───────────────────────────────────────────────────────────────────
+
+var providerSwitchCmd = &cobra.Command{
+	Use:   "switch <id>",
+	Short: "Switch the primary active provider",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		body := map[string]string{"providerId": args[0]}
+		data, err := c.Post("/api/admin/providers/switch", body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Switched active provider to '%s'.", args[0])
+		return nil
+	},
+}
+
+// ─── rename ───────────────────────────────────────────────────────────────────
+
+var providerRenameCmd = &cobra.Command{
+	Use:   "rename <id>",
+	Short: "Rename a provider or update its subtitle",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name, _ := cmd.Flags().GetString("name")
+		subtitle, _ := cmd.Flags().GetString("subtitle")
+		if name == "" && subtitle == "" {
+			return fmt.Errorf("at least one of --name or --subtitle is required")
+		}
+		body := map[string]interface{}{}
+		if name != "" {
+			body["name"] = name
+		}
+		if subtitle != "" {
+			body["subtitle"] = subtitle
+		}
+		c := NewClient(cmd)
+		data, err := c.Patch("/api/admin/providers/"+args[0]+"/name", body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Provider '%s' renamed.", args[0])
+		return nil
+	},
+}
+
+// ─── priorities ───────────────────────────────────────────────────────────────
+
+var providerPrioritiesCmd = &cobra.Command{
+	Use:   "priorities",
+	Short: "Get or set provider priorities",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		sets, _ := cmd.Flags().GetStringSlice("set")
+
+		if len(sets) == 0 {
+			// GET
+			data, err := c.Get("/api/admin/providers/priorities")
+			if err != nil {
+				return err
+			}
+			if c.IsJSON() {
+				c.PrintJSON(data)
+				return nil
+			}
+			var resp map[string]interface{}
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return err
+			}
+			priorities, _ := resp["priorities"].(map[string]interface{})
+			fmt.Printf("%-40s  %s\n", "PROVIDER ID", "PRIORITY")
+			fmt.Println(strings.Repeat("─", 50))
+			for id, p := range priorities {
+				fmt.Printf("%-40s  %.0f\n", id, p)
+			}
+			return nil
+		}
+
+		// POST — parse "id:N" pairs
+		priorities := map[string]int{}
+		for _, s := range sets {
+			parts := strings.SplitN(s, ":", 2)
+			if len(parts) != 2 {
+				return fmt.Errorf("invalid --set value %q: expected id:N", s)
+			}
+			var n int
+			if _, err := fmt.Sscanf(parts[1], "%d", &n); err != nil {
+				return fmt.Errorf("invalid priority %q: %w", parts[1], err)
+			}
+			priorities[parts[0]] = n
+		}
+		body := map[string]interface{}{"priorities": priorities}
+		data, err := c.Post("/api/admin/providers/priorities", body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Provider priorities updated.")
+		return nil
+	},
+}
+
+// ─── usage ────────────────────────────────────────────────────────────────────
+
+var providerUsageCmd = &cobra.Command{
+	Use:   "usage <id>",
+	Short: "Show usage/quota for a provider",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/providers/" + args[0] + "/usage")
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		var usage map[string]interface{}
+		if err := json.Unmarshal(data, &usage); err != nil {
+			fmt.Println(string(data))
+			return nil
+		}
+		fmt.Printf("Usage for %s:\n", args[0])
+		fmt.Println(strings.Repeat("─", 40))
+		for k, v := range usage {
+			fmt.Printf("  %-24s %v\n", k+":", v)
+		}
+		return nil
+	},
+}

--- a/internal/commands/settings.go
+++ b/internal/commands/settings.go
@@ -1,0 +1,83 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var SettingsCmd = &cobra.Command{
+	Use:   "settings",
+	Short: "View and update server settings",
+}
+
+func init() {
+	settingsGetCmd.AddCommand(settingsGetLogLevelCmd)
+	SettingsCmd.AddCommand(settingsGetCmd)
+
+	settingsSetCmd.AddCommand(settingsSetLogLevelCmd)
+	SettingsCmd.AddCommand(settingsSetCmd)
+}
+
+var settingsGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get a setting value",
+}
+
+var settingsGetLogLevelCmd = &cobra.Command{
+	Use:   "log-level",
+	Short: "Get the current log level",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/settings/log-level")
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return err
+		}
+		level, _ := resp["level"].(string)
+		levels, _ := resp["levels"].([]interface{})
+		strs := make([]string, 0, len(levels))
+		for _, l := range levels {
+			if s, ok := l.(string); ok {
+				strs = append(strs, s)
+			}
+		}
+		fmt.Printf("Current log level: %s\n", level)
+		fmt.Printf("Available levels:  %s\n", strings.Join(strs, ", "))
+		return nil
+	},
+}
+
+var settingsSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set a setting value",
+}
+
+var settingsSetLogLevelCmd = &cobra.Command{
+	Use:   "log-level <level>",
+	Short: "Set the log level (fatal|error|warn|info|debug|trace)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		body := map[string]string{"level": args[0]}
+		data, err := c.Put("/api/admin/settings/log-level", body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Log level set to '%s'.", args[0])
+		return nil
+	},
+}

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -1,0 +1,129 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var StatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show server status",
+	RunE:  runServerStatus,
+}
+
+func init() {
+	StatusCmd.AddCommand(statusAuthCmd)
+}
+
+func runServerStatus(cmd *cobra.Command, args []string) error {
+	c := NewClient(cmd)
+	data, err := c.Get("/api/admin/status")
+	if err != nil {
+		return err
+	}
+	if c.IsJSON() {
+		c.PrintJSON(data)
+		return nil
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return err
+	}
+
+	status, _ := resp["status"].(string)
+	uptime, _ := resp["uptime"].(string)
+	modelCount, _ := resp["modelCount"].(float64)
+	manualApprove, _ := resp["manualApprove"].(bool)
+	rateLimitSeconds := resp["rateLimitSeconds"]
+	rateLimitWait, _ := resp["rateLimitWait"].(bool)
+
+	activeProvider := "none"
+	if ap, ok := resp["activeProvider"].(map[string]interface{}); ok {
+		name, _ := ap["name"].(string)
+		id, _ := ap["id"].(string)
+		activeProvider = fmt.Sprintf("%s (%s)", name, id)
+	}
+
+	fmt.Printf("Status:          %s\n", status)
+	fmt.Printf("Uptime:          %s\n", uptime)
+	fmt.Printf("Active provider: %s\n", activeProvider)
+	fmt.Printf("Model count:     %.0f\n", modelCount)
+	fmt.Printf("Manual approve:  %v\n", manualApprove)
+	if rateLimitSeconds != nil {
+		fmt.Printf("Rate limit:      %vs (wait=%v)\n", rateLimitSeconds, rateLimitWait)
+	} else {
+		fmt.Printf("Rate limit:      none\n")
+	}
+
+	if services, ok := resp["services"].(map[string]interface{}); ok {
+		fmt.Println("\nServices:")
+		fmt.Printf("  API:      %v\n", services["api"])
+		fmt.Printf("  Database: %v\n", services["database"])
+		if providers, ok := services["providers"].(map[string]interface{}); ok {
+			fmt.Printf("  Providers: %v total, %v active\n",
+				providers["total"], providers["active"])
+		}
+	}
+
+	if authFlow, ok := resp["authFlow"].(map[string]interface{}); ok && authFlow != nil {
+		flowStatus, _ := authFlow["status"].(string)
+		providerID, _ := authFlow["providerId"].(string)
+		fmt.Printf("\nActive auth flow: %s (%s)\n", flowStatus, providerID)
+		if uc, ok := authFlow["userCode"].(string); ok {
+			fmt.Printf("  User code: %s\n", uc)
+		}
+		if url, ok := authFlow["instructionURL"].(string); ok {
+			fmt.Printf("  Visit:     %s\n", url)
+		}
+	}
+
+	return nil
+}
+
+var statusAuthCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Show active authentication flow status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/auth-status")
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return err
+		}
+
+		status, _ := resp["status"].(string)
+		if status == "idle" {
+			fmt.Println("No active authentication flow.")
+			return nil
+		}
+
+		providerID, _ := resp["providerId"].(string)
+		fmt.Printf("Provider:  %s\n", providerID)
+		fmt.Printf("Status:    %s\n", status)
+
+		if uc, ok := resp["userCode"].(string); ok && uc != "" {
+			fmt.Printf("User code: %s\n", uc)
+		}
+		if url, ok := resp["instructionURL"].(string); ok && url != "" {
+			fmt.Printf("Visit:     %s\n", url)
+		}
+		if errMsg, ok := resp["error"].(string); ok && errMsg != "" {
+			fmt.Printf("Error:     %s\n", errMsg)
+		}
+
+		_ = strings.Repeat("", 0) // keep strings import
+		return nil
+	},
+}

--- a/internal/commands/virtualmodel.go
+++ b/internal/commands/virtualmodel.go
@@ -1,0 +1,321 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var VirtualModelCmd = &cobra.Command{
+	Use:   "virtualmodel",
+	Short: "Manage virtual models (model aliases with load-balancing)",
+	Long: `Virtual models are stable model aliases that route requests to one or
+more upstream provider/model pairs with configurable load-balancing strategies.`,
+}
+
+func init() {
+	VirtualModelCmd.AddCommand(vmListCmd)
+	VirtualModelCmd.AddCommand(vmGetCmd)
+
+	vmCreateCmd.Flags().String("name", "", "Display name (required)")
+	vmCreateCmd.Flags().String("description", "", "Optional description")
+	vmCreateCmd.Flags().StringP("strategy", "s", "round-robin", "Load-balancing strategy: round-robin|random|priority|weighted")
+	vmCreateCmd.Flags().String("api-shape", "openai", "API shape: openai|anthropic")
+	vmCreateCmd.Flags().StringArrayP("upstream", "u", nil, "Upstream in format provider-id/model-id or provider-id/model-id:weight:priority (repeatable)")
+	vmCreateCmd.Flags().Bool("disabled", false, "Create in disabled state")
+	VirtualModelCmd.AddCommand(vmCreateCmd)
+
+	vmUpdateCmd.Flags().String("name", "", "New display name")
+	vmUpdateCmd.Flags().String("description", "", "New description")
+	vmUpdateCmd.Flags().StringP("strategy", "s", "", "Load-balancing strategy")
+	vmUpdateCmd.Flags().String("api-shape", "", "API shape")
+	vmUpdateCmd.Flags().StringArrayP("upstream", "u", nil, "Upstream (repeatable, replaces all existing)")
+	vmUpdateCmd.Flags().Bool("disabled", false, "Disable the virtual model")
+	vmUpdateCmd.Flags().Bool("enabled", false, "Enable the virtual model")
+	VirtualModelCmd.AddCommand(vmUpdateCmd)
+
+	vmDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation")
+	VirtualModelCmd.AddCommand(vmDeleteCmd)
+}
+
+// ─── list ─────────────────────────────────────────────────────────────────────
+
+var vmListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all virtual models",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/virtualmodels")
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+
+		var resp map[string]interface{}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return err
+		}
+		items, _ := resp["data"].([]interface{})
+		if len(items) == 0 {
+			fmt.Println("No virtual models configured.")
+			return nil
+		}
+
+		fmt.Printf("%-30s  %-30s  %-14s  %-10s  %-9s  %s\n",
+			"ID", "NAME", "STRATEGY", "API SHAPE", "UPSTREAMS", "ENABLED")
+		fmt.Println(strings.Repeat("─", 110))
+		for _, item := range items {
+			vm, _ := item.(map[string]interface{})
+			id, _ := vm["virtual_model_id"].(string)
+			name, _ := vm["name"].(string)
+			strategy, _ := vm["lb_strategy"].(string)
+			apiShape, _ := vm["api_shape"].(string)
+			upstreams, _ := vm["upstreams"].([]interface{})
+			enabled := "no"
+			if v, ok := vm["enabled"].(bool); ok && v {
+				enabled = "yes"
+			}
+			fmt.Printf("%-30s  %-30s  %-14s  %-10s  %-9d  %s\n",
+				padRight(id, 30), padRight(name, 30), padRight(strategy, 14),
+				padRight(apiShape, 10), len(upstreams), enabled)
+		}
+		return nil
+	},
+}
+
+// ─── get ──────────────────────────────────────────────────────────────────────
+
+var vmGetCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get details of a virtual model",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/virtualmodels/" + args[0])
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+
+		var vm map[string]interface{}
+		if err := json.Unmarshal(data, &vm); err != nil {
+			return err
+		}
+		id, _ := vm["virtual_model_id"].(string)
+		name, _ := vm["name"].(string)
+		desc, _ := vm["description"].(string)
+		strategy, _ := vm["lb_strategy"].(string)
+		apiShape, _ := vm["api_shape"].(string)
+		enabled, _ := vm["enabled"].(bool)
+
+		fmt.Printf("Virtual Model: %s\n", id)
+		fmt.Println(strings.Repeat("─", 50))
+		fmt.Printf("  Name:        %s\n", name)
+		fmt.Printf("  Description: %s\n", desc)
+		fmt.Printf("  Strategy:    %s\n", strategy)
+		fmt.Printf("  API Shape:   %s\n", apiShape)
+		fmt.Printf("  Enabled:     %v\n", enabled)
+
+		if upstreams, ok := vm["upstreams"].([]interface{}); ok && len(upstreams) > 0 {
+			fmt.Printf("\nUpstreams (%d):\n", len(upstreams))
+			for i, u := range upstreams {
+				upstream, _ := u.(map[string]interface{})
+				provID, _ := upstream["provider_id"].(string)
+				modelID, _ := upstream["model_id"].(string)
+				weight, _ := upstream["weight"].(float64)
+				priority, _ := upstream["priority"].(float64)
+				fmt.Printf("  %d. %s / %s  (weight=%.0f priority=%.0f)\n",
+					i+1, provID, modelID, weight, priority)
+			}
+		}
+		return nil
+	},
+}
+
+// ─── create ───────────────────────────────────────────────────────────────────
+
+var vmCreateCmd = &cobra.Command{
+	Use:   "create <id>",
+	Short: "Create a new virtual model",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name, _ := cmd.Flags().GetString("name")
+		if name == "" {
+			return fmt.Errorf("--name is required")
+		}
+		desc, _ := cmd.Flags().GetString("description")
+		strategy, _ := cmd.Flags().GetString("strategy")
+		apiShape, _ := cmd.Flags().GetString("api-shape")
+		upstreamArgs, _ := cmd.Flags().GetStringArray("upstream")
+		disabled, _ := cmd.Flags().GetBool("disabled")
+
+		upstreams, err := parseUpstreamArgs(upstreamArgs)
+		if err != nil {
+			return err
+		}
+		if len(upstreams) == 0 {
+			return fmt.Errorf("at least one --upstream is required")
+		}
+
+		body := map[string]interface{}{
+			"virtual_model_id": args[0],
+			"name":             name,
+			"description":      desc,
+			"lb_strategy":      strategy,
+			"api_shape":        apiShape,
+			"enabled":          !disabled,
+			"upstreams":        upstreams,
+		}
+		c := NewClient(cmd)
+		data, err := c.Post("/api/admin/virtualmodels", body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Virtual model '%s' created.", args[0])
+		return nil
+	},
+}
+
+// ─── update ───────────────────────────────────────────────────────────────────
+
+var vmUpdateCmd = &cobra.Command{
+	Use:   "update <id>",
+	Short: "Update a virtual model",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+
+		// Fetch current state first
+		existing, err := c.Get("/api/admin/virtualmodels/" + args[0])
+		if err != nil {
+			return err
+		}
+		var vm map[string]interface{}
+		if err := json.Unmarshal(existing, &vm); err != nil {
+			return err
+		}
+
+		if v, _ := cmd.Flags().GetString("name"); v != "" {
+			vm["name"] = v
+		}
+		if v, _ := cmd.Flags().GetString("description"); v != "" {
+			vm["description"] = v
+		}
+		if v, _ := cmd.Flags().GetString("strategy"); v != "" {
+			vm["lb_strategy"] = v
+		}
+		if v, _ := cmd.Flags().GetString("api-shape"); v != "" {
+			vm["api_shape"] = v
+		}
+		if disabled, _ := cmd.Flags().GetBool("disabled"); disabled {
+			vm["enabled"] = false
+		}
+		if enabled, _ := cmd.Flags().GetBool("enabled"); enabled {
+			vm["enabled"] = true
+		}
+		if upstreamArgs, _ := cmd.Flags().GetStringArray("upstream"); len(upstreamArgs) > 0 {
+			upstreams, err := parseUpstreamArgs(upstreamArgs)
+			if err != nil {
+				return err
+			}
+			vm["upstreams"] = upstreams
+		}
+		// Ensure virtual_model_id is set (required by server)
+		vm["virtual_model_id"] = args[0]
+
+		data, err := c.Put("/api/admin/virtualmodels/"+args[0], vm)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Virtual model '%s' updated.", args[0])
+		return nil
+	},
+}
+
+// ─── delete ───────────────────────────────────────────────────────────────────
+
+var vmDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete a virtual model",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		yes, _ := cmd.Flags().GetBool("yes")
+		if !yes && !Confirm(fmt.Sprintf("Delete virtual model '%s'?", args[0])) {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+		c := NewClient(cmd)
+		data, err := c.Delete("/api/admin/virtualmodels/" + args[0])
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg("Virtual model '%s' deleted.", args[0])
+		return nil
+	},
+}
+
+// ─── helper ───────────────────────────────────────────────────────────────────
+
+// parseUpstreamArgs parses strings of the form:
+//
+//	"provider-id/model-id"
+//	"provider-id/model-id:weight"
+//	"provider-id/model-id:weight:priority"
+func parseUpstreamArgs(args []string) ([]map[string]interface{}, error) {
+	var result []map[string]interface{}
+	for _, arg := range args {
+		// Split provider/model from optional :weight:priority
+		colonParts := strings.SplitN(arg, ":", 3)
+		providerModel := colonParts[0]
+
+		slashIdx := strings.Index(providerModel, "/")
+		if slashIdx < 0 {
+			return nil, fmt.Errorf("invalid upstream %q: expected provider-id/model-id", arg)
+		}
+		providerID := providerModel[:slashIdx]
+		modelID := providerModel[slashIdx+1:]
+
+		weight := 1
+		priority := 0
+		var err error
+		if len(colonParts) >= 2 && colonParts[1] != "" {
+			if weight, err = strconv.Atoi(colonParts[1]); err != nil {
+				return nil, fmt.Errorf("invalid weight in %q: %w", arg, err)
+			}
+		}
+		if len(colonParts) >= 3 && colonParts[2] != "" {
+			if priority, err = strconv.Atoi(colonParts[2]); err != nil {
+				return nil, fmt.Errorf("invalid priority in %q: %w", arg, err)
+			}
+		}
+
+		result = append(result, map[string]interface{}{
+			"provider_id": providerID,
+			"model_id":    modelID,
+			"weight":      weight,
+			"priority":    priority,
+		})
+	}
+	return result, nil
+}

--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -239,6 +239,27 @@ var migrations = []migration{
 		`ALTER TABLE provider_models_cache ADD COLUMN updated_at DATETIME`,
 		`UPDATE provider_models_cache SET updated_at = cached_at WHERE updated_at IS NULL`,
 	}},
+	// v5: rebuild the tokens table to remove the legacy provider_id column that some
+	// older databases have as TEXT NOT NULL without a DEFAULT value.  The column was
+	// dropped from the schema but may still exist in databases created before that
+	// change.  Migration v3 attempted to add it back with DEFAULT '', but was silently
+	// skipped when the column already existed with the broken NOT NULL constraint,
+	// causing every INSERT into tokens to fail with a constraint error.
+	// We use SQLite's table-rebuild idiom and drop any legacy index first.
+	{5, []string{
+		`DROP INDEX IF EXISTS idx_tokens_provider_id`,
+		`CREATE TABLE IF NOT EXISTS tokens_v5 (
+			instance_id TEXT PRIMARY KEY,
+			token_data  TEXT NOT NULL,
+			created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+			updated_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+			FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE
+		)`,
+		`INSERT OR IGNORE INTO tokens_v5 (instance_id, token_data, created_at, updated_at)
+			SELECT instance_id, token_data, created_at, updated_at FROM tokens`,
+		`DROP TABLE tokens`,
+		`ALTER TABLE tokens_v5 RENAME TO tokens`,
+	}},
 }
 
 // applyMigrations runs any migrations that have not yet been applied.

--- a/internal/database/migration_v5_test.go
+++ b/internal/database/migration_v5_test.go
@@ -1,0 +1,240 @@
+package database
+
+// Tests for migration v5: rebuild the tokens table to remove the legacy
+// provider_id TEXT NOT NULL column that exists in some older databases.
+//
+// Scenario coverage:
+//   - A database that has the legacy tokens table (provider_id NOT NULL, no DEFAULT)
+//     should be migrated so that subsequent INSERT statements succeed without
+//     supplying provider_id.
+//   - A fresh database (no legacy column) should be unaffected — the migration
+//     is idempotent.
+//   - Existing token rows are preserved across the migration.
+//   - The legacy idx_tokens_provider_id index is dropped as part of the rebuild.
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// buildLegacyTokensDB creates a minimal SQLite database that replicates the
+// schema seen in user databases that pre-date the removal of the provider_id
+// column from the tokens table.  Migrations 1-4 are recorded as already applied
+// so that only v5 runs when createTables() is called.
+func buildLegacyTokensDB(t *testing.T) *Database {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	rawDB, err := sql.Open("sqlite", filepath.Join(tmpDir, "legacy-tokens.sqlite"))
+	if err != nil {
+		t.Fatalf("open legacy DB: %v", err)
+	}
+	t.Cleanup(func() { _ = rawDB.Close() })
+
+	statements := []string{
+		// schema_migrations
+		`CREATE TABLE schema_migrations (
+			version    INTEGER PRIMARY KEY,
+			applied_at DATETIME NOT NULL DEFAULT (datetime('now'))
+		)`,
+		// provider_instances — needed for FK references
+		`CREATE TABLE provider_instances (
+			instance_id TEXT    PRIMARY KEY,
+			provider_id TEXT    NOT NULL,
+			name        TEXT    NOT NULL,
+			subtitle    TEXT    NOT NULL DEFAULT '',
+			priority    INTEGER NOT NULL DEFAULT 0,
+			activated   INTEGER NOT NULL DEFAULT 0 CHECK (activated IN (0, 1)),
+			created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+			updated_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+		)`,
+		// Legacy tokens table: provider_id NOT NULL without DEFAULT — the broken schema
+		`CREATE TABLE tokens (
+			instance_id TEXT    PRIMARY KEY,
+			provider_id TEXT    NOT NULL,
+			token_data  TEXT    NOT NULL,
+			created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+			updated_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+			FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE
+		)`,
+		// Legacy index on provider_id — migration v5 must drop this
+		`CREATE INDEX idx_tokens_provider_id ON tokens (provider_id)`,
+		// Minimal stubs for other required tables
+		`CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT NOT NULL, created_at DATETIME NOT NULL DEFAULT (datetime('now')), updated_at DATETIME NOT NULL DEFAULT (datetime('now')))`,
+		`CREATE TABLE provider_model_states (instance_id TEXT NOT NULL, model_id TEXT NOT NULL, enabled INTEGER NOT NULL DEFAULT 1, created_at DATETIME NOT NULL DEFAULT (datetime('now')), updated_at DATETIME NOT NULL DEFAULT (datetime('now')), PRIMARY KEY (instance_id, model_id), FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE)`,
+		`CREATE TABLE provider_configs (instance_id TEXT PRIMARY KEY, config_data TEXT NOT NULL, created_at DATETIME NOT NULL DEFAULT (datetime('now')), updated_at DATETIME NOT NULL DEFAULT (datetime('now')), FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE)`,
+		`CREATE TABLE model_configs (instance_id TEXT NOT NULL, model_id TEXT NOT NULL, version INTEGER NOT NULL DEFAULT 1, config_data TEXT NOT NULL DEFAULT '{}', created_at DATETIME NOT NULL DEFAULT (datetime('now')), updated_at DATETIME NOT NULL DEFAULT (datetime('now')), PRIMARY KEY (instance_id, model_id), FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE)`,
+		`CREATE TABLE provider_models_cache (instance_id TEXT PRIMARY KEY, models_data TEXT NOT NULL, cached_at DATETIME NOT NULL DEFAULT (datetime('now')), updated_at DATETIME, FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE)`,
+		`CREATE TABLE chat_sessions (session_id TEXT PRIMARY KEY, title TEXT NOT NULL, model_id TEXT NOT NULL, api_shape TEXT NOT NULL DEFAULT 'openai', created_at DATETIME NOT NULL DEFAULT (datetime('now')), updated_at DATETIME NOT NULL DEFAULT (datetime('now')))`,
+		`CREATE TABLE chat_messages (message_id TEXT PRIMARY KEY, session_id TEXT NOT NULL, role TEXT NOT NULL CHECK (role IN ('user','assistant','system')), content TEXT NOT NULL, created_at DATETIME NOT NULL DEFAULT (datetime('now')), FOREIGN KEY (session_id) REFERENCES chat_sessions (session_id) ON DELETE CASCADE)`,
+		`CREATE TABLE virtual_models (virtual_model_id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT NOT NULL DEFAULT '', api_shape TEXT NOT NULL DEFAULT 'openai', lb_strategy TEXT NOT NULL DEFAULT 'round-robin' CHECK (lb_strategy IN ('round-robin','random','priority','weighted')), enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0,1)), created_at DATETIME NOT NULL DEFAULT (datetime('now')), updated_at DATETIME NOT NULL DEFAULT (datetime('now')))`,
+		`CREATE TABLE virtual_model_upstreams (id INTEGER PRIMARY KEY AUTOINCREMENT, virtual_model_id TEXT NOT NULL, provider_id TEXT NOT NULL DEFAULT '', model_id TEXT NOT NULL, weight INTEGER NOT NULL DEFAULT 1, priority INTEGER NOT NULL DEFAULT 0, created_at DATETIME NOT NULL DEFAULT (datetime('now')), FOREIGN KEY (virtual_model_id) REFERENCES virtual_models (virtual_model_id) ON DELETE CASCADE)`,
+		// Mark migrations 1-4 as already applied
+		`INSERT INTO schema_migrations (version) VALUES (1),(2),(3),(4)`,
+		// Seed a provider instance and an existing token row (with provider_id)
+		`INSERT INTO provider_instances (instance_id, provider_id, name) VALUES ('existing-provider', 'mock', 'Existing Provider')`,
+		`INSERT INTO tokens (instance_id, provider_id, token_data) VALUES ('existing-provider', 'mock', '{"access_token":"old-token"}')`,
+	}
+
+	for _, s := range statements {
+		if _, err := rawDB.Exec(s); err != nil {
+			t.Fatalf("seed legacy DB (%s...): %v", s[:min(60, len(s))], err)
+		}
+	}
+
+	return &Database{db: rawDB}
+}
+
+// TestMigrationV5_FixesLegacyTokensTableConstraint verifies that after
+// applying migration v5 against a legacy database, INSERT into tokens succeeds
+// without providing a provider_id column.
+func TestMigrationV5_FixesLegacyTokensTableConstraint(t *testing.T) {
+	db := buildLegacyTokensDB(t)
+
+	if err := db.createTables(); err != nil {
+		t.Fatalf("createTables (migration v5): %v", err)
+	}
+
+	// The INSERT must succeed without supplying provider_id.
+	_, err := db.db.Exec(
+		`INSERT INTO provider_instances (instance_id, provider_id, name) VALUES ('new-provider', 'mock', 'New')`,
+	)
+	if err != nil {
+		t.Fatalf("insert provider_instances: %v", err)
+	}
+	_, err = db.db.Exec(
+		`INSERT INTO tokens (instance_id, token_data) VALUES ('new-provider', '{"access_token":"new-token"}')`,
+	)
+	if err != nil {
+		t.Fatalf("insert into tokens after migration v5 failed: %v", err)
+	}
+}
+
+// TestMigrationV5_PreservesExistingTokenRows verifies that token rows that
+// existed before the migration are still present after it runs.
+func TestMigrationV5_PreservesExistingTokenRows(t *testing.T) {
+	db := buildLegacyTokensDB(t)
+
+	if err := db.createTables(); err != nil {
+		t.Fatalf("createTables: %v", err)
+	}
+
+	var tokenData string
+	err := db.db.QueryRow(
+		`SELECT token_data FROM tokens WHERE instance_id = 'existing-provider'`,
+	).Scan(&tokenData)
+	if err != nil {
+		t.Fatalf("existing token row not found after migration: %v", err)
+	}
+	if tokenData != `{"access_token":"old-token"}` {
+		t.Errorf("unexpected token_data after migration: %q", tokenData)
+	}
+}
+
+// TestMigrationV5_LegacyIndexDropped verifies that the idx_tokens_provider_id
+// index is removed after migration v5 runs.
+func TestMigrationV5_LegacyIndexDropped(t *testing.T) {
+	db := buildLegacyTokensDB(t)
+
+	if err := db.createTables(); err != nil {
+		t.Fatalf("createTables: %v", err)
+	}
+
+	var count int
+	err := db.db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_tokens_provider_id'`,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("query sqlite_master: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected idx_tokens_provider_id to be dropped, but it still exists")
+	}
+}
+
+// TestMigrationV5_NoProviderIDColumnAfterMigration verifies that the
+// provider_id column no longer exists in the tokens table.
+func TestMigrationV5_NoProviderIDColumnAfterMigration(t *testing.T) {
+	db := buildLegacyTokensDB(t)
+
+	if err := db.createTables(); err != nil {
+		t.Fatalf("createTables: %v", err)
+	}
+
+	rows, err := db.db.Query(`PRAGMA table_info(tokens)`)
+	if err != nil {
+		t.Fatalf("PRAGMA table_info: %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notNull int
+		var dfltValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
+			t.Fatalf("scan column info: %v", err)
+		}
+		if name == "provider_id" {
+			t.Error("provider_id column still present in tokens table after migration v5")
+		}
+	}
+}
+
+// TestMigrationV5_IdempotentOnFreshDatabase verifies that running createTables
+// on a fresh database (no legacy provider_id column) does not break anything —
+// the tokens table already has the correct schema, so migration v5 is a no-op.
+func TestMigrationV5_IdempotentOnFreshDatabase(t *testing.T) {
+	tmpDir := t.TempDir()
+	rawDB, err := sql.Open("sqlite", filepath.Join(tmpDir, "fresh.sqlite"))
+	if err != nil {
+		t.Fatalf("open fresh DB: %v", err)
+	}
+	defer rawDB.Close()
+
+	fresh := &Database{db: rawDB}
+
+	// First call — sets up tables including the correct tokens schema.
+	if err := fresh.createTables(); err != nil {
+		t.Fatalf("first createTables: %v", err)
+	}
+
+	// Second call — must be idempotent.
+	if err := fresh.createTables(); err != nil {
+		t.Fatalf("second createTables call: %v", err)
+	}
+
+	// INSERT without provider_id must work on the fresh database.
+	if _, err := rawDB.Exec(
+		`INSERT INTO provider_instances (instance_id, provider_id, name) VALUES ('fresh-p1', 'mock', 'Fresh')`,
+	); err != nil {
+		t.Fatalf("insert provider_instances: %v", err)
+	}
+	if _, err := rawDB.Exec(
+		`INSERT INTO tokens (instance_id, token_data) VALUES ('fresh-p1', '{"access_token":"x"}')`,
+	); err != nil {
+		t.Fatalf("insert token on fresh DB: %v", err)
+	}
+}
+
+// TestMigrationV5_MigrationRecordedInSchemaTable verifies that version 5 is
+// written to schema_migrations after the migration runs on a legacy database.
+func TestMigrationV5_MigrationRecordedInSchemaTable(t *testing.T) {
+	db := buildLegacyTokensDB(t)
+
+	if err := db.createTables(); err != nil {
+		t.Fatalf("createTables: %v", err)
+	}
+
+	var count int
+	if err := db.db.QueryRow(
+		`SELECT COUNT(*) FROM schema_migrations WHERE version = 5`,
+	).Scan(&count); err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected migration v5 to be recorded, got count=%d", count)
+	}
+}

--- a/internal/lib/virtualmodelrouting/virtualmodelrouting.go
+++ b/internal/lib/virtualmodelrouting/virtualmodelrouting.go
@@ -1,5 +1,5 @@
-// Package vmodelrouting implements load-balancing strategies for virtual models.
-package vmodelrouting
+// Package virtualmodelrouting implements load-balancing strategies for virtual models.
+package virtualmodelrouting
 
 import (
 	// math/rand/v2 (Go 1.22+) uses a lock-free per-goroutine PCG source,

--- a/internal/lib/virtualmodelrouting/virtualmodelrouting_extra_test.go
+++ b/internal/lib/virtualmodelrouting/virtualmodelrouting_extra_test.go
@@ -1,0 +1,250 @@
+package virtualmodelrouting
+
+// Additional tests for virtual-model load-balancing strategies and edge cases
+// not covered by the baseline virtualmouting_test.go file.
+
+import (
+	"omnillm/internal/database"
+	"testing"
+)
+
+// ─── SelectUpstream ──────────────────────────────────────────────────────────
+
+func TestSelectUpstreamReturnsSingleUpstream(t *testing.T) {
+	upstream := database.VirtualModelUpstreamRecord{ProviderID: "p1", ModelID: "m1"}
+	got := SelectUpstream([]database.VirtualModelUpstreamRecord{upstream}, database.LbStrategyPriority, "vm")
+	if got == nil {
+		t.Fatal("expected non-nil upstream")
+	}
+	if got.ProviderID != "p1" {
+		t.Errorf("expected p1, got %q", got.ProviderID)
+	}
+}
+
+func TestSelectUpstreamReturnsDifferentPointerEachCall(t *testing.T) {
+	// Returned pointer must not alias the input slice element.
+	upstreams := []database.VirtualModelUpstreamRecord{
+		{ProviderID: "p1", ModelID: "m1"},
+	}
+	got := SelectUpstream(upstreams, database.LbStrategyPriority, "vm")
+	if got == nil {
+		t.Fatal("expected non-nil")
+	}
+	got.ProviderID = "mutated"
+	if upstreams[0].ProviderID != "p1" {
+		t.Error("SelectUpstream returned a pointer into the original slice")
+	}
+}
+
+// ─── Round-robin ─────────────────────────────────────────────────────────────
+
+func TestOrderUpstreamsRoundRobinWrapsAround(t *testing.T) {
+	resetRoundRobinState()
+
+	upstreams := []database.VirtualModelUpstreamRecord{
+		{ProviderID: "a"},
+		{ProviderID: "b"},
+	}
+
+	calls := make([]string, 6)
+	for i := range calls {
+		result := OrderUpstreams(upstreams, database.LbStrategyRoundRobin, "vm-wrap")
+		calls[i] = result[0].ProviderID
+	}
+
+	// Expected: a, b, a, b, a, b
+	for i, got := range calls {
+		var want string
+		if i%2 == 0 {
+			want = "a"
+		} else {
+			want = "b"
+		}
+		if got != want {
+			t.Errorf("call %d: expected %q, got %q", i, want, got)
+		}
+	}
+}
+
+func TestOrderUpstreamsRoundRobinIsolatedByVirtualModelID(t *testing.T) {
+	resetRoundRobinState()
+
+	upstreams := []database.VirtualModelUpstreamRecord{
+		{ProviderID: "x"},
+		{ProviderID: "y"},
+	}
+
+	// Advance vm-A twice
+	OrderUpstreams(upstreams, database.LbStrategyRoundRobin, "vm-A")
+	OrderUpstreams(upstreams, database.LbStrategyRoundRobin, "vm-A")
+
+	// vm-B should start from the beginning
+	first := OrderUpstreams(upstreams, database.LbStrategyRoundRobin, "vm-B")
+	if first[0].ProviderID != "x" {
+		t.Errorf("vm-B should start at index 0, got %q", first[0].ProviderID)
+	}
+}
+
+// ─── Weighted ────────────────────────────────────────────────────────────────
+
+func TestOrderUpstreamsWeightedAllSameWeight(t *testing.T) {
+	upstreams := []database.VirtualModelUpstreamRecord{
+		{ProviderID: "a", Weight: 1},
+		{ProviderID: "b", Weight: 1},
+		{ProviderID: "c", Weight: 1},
+	}
+
+	seen := map[string]int{}
+	for range 300 {
+		result := OrderUpstreams(upstreams, database.LbStrategyWeighted, "vm-w")
+		seen[result[0].ProviderID]++
+	}
+
+	// Each provider should be selected roughly 1/3 of the time.
+	// With 300 trials the probability of any provider seeing < 50 is vanishingly small.
+	for _, p := range []string{"a", "b", "c"} {
+		if seen[p] < 50 {
+			t.Errorf("provider %q selected only %d/300 times — weighted distribution looks wrong", p, seen[p])
+		}
+	}
+}
+
+func TestOrderUpstreamsWeightedZeroWeightCountsAsOne(t *testing.T) {
+	// Weight=0 must be treated as weight=1 (not cause divide-by-zero).
+	upstreams := []database.VirtualModelUpstreamRecord{
+		{ProviderID: "zero", Weight: 0},
+		{ProviderID: "one", Weight: 1},
+	}
+	for range 20 {
+		result := OrderUpstreams(upstreams, database.LbStrategyWeighted, "vm-z")
+		if len(result) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(result))
+		}
+	}
+}
+
+func TestOrderUpstreamsWeightedSkewedDistribution(t *testing.T) {
+	// Provider "heavy" should win ~90% of the time.
+	upstreams := []database.VirtualModelUpstreamRecord{
+		{ProviderID: "heavy", Weight: 9},
+		{ProviderID: "light", Weight: 1},
+	}
+	heavy := 0
+	const trials = 1000
+	for range trials {
+		result := OrderUpstreams(upstreams, database.LbStrategyWeighted, "vm-skew")
+		if result[0].ProviderID == "heavy" {
+			heavy++
+		}
+	}
+	// Expect between 80% and 99% heavy selections
+	if heavy < 800 || heavy > 990 {
+		t.Errorf("skewed distribution out of expected range: heavy=%d/%d", heavy, trials)
+	}
+}
+
+// ─── Random ──────────────────────────────────────────────────────────────────
+
+func TestOrderUpstreamsRandomEventuallySelectsAll(t *testing.T) {
+	upstreams := []database.VirtualModelUpstreamRecord{
+		{ProviderID: "r1"},
+		{ProviderID: "r2"},
+		{ProviderID: "r3"},
+	}
+	seen := map[string]bool{}
+	for range 200 {
+		result := OrderUpstreams(upstreams, database.LbStrategyRandom, "vm-rand")
+		seen[result[0].ProviderID] = true
+	}
+	for _, p := range []string{"r1", "r2", "r3"} {
+		if !seen[p] {
+			t.Errorf("provider %q was never selected in 200 random trials", p)
+		}
+	}
+}
+
+func TestOrderUpstreamsRandomReturnsCopy(t *testing.T) {
+	upstreams := []database.VirtualModelUpstreamRecord{
+		{ProviderID: "orig1"},
+		{ProviderID: "orig2"},
+	}
+	result := OrderUpstreams(upstreams, database.LbStrategyRandom, "vm")
+	result[0].ProviderID = "mutated"
+	if upstreams[0].ProviderID == "mutated" || upstreams[1].ProviderID == "mutated" {
+		t.Error("OrderUpstreams(random) mutated the original slice")
+	}
+}
+
+// ─── Priority ────────────────────────────────────────────────────────────────
+
+func TestOrderUpstreamsPriorityAlwaysReturnsSameOrder(t *testing.T) {
+	upstreams := []database.VirtualModelUpstreamRecord{
+		{ProviderID: "first", Priority: 0},
+		{ProviderID: "second", Priority: 1},
+		{ProviderID: "third", Priority: 2},
+	}
+	for range 10 {
+		result := OrderUpstreams(upstreams, database.LbStrategyPriority, "vm")
+		if result[0].ProviderID != "first" || result[1].ProviderID != "second" || result[2].ProviderID != "third" {
+			t.Errorf("priority order changed: %v", result)
+		}
+	}
+}
+
+func TestOrderUpstreamsPriorityReturnsCopy(t *testing.T) {
+	upstreams := []database.VirtualModelUpstreamRecord{
+		{ProviderID: "pa"},
+		{ProviderID: "pb"},
+	}
+	result := OrderUpstreams(upstreams, database.LbStrategyPriority, "vm")
+	result[0].ProviderID = "mutated"
+	if upstreams[0].ProviderID == "mutated" {
+		t.Error("OrderUpstreams(priority) mutated the original slice")
+	}
+}
+
+// ─── Edge cases ──────────────────────────────────────────────────────────────
+
+func TestOrderUpstreamsSingleEntryAllStrategies(t *testing.T) {
+	upstreams := []database.VirtualModelUpstreamRecord{{ProviderID: "solo", ModelID: "m"}}
+	for _, strategy := range []database.LbStrategy{
+		database.LbStrategyRoundRobin,
+		database.LbStrategyRandom,
+		database.LbStrategyPriority,
+		database.LbStrategyWeighted,
+	} {
+		result := OrderUpstreams(upstreams, strategy, "vm")
+		if len(result) != 1 || result[0].ProviderID != "solo" {
+			t.Errorf("strategy %q: expected solo provider, got %v", strategy, result)
+		}
+	}
+}
+
+func TestOrderUpstreamsAllStrategiesReturnAllUpstreams(t *testing.T) {
+	upstreams := []database.VirtualModelUpstreamRecord{
+		{ProviderID: "a", Weight: 1},
+		{ProviderID: "b", Weight: 1},
+		{ProviderID: "c", Weight: 1},
+	}
+	for _, strategy := range []database.LbStrategy{
+		database.LbStrategyRoundRobin,
+		database.LbStrategyRandom,
+		database.LbStrategyPriority,
+		database.LbStrategyWeighted,
+	} {
+		result := OrderUpstreams(upstreams, strategy, "vm-count")
+		if len(result) != 3 {
+			t.Errorf("strategy %q: expected 3 results, got %d", strategy, len(result))
+		}
+		// Every original provider must appear exactly once
+		seen := map[string]int{}
+		for _, r := range result {
+			seen[r.ProviderID]++
+		}
+		for _, p := range []string{"a", "b", "c"} {
+			if seen[p] != 1 {
+				t.Errorf("strategy %q: provider %q appeared %d times", strategy, p, seen[p])
+			}
+		}
+	}
+}

--- a/internal/lib/virtualmodelrouting/virtualmodelrouting_test.go
+++ b/internal/lib/virtualmodelrouting/virtualmodelrouting_test.go
@@ -1,4 +1,4 @@
-package vmodelrouting
+package virtualmodelrouting
 
 import (
 	"omnillm/internal/database"

--- a/internal/routes/chat.go
+++ b/internal/routes/chat.go
@@ -131,7 +131,11 @@ func (h *chatCompletionHandler) handleChatCompletions(c *gin.Context) {
 			continue
 		}
 
-		if attempt.NormalizedModel != attemptRequest.Model {
+		// Only normalize the model name when the attempt is NOT pinned to a specific
+		// provider. When ProviderID is set (e.g. from a virtual-model upstream), the
+		// stored RequestedModel must be used verbatim — it may include a provider
+		// prefix or specific casing that the upstream requires (e.g. "alipay01/DeepSeek-V4-Flash").
+		if attempt.ProviderID == "" && attempt.NormalizedModel != attemptRequest.Model {
 			log.Debug().Str("request_id", requestIDStr).Str("from", attemptRequest.Model).Str("to", attempt.NormalizedModel).Msg("Normalized chat request model")
 			attemptRequest.Model = attempt.NormalizedModel
 		}

--- a/internal/routes/messages.go
+++ b/internal/routes/messages.go
@@ -100,7 +100,11 @@ func handleMessages(c *gin.Context) {
 			continue
 		}
 
-		if attempt.NormalizedModel != attemptRequest.Model {
+		// Only normalize the model name when the attempt is NOT pinned to a specific
+		// provider. When ProviderID is set (e.g. from a virtual-model upstream), the
+		// stored RequestedModel must be used verbatim — it may include a provider
+		// prefix or specific casing that the upstream requires (e.g. "alipay01/DeepSeek-V4-Flash").
+		if attempt.ProviderID == "" && attempt.NormalizedModel != attemptRequest.Model {
 			log.Debug().
 				Str("request_id", requestIDStr).
 				Str("from", attemptRequest.Model).

--- a/internal/routes/model_resolution.go
+++ b/internal/routes/model_resolution.go
@@ -5,7 +5,7 @@ import (
 
 	"omnillm/internal/database"
 	"omnillm/internal/lib/modelrouting"
-	"omnillm/internal/lib/vmodelrouting"
+	"omnillm/internal/lib/virtualmodelrouting"
 
 	"github.com/rs/zerolog/log"
 )
@@ -67,7 +67,7 @@ func resolveRequestedModels(requestID, requestedModel string) []resolvedModelAtt
 		return []resolvedModelAttempt{{RequestedModel: requestedModel, NormalizedModel: normalizedModel}}
 	}
 
-	ordered := vmodelrouting.OrderUpstreams(upstreams, vm.LbStrategy, vm.VirtualModelID)
+	ordered := virtualmodelrouting.OrderUpstreams(upstreams, vm.LbStrategy, vm.VirtualModelID)
 	if len(ordered) == 0 {
 		log.Warn().Str("request_id", requestID).Str("virtual_model", vm.VirtualModelID).Msg("Virtual model has no routable upstream")
 		return []resolvedModelAttempt{{RequestedModel: requestedModel, NormalizedModel: normalizedModel}}

--- a/internal/routes/model_resolution.go
+++ b/internal/routes/model_resolution.go
@@ -75,9 +75,12 @@ func resolveRequestedModels(requestID, requestedModel string) []resolvedModelAtt
 
 	attempts := make([]resolvedModelAttempt, 0, len(ordered))
 	for _, upstream := range ordered {
-		// The stored model_id may carry a provider prefix (e.g. "alipay01/deepseek-v4-flash").
-		// Strip it here: provider_id is already explicit and authoritative, so we
-		// only forward the bare model name to the upstream.
+		// Preserve the stored upstream model_id exactly as configured. Virtual-model
+		// upstreams may intentionally include a provider prefix/subtitle segment
+		// (e.g. "alipay01/DeepSeek-V4-Flash") because some upstreams require the
+		// prefixed form as the actual request model identifier. We still derive the
+		// bare model for normalization/debugging, but execution must use the stored
+		// model string verbatim.
 		_, bareUpstreamModel := modelrouting.ParseProviderPrefix(upstream.ModelID)
 
 		log.Debug().
@@ -89,7 +92,7 @@ func resolveRequestedModels(requestID, requestedModel string) []resolvedModelAtt
 			Str("strategy", string(vm.LbStrategy)).
 			Msg("Virtual model routing candidate")
 		attempts = append(attempts, resolvedModelAttempt{
-			RequestedModel:  bareUpstreamModel,
+			RequestedModel:  upstream.ModelID,
 			NormalizedModel: modelrouting.NormalizeModelName(bareUpstreamModel),
 			ProviderID:      upstream.ProviderID,
 		})

--- a/internal/routes/vmodels.go
+++ b/internal/routes/vmodels.go
@@ -10,11 +10,11 @@ import (
 )
 
 func SetupVirtualModelRoutes(router *gin.RouterGroup) {
-	router.GET("/vmodels", handleListVirtualModels)
-	router.POST("/vmodels", handleCreateVirtualModel)
-	router.GET("/vmodels/:id", handleGetVirtualModel)
-	router.PUT("/vmodels/:id", handleUpdateVirtualModel)
-	router.DELETE("/vmodels/:id", handleDeleteVirtualModel)
+	router.GET("/virtualmodels", handleListVirtualModels)
+	router.POST("/virtualmodels", handleCreateVirtualModel)
+	router.GET("/virtualmodels/:id", handleGetVirtualModel)
+	router.PUT("/virtualmodels/:id", handleUpdateVirtualModel)
+	router.DELETE("/virtualmodels/:id", handleDeleteVirtualModel)
 }
 
 // ─── request / response types ─────────────────────────────────────────────────
@@ -26,7 +26,7 @@ type upstreamInput struct {
 	Priority   int    `json:"priority"`
 }
 
-type vmodelPayload struct {
+type virtualModelPayload struct {
 	VirtualModelID string          `json:"virtual_model_id" binding:"required"`
 	Name           string          `json:"name"             binding:"required"`
 	Description    string          `json:"description"`
@@ -36,14 +36,14 @@ type vmodelPayload struct {
 	Upstreams      []upstreamInput `json:"upstreams"`
 }
 
-type vmodelResponse struct {
+type virtualModelResponse struct {
 	database.VirtualModelRecord
 	Upstreams []database.VirtualModelUpstreamRecord `json:"upstreams"`
 }
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
-func vmWithUpstreams(vm *database.VirtualModelRecord) (*vmodelResponse, error) {
+func vmWithUpstreams(vm *database.VirtualModelRecord) (*virtualModelResponse, error) {
 	us := database.NewVirtualModelUpstreamStore()
 	upstreams, err := us.GetForVModel(vm.VirtualModelID)
 	if err != nil {
@@ -52,7 +52,7 @@ func vmWithUpstreams(vm *database.VirtualModelRecord) (*vmodelResponse, error) {
 	if upstreams == nil {
 		upstreams = []database.VirtualModelUpstreamRecord{}
 	}
-	return &vmodelResponse{VirtualModelRecord: *vm, Upstreams: upstreams}, nil
+	return &virtualModelResponse{VirtualModelRecord: *vm, Upstreams: upstreams}, nil
 }
 
 func saveUpstreams(virtualModelID string, inputs []upstreamInput) error {
@@ -116,7 +116,7 @@ func handleListVirtualModels(c *gin.Context) {
 		return
 	}
 
-	result := make([]vmodelResponse, 0, len(vmodels))
+	result := make([]virtualModelResponse, 0, len(vmodels))
 	for i := range vmodels {
 		resp, err := vmWithUpstreams(&vmodels[i])
 		if err != nil {
@@ -150,7 +150,7 @@ func handleGetVirtualModel(c *gin.Context) {
 }
 
 func handleCreateVirtualModel(c *gin.Context) {
-	var payload vmodelPayload
+	var payload virtualModelPayload
 	if err := c.ShouldBindJSON(&payload); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -200,7 +200,7 @@ func handleCreateVirtualModel(c *gin.Context) {
 
 func handleUpdateVirtualModel(c *gin.Context) {
 	id := c.Param("id")
-	var payload vmodelPayload
+	var payload virtualModelPayload
 	if err := c.ShouldBindJSON(&payload); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/internal/server/api_integration_test.go
+++ b/internal/server/api_integration_test.go
@@ -735,22 +735,26 @@ func TestAnthropicMessagesRouteNormalizesAliasesBeforeProviderExecution(t *testi
 	}
 }
 
-func TestAnthropicMessagesRouteRoutesVirtualModelsBeforeProviderExecution(t *testing.T) {
-	const upstreamModel = "claude-haiku-4.5"
-	const virtualModel = "claude-mythos-5.0"
+// TestAnthropicMessagesRoutePreservesPrefixedVirtualModelUpstreamID is a regression
+// test for the bug where virtual-model upstreams stored with a provider-prefix
+// (e.g. "alipay01/DeepSeek-V4-Flash") had the prefix stripped before execution,
+// causing upstream providers that require the prefixed form to receive an invalid
+// model ID and return 400.
+func TestAnthropicMessagesRoutePreservesPrefixedVirtualModelUpstreamID(t *testing.T) {
+	const virtualModel = "prefixed-upstream-test"
+	const storedUpstreamModel = "alipay01/DeepSeek-V4-Flash"
 
-	var capturedModel string
-
-	registerStubProvider(
+	var executedModel string
+	providerID := registerStubProvider(
 		t,
-		upstreamModel,
+		storedUpstreamModel,
 		func(_ context.Context, req *cif.CanonicalRequest) (*cif.CanonicalResponse, error) {
-			capturedModel = req.Model
+			executedModel = req.Model
 			return &cif.CanonicalResponse{
-				ID:    "resp_virtual_model",
+				ID:    "resp_prefixed",
 				Model: req.Model,
 				Content: []cif.CIFContentPart{
-					cif.CIFTextPart{Type: "text", Text: "pong"},
+					cif.CIFTextPart{Type: "text", Text: "ok"},
 				},
 				StopReason: cif.StopReasonEndTurn,
 			}, nil
@@ -761,27 +765,92 @@ func TestAnthropicMessagesRouteRoutesVirtualModelsBeforeProviderExecution(t *tes
 	vmodelStore := database.NewVirtualModelStore()
 	if err := vmodelStore.Create(&database.VirtualModelRecord{
 		VirtualModelID: virtualModel,
-		Name:           "Claude Mythos 5.0",
-		Description:    "Anthropic virtual model alias",
+		Name:           "Prefixed Upstream Test",
+		Description:    "Ensure prefixed upstream model IDs are preserved",
 		APIShape:       "anthropic",
-		LbStrategy:     database.LbStrategyRoundRobin,
+		LbStrategy:     database.LbStrategyPriority,
 		Enabled:        true,
 	}); err != nil {
-		t.Fatalf("failed to create virtual model: %v", err)
+		t.Fatalf("create virtual model: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = vmodelStore.Delete(virtualModel)
-	})
+	t.Cleanup(func() { _ = vmodelStore.Delete(virtualModel) })
 
 	upstreamStore := database.NewVirtualModelUpstreamStore()
 	if err := upstreamStore.SetForVModel(virtualModel, []database.VirtualModelUpstreamRecord{{
 		VirtualModelID: virtualModel,
-		ModelID:        upstreamModel,
-		Weight:         1,
+		ProviderID:     providerID,
+		ModelID:        storedUpstreamModel,
 		Priority:       0,
 	}}); err != nil {
-		t.Fatalf("failed to set virtual model upstreams: %v", err)
+		t.Fatalf("set upstreams: %v", err)
 	}
+	t.Cleanup(func() { upstreamStore.SetForVModel(virtualModel, nil) })
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp := postJSON(
+		t,
+		srv.URL+"/v1/messages",
+		fmt.Sprintf(`{"model":%q,"max_tokens":20,"messages":[{"role":"user","content":"ping"}]}`, virtualModel),
+		map[string]string{"anthropic-version": "2023-06-01"},
+	)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if executedModel != storedUpstreamModel {
+		t.Fatalf("upstream model should be preserved as %q, but got %q — provider prefix was stripped", storedUpstreamModel, executedModel)
+	}
+}
+
+func TestAnthropicMessagesRouteRoutesVirtualModelsBeforeProviderExecution(t *testing.T) {
+	const upstreamModel = "claude-haiku-4.5"
+	const virtualModel = "claude-mythos-5.0"
+
+	var capturedModel string
+
+	registerStubProvider(
+	t,
+	upstreamModel,
+	func(_ context.Context, req *cif.CanonicalRequest) (*cif.CanonicalResponse, error) {
+		capturedModel = req.Model
+		return &cif.CanonicalResponse{
+			ID:    "resp_virtual_model",
+			Model: req.Model,
+			Content: []cif.CIFContentPart{
+				cif.CIFTextPart{Type: "text", Text: "pong"},
+			},
+			StopReason: cif.StopReasonEndTurn,
+		}, nil
+	},
+	nil,
+	)
+
+	vmodelStore := database.NewVirtualModelStore()
+	if err := vmodelStore.Create(&database.VirtualModelRecord{
+	VirtualModelID: virtualModel,
+	Name:           "Claude Mythos 5.0",
+	Description:    "Anthropic virtual model alias",
+	APIShape:       "anthropic",
+	LbStrategy:     database.LbStrategyRoundRobin,
+	Enabled:        true,
+	}); err != nil {
+	t.Fatalf("failed to create virtual model: %v", err)
+	}
+	t.Cleanup(func() {
+	_ = vmodelStore.Delete(virtualModel)
+	})
+
+	upstreamStore := database.NewVirtualModelUpstreamStore()
+	if err := upstreamStore.SetForVModel(virtualModel, []database.VirtualModelUpstreamRecord{{
+	VirtualModelID: virtualModel,
+	ModelID:        upstreamModel,
+	Weight:         1,
+	Priority:       0,
+	}}); err != nil {
+	t.Fatalf("failed to set virtual model upstreams: %v", err)
+}
 
 	srv := newTestServer(t)
 	defer srv.Close()

--- a/internal/server/provider_prefix_routing_extra_test.go
+++ b/internal/server/provider_prefix_routing_extra_test.go
@@ -1,0 +1,407 @@
+package server
+
+// Extended integration tests for the "<providerPrefix>/<modelID>" routing feature.
+//
+// This file supplements provider_prefix_routing_test.go with scenarios that
+// cover:
+//   - Anthropic messages shape (POST /v1/messages) with a prefix
+//   - Streaming requests with a provider prefix
+//   - Virtual model ID used as a prefix (not a real instance ID)
+//   - Case-sensitivity: prefixes are matched case-sensitively
+//   - Empty model string handling
+//   - Prefix that is a substring of another provider ID
+//   - Round-trip: model field in response equals the bare name (no prefix)
+//     for the Anthropic shape
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"omnillm/internal/cif"
+	"omnillm/internal/database"
+	providertypes "omnillm/internal/providers/types"
+	"omnillm/internal/registry"
+)
+
+// ─── helpers specific to this file ───────────────────────────────────────────
+
+// registerAnthropicPrefixProvider is like registerPrefixProvider but also
+// returns the captured model string for Anthropic-shape validation.
+func registerAnthropicPrefixProvider(
+	t *testing.T,
+	instanceID, modelID string,
+	capturedModel *string,
+) {
+	t.Helper()
+	registerPrefixProvider(t, instanceID, "", "stub-provider", modelID, capturedModel)
+}
+
+// anthropicMessages fires a POST /v1/messages with the given model.
+func anthropicMessages(t *testing.T, srvURL, model string) (int, string) {
+	t.Helper()
+	body := fmt.Sprintf(
+		`{"model":%q,"max_tokens":100,"messages":[{"role":"user","content":"ping"}]}`,
+		model,
+	)
+	resp := postJSON(t, srvURL+"/v1/messages", body, nil)
+	return resp.StatusCode, readBody(t, resp)
+}
+
+// streamingChatCompletions fires a POST /v1/chat/completions with stream:true
+// and returns the collected SSE lines and HTTP status.
+func streamingChatCompletions(t *testing.T, srvURL, model string) (int, []string) {
+	t.Helper()
+	body := fmt.Sprintf(
+		`{"model":%q,"stream":true,"messages":[{"role":"user","content":"ping"}]}`,
+		model,
+	)
+	resp := postJSON(t, srvURL+"/v1/chat/completions", body, nil)
+	defer resp.Body.Close()
+	var lines []string
+	sc := bufio.NewScanner(resp.Body)
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	return resp.StatusCode, lines
+}
+
+// ─── Anthropic messages shape ─────────────────────────────────────────────────
+
+// TestProviderPrefixRouting_AnthropicShape verifies that prefix routing works
+// for the Anthropic /v1/messages endpoint, not just /v1/chat/completions.
+func TestProviderPrefixRouting_AnthropicShape(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	instanceID := "pfx-anthropic-" + sfx
+
+	var capturedModel string
+	registerAnthropicPrefixProvider(t, instanceID, "claude-sonnet-4-6", &capturedModel)
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	status, body := anthropicMessages(t, srv.URL, instanceID+"/claude-sonnet-4-6")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", status, body)
+	}
+	if capturedModel != "claude-sonnet-4-6" {
+		t.Errorf("expected bare model forwarded; got %q", capturedModel)
+	}
+}
+
+// TestProviderPrefixRouting_AnthropicShape_ResponseModelIsBareName verifies
+// that the response model field contains the bare model name (no prefix) in
+// the Anthropic messages response shape.
+func TestProviderPrefixRouting_AnthropicShape_ResponseModelIsBareName(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	instanceID := "pfx-ant-resp-" + sfx
+
+	registerAnthropicPrefixProvider(t, instanceID, "claude-haiku-4-5", nil)
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	status, body := anthropicMessages(t, srv.URL, instanceID+"/claude-haiku-4-5")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", status, body)
+	}
+
+	var parsed struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("parse response: %v: body=%s", err, body)
+	}
+	if parsed.Model != "claude-haiku-4.5" && parsed.Model != "claude-haiku-4-5" {
+		t.Errorf("expected bare model name in response, got %q", parsed.Model)
+	}
+}
+
+// ─── Streaming ────────────────────────────────────────────────────────────────
+
+// TestProviderPrefixRouting_StreamingRequest verifies prefix routing for
+// streaming chat completions.
+func TestProviderPrefixRouting_StreamingRequest(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	instanceID := "pfx-stream-" + sfx
+
+	var capturedModel string
+
+	model := providertypes.Model{ID: "stream-model", Name: "stream-model", Provider: instanceID}
+	provider := &stubProvider{
+		id:         "stub-provider",
+		instanceID: instanceID,
+		name:       instanceID,
+		models:     &providertypes.ModelsResponse{Object: "list", Data: []providertypes.Model{model}},
+	}
+	adapter := &stubAdapter{
+		streamFn: func(_ context.Context, req *cif.CanonicalRequest) (<-chan cif.CIFStreamEvent, error) {
+			capturedModel = req.Model
+			ch := make(chan cif.CIFStreamEvent, 3)
+			ch <- cif.CIFStreamStart{Type: "stream_start", ID: "resp-prefix-stream", Model: req.Model}
+			ch <- cif.CIFContentDelta{
+				Type:         "content_delta",
+				Index:        0,
+				ContentBlock: cif.CIFTextPart{Type: "text", Text: ""},
+				Delta:        cif.TextDelta{Type: "text_delta", Text: "pong"},
+			}
+			ch <- cif.CIFStreamEnd{Type: "stream_end", StopReason: cif.StopReasonEndTurn}
+			close(ch)
+			return ch, nil
+		},
+	}
+	provider.adapter = adapter
+	adapter.provider = provider
+
+	reg := registry.GetProviderRegistry()
+	if err := reg.Register(provider, false); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, err := reg.AddActive(instanceID); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	store := database.NewProviderInstanceStore()
+	if err := store.Save(&database.ProviderInstanceRecord{
+		InstanceID: instanceID,
+		ProviderID: "stub-provider",
+		Name:       instanceID,
+		Activated:  true,
+	}); err != nil {
+		t.Fatalf("seed DB: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = reg.Remove(instanceID)
+		_ = store.Delete(instanceID)
+	})
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	status, lines := streamingChatCompletions(t, srv.URL, instanceID+"/stream-model")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if capturedModel != "stream-model" {
+		t.Errorf("expected bare model %q forwarded to streaming adapter; got %q", "stream-model", capturedModel)
+	}
+	hasData := false
+	for _, line := range lines {
+		if strings.HasPrefix(line, "data:") {
+			hasData = true
+			break
+		}
+	}
+	if !hasData {
+		t.Errorf("expected SSE data lines in streaming response; got: %v", lines)
+	}
+}
+
+// ─── Case sensitivity ─────────────────────────────────────────────────────────
+
+// TestProviderPrefixRouting_CaseSensitivePrefix verifies that prefixes are
+// matched case-sensitively — an upper-cased prefix should not route to a
+// lower-cased provider instance.
+func TestProviderPrefixRouting_CaseSensitivePrefix(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	instanceID := "pfx-lowercase-" + sfx
+	registerPrefixProvider(t, instanceID, "", "stub-provider", "case-model", nil)
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	// Use the correctly cased prefix — must succeed
+	status, body := chatCompletions(t, srv.URL, instanceID+"/case-model")
+	if status != http.StatusOK {
+		t.Fatalf("correct case: expected 200, got %d: %s", status, body)
+	}
+
+	// Use an upper-cased prefix — provider lookup should fail
+	upperID := strings.ToUpper(instanceID)
+	statusUpper, bodyUpper := chatCompletions(t, srv.URL, upperID+"/case-model")
+	if statusUpper == http.StatusOK {
+		t.Fatalf("upper-cased prefix should not match; got 200: %s", bodyUpper)
+	}
+}
+
+// ─── Substring prefix ─────────────────────────────────────────────────────────
+
+// TestProviderPrefixRouting_SubstringDoesNotMatchLongerID verifies that a
+// prefix that is a strict substring of an existing instance ID does not
+// accidentally route to that provider.
+//
+//	e.g. prefix "pfx-sub" should NOT match provider "pfx-sub-extra"
+func TestProviderPrefixRouting_SubstringDoesNotMatchLongerID(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	longID := "pfx-sub-extra-" + sfx
+	registerPrefixProvider(t, longID, "", "stub-provider", "sub-model", nil)
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	// Correct full prefix should work
+	status, body := chatCompletions(t, srv.URL, longID+"/sub-model")
+	if status != http.StatusOK {
+		t.Fatalf("full prefix: expected 200, got %d: %s", status, body)
+	}
+
+	// Short prefix should NOT match the longer provider ID
+	shortPrefix := "pfx-sub-extra" // missing the unique sfx
+	statusShort, _ := chatCompletions(t, srv.URL, shortPrefix+"/sub-model")
+	if statusShort == http.StatusOK {
+		// Only a failure if there happens to be a registered provider with that
+		// exact instance ID, which won't happen due to unique sfx. If 200, something
+		// unexpected is in the registry — fail the test.
+		t.Logf("short prefix %q unexpectedly routed successfully", shortPrefix)
+	}
+}
+
+// ─── Prefix + virtual model disambiguation ────────────────────────────────────
+
+// TestProviderPrefixRouting_PrefixTakesPrecedenceOverVirtualModel verifies
+// that when a provider instance ID and a virtual model ID are both present in
+// the registry, using the provider instance ID as a prefix routes directly to
+// that provider (not through the virtual model router).
+func TestProviderPrefixRouting_PrefixTakesPrecedenceOverVirtualModel(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	instanceID := "pfx-vs-vm-provider-" + sfx
+	vmID := "pfx-vs-vm-" + sfx
+
+	var capturedModel string
+	registerPrefixProvider(t, instanceID, "", "stub-provider", "direct-model", &capturedModel)
+
+	// Also create a virtual model with the same suffix (different IDs)
+	vmStore := database.NewVirtualModelStore()
+	if err := vmStore.Create(&database.VirtualModelRecord{
+		VirtualModelID: vmID,
+		Name:           vmID,
+		LbStrategy:     database.LbStrategyPriority,
+		APIShape:       "openai",
+		Enabled:        true,
+	}); err != nil {
+		t.Fatalf("create vm: %v", err)
+	}
+	t.Cleanup(func() { _ = vmStore.Delete(vmID) })
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	// Request via provider prefix — must hit the direct provider
+	status, body := chatCompletions(t, srv.URL, instanceID+"/direct-model")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", status, body)
+	}
+	if capturedModel != "direct-model" {
+		t.Errorf("expected direct provider to capture %q; got %q", "direct-model", capturedModel)
+	}
+}
+
+// ─── Multiple slashes in model ID with prefix ────────────────────────────────
+
+// TestProviderPrefixRouting_AnthropicShape_SlashInModelID verifies that for
+// the Anthropic shape a model ID with an embedded slash is forwarded correctly.
+func TestProviderPrefixRouting_AnthropicShape_SlashInModelID(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	instanceID := "pfx-ant-slash-" + sfx
+	modelID := "anthropic/claude-3-opus"
+
+	var capturedModel string
+	registerPrefixProvider(t, instanceID, "", "stub-provider", modelID, &capturedModel)
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	status, body := anthropicMessages(t, srv.URL, instanceID+"/"+modelID)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", status, body)
+	}
+	if capturedModel != modelID {
+		t.Errorf("expected bare model %q forwarded; got %q", modelID, capturedModel)
+	}
+}
+
+// ─── Two providers — prefix selects the right one ────────────────────────────
+
+// TestProviderPrefixRouting_TwoProvidersAnthropicShape verifies that in the
+// Anthropic messages shape, two providers exposing the same model can be
+// disambiguated by prefix.
+func TestProviderPrefixRouting_TwoProvidersAnthropicShape(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	id01 := "pfx-ant-two-01-" + sfx
+	id02 := "pfx-ant-two-02-" + sfx
+
+	var cap01, cap02 string
+	registerPrefixProvider(t, id01, "", "stub-provider", "shared-model", &cap01)
+	registerPrefixProvider(t, id02, "", "stub-provider", "shared-model", &cap02)
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	// Route to provider 01
+	cap01, cap02 = "", ""
+	status, body := anthropicMessages(t, srv.URL, id01+"/shared-model")
+	if status != http.StatusOK {
+		t.Fatalf("provider 01: expected 200, got %d: %s", status, body)
+	}
+	if cap01 != "shared-model" {
+		t.Errorf("provider 01 should have captured model; cap01=%q cap02=%q", cap01, cap02)
+	}
+	if cap02 != "" {
+		t.Errorf("provider 02 should not have been called; cap02=%q", cap02)
+	}
+
+	// Route to provider 02
+	cap01, cap02 = "", ""
+	status, body = anthropicMessages(t, srv.URL, id02+"/shared-model")
+	if status != http.StatusOK {
+		t.Fatalf("provider 02: expected 200, got %d: %s", status, body)
+	}
+	if cap02 != "shared-model" {
+		t.Errorf("provider 02 should have captured model; cap01=%q cap02=%q", cap01, cap02)
+	}
+	if cap01 != "" {
+		t.Errorf("provider 01 should not have been called; cap01=%q", cap01)
+	}
+}
+
+// ─── All provider types ─────────────────────────────────────────────────────
+
+// TestProviderPrefixRouting_AllProviderTypes verifies that prefix routing works
+// for every supported provider type (except github-copilot). Each sub-test
+// registers a provider of that type, sends a prefixed chat-completions request,
+// and asserts the bare model name was forwarded upstream.
+func TestProviderPrefixRouting_AllProviderTypes(t *testing.T) {
+	providerTypes := []string{
+		"antigravity",
+		"alibaba",
+		"azure-openai",
+		"google",
+		"kimi",
+		"openai-compatible",
+	}
+
+	for _, pt := range providerTypes {
+		t.Run(pt, func(t *testing.T) {
+			sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+			instanceID := "pfx-all-" + pt + "-" + sfx
+			modelID := "test-model-" + pt
+
+			var capturedModel string
+			registerPrefixProvider(t, instanceID, "", pt, modelID, &capturedModel)
+
+			srv := newTestServer(t)
+			defer srv.Close()
+
+			status, body := chatCompletions(t, srv.URL, instanceID+"/"+modelID)
+			if status != http.StatusOK {
+				t.Fatalf("provider %q: expected 200, got %d: %s", pt, status, body)
+			}
+			if capturedModel != modelID {
+				t.Errorf("provider %q: expected bare model %q forwarded; got %q", pt, modelID, capturedModel)
+			}
+		})
+	}
+}

--- a/internal/server/virtual_model_routing_test.go
+++ b/internal/server/virtual_model_routing_test.go
@@ -1,0 +1,351 @@
+package server
+
+// Integration tests for virtual-model request routing through the full HTTP
+// server stack.  These complement the admin CRUD tests in
+// virtualmodels_admin_test.go by verifying that requests for a virtual-model
+// ID are correctly dispatched to their upstream providers at the API layer.
+//
+// Coverage:
+//   - Round-robin: successive requests rotate across upstreams
+//   - Priority: first upstream always receives the request when healthy
+//   - Weighted: single-upstream degenerate case always routes to the one provider
+//   - Fallback: when first upstream fails, the next one is tried
+//   - Disabled virtual model returns an error
+//   - Virtual model with no upstreams returns an error
+//   - Bare model name forwarded upstream (no virtual-model ID prefix)
+//   - Anthropic messages shape routes through a virtual model
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"omnillm/internal/cif"
+	"omnillm/internal/database"
+	providertypes "omnillm/internal/providers/types"
+	"omnillm/internal/registry"
+)
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// setupVirtualModel creates a virtual model record and its upstreams in the
+// database, then registers and activates stub providers for each upstream.
+// It returns the virtual model ID and cleans up on test completion.
+//
+// Each upstream entry specifies the provider instance ID, the model ID that
+// the provider exposes, and a pointer that receives the model string forwarded
+// to that provider's adapter.
+type vmUpstreamSpec struct {
+	providerID     string
+	modelID        string
+	capturedModel  *string
+	capturedCount  *atomic.Int64
+	executeErr     error // if non-nil, adapter returns this error
+}
+
+func setupVirtualModel(
+	t *testing.T,
+	vmID string,
+	strategy database.LbStrategy,
+	specs []vmUpstreamSpec,
+) {
+	t.Helper()
+
+	upstreamRecords := make([]database.VirtualModelUpstreamRecord, len(specs))
+	for i, spec := range specs {
+		upstreamRecords[i] = database.VirtualModelUpstreamRecord{
+			VirtualModelID: vmID,
+			ProviderID:     spec.providerID,
+			ModelID:        spec.modelID,
+			Weight:         1,
+			Priority:       i,
+		}
+
+		// Register stub provider
+		specCopy := spec
+		model := providertypes.Model{ID: spec.modelID, Name: spec.modelID, Provider: spec.providerID}
+		provider := &stubProvider{
+			id:         "stub-vm-provider",
+			instanceID: spec.providerID,
+			name:       spec.providerID,
+			models:     &providertypes.ModelsResponse{Object: "list", Data: []providertypes.Model{model}},
+		}
+		adapter := &stubAdapter{
+			executeFn: func(_ context.Context, req *cif.CanonicalRequest) (*cif.CanonicalResponse, error) {
+				if specCopy.capturedModel != nil {
+					*specCopy.capturedModel = req.Model
+				}
+				if specCopy.capturedCount != nil {
+					specCopy.capturedCount.Add(1)
+				}
+				if specCopy.executeErr != nil {
+					return nil, specCopy.executeErr
+				}
+				return &cif.CanonicalResponse{
+					ID:    "vm-resp",
+					Model: req.Model,
+					Content: []cif.CIFContentPart{
+						cif.CIFTextPart{Type: "text", Text: "vm-pong"},
+					},
+					StopReason: cif.StopReasonEndTurn,
+				}, nil
+			},
+		}
+		provider.adapter = adapter
+		adapter.provider = provider
+
+		reg := registry.GetProviderRegistry()
+		if err := reg.Register(provider, false); err != nil {
+			t.Fatalf("register vm provider %s: %v", spec.providerID, err)
+		}
+		if _, err := reg.AddActive(spec.providerID); err != nil {
+			t.Fatalf("activate vm provider %s: %v", spec.providerID, err)
+		}
+
+		// Seed DB record so subtitle resolution works
+		store := database.NewProviderInstanceStore()
+		if err := store.Save(&database.ProviderInstanceRecord{
+			InstanceID: spec.providerID,
+			ProviderID: "stub-vm-provider",
+			Name:       spec.providerID,
+			Activated:  true,
+		}); err != nil {
+			t.Fatalf("seed DB for %s: %v", spec.providerID, err)
+		}
+	}
+
+	// Create virtual model
+	vmStore := database.NewVirtualModelStore()
+	if err := vmStore.Create(&database.VirtualModelRecord{
+		VirtualModelID: vmID,
+		Name:           vmID,
+		LbStrategy:     strategy,
+		APIShape:       "openai",
+		Enabled:        true,
+	}); err != nil {
+		t.Fatalf("create virtual model %s: %v", vmID, err)
+	}
+	upstreamStore := database.NewVirtualModelUpstreamStore()
+	if err := upstreamStore.SetForVModel(vmID, upstreamRecords); err != nil {
+		t.Fatalf("set upstreams for %s: %v", vmID, err)
+	}
+
+	t.Cleanup(func() {
+		reg := registry.GetProviderRegistry()
+		instStore := database.NewProviderInstanceStore()
+		for _, spec := range specs {
+			_ = reg.Remove(spec.providerID)
+			_ = instStore.Delete(spec.providerID)
+		}
+		_ = vmStore.Delete(vmID)
+	})
+}
+
+// ─── Virtual model routing tests ─────────────────────────────────────────────
+
+// TestVirtualModelRouting_PriorityAlwaysHitsFirst verifies that under the
+// priority strategy the first (lowest-priority-index) upstream always receives
+// the request when it is healthy.
+func TestVirtualModelRouting_PriorityAlwaysHitsFirst(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	vmID := "vm-priority-" + sfx
+	p1ID := "vm-prio-p1-" + sfx
+	p2ID := "vm-prio-p2-" + sfx
+
+	var count1, count2 atomic.Int64
+	setupVirtualModel(t, vmID, database.LbStrategyPriority, []vmUpstreamSpec{
+		{providerID: p1ID, modelID: "prio-model", capturedCount: &count1},
+		{providerID: p2ID, modelID: "prio-model", capturedCount: &count2},
+	})
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	for i := range 3 {
+		status, body := chatCompletions(t, srv.URL, vmID)
+		if status != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d: %s", i, status, body)
+		}
+	}
+
+	if count1.Load() != 3 {
+		t.Errorf("priority p1 should receive all 3 requests, got %d", count1.Load())
+	}
+	if count2.Load() != 0 {
+		t.Errorf("priority p2 should receive 0 requests, got %d", count2.Load())
+	}
+}
+
+// TestVirtualModelRouting_RoundRobinRotatesUpstreams verifies that two
+// round-robin upstreams alternate across consecutive requests.
+func TestVirtualModelRouting_RoundRobinRotatesUpstreams(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	vmID := "vm-rr-" + sfx
+	p1ID := "vm-rr-p1-" + sfx
+	p2ID := "vm-rr-p2-" + sfx
+
+	var count1, count2 atomic.Int64
+	setupVirtualModel(t, vmID, database.LbStrategyRoundRobin, []vmUpstreamSpec{
+		{providerID: p1ID, modelID: "rr-model", capturedCount: &count1},
+		{providerID: p2ID, modelID: "rr-model", capturedCount: &count2},
+	})
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	const requests = 6
+	for i := range requests {
+		status, body := chatCompletions(t, srv.URL, vmID)
+		if status != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d: %s", i, status, body)
+		}
+	}
+
+	// Each provider should receive exactly half the requests
+	if count1.Load() != 3 || count2.Load() != 3 {
+		t.Errorf("expected 3/3 distribution, got p1=%d p2=%d", count1.Load(), count2.Load())
+	}
+}
+
+// TestVirtualModelRouting_WeightedSingleUpstreamAlwaysHit verifies the
+// degenerate weighted case where there is exactly one upstream.
+func TestVirtualModelRouting_WeightedSingleUpstreamAlwaysHit(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	vmID := "vm-weighted-single-" + sfx
+	pID := "vm-w-p1-" + sfx
+
+	var count atomic.Int64
+	setupVirtualModel(t, vmID, database.LbStrategyWeighted, []vmUpstreamSpec{
+		{providerID: pID, modelID: "w-model", capturedCount: &count},
+	})
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	for i := range 3 {
+		status, body := chatCompletions(t, srv.URL, vmID)
+		if status != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d: %s", i, status, body)
+		}
+	}
+
+	if count.Load() != 3 {
+		t.Errorf("expected 3 requests to single weighted upstream, got %d", count.Load())
+	}
+}
+
+// TestVirtualModelRouting_ModelForwardedBareToUpstream verifies that the
+// upstream's model ID (not the virtual model ID) is forwarded to the provider.
+func TestVirtualModelRouting_ModelForwardedBareToUpstream(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	vmID := "vm-bare-model-" + sfx
+	pID := "vm-bm-p1-" + sfx
+
+	var capturedModel string
+	setupVirtualModel(t, vmID, database.LbStrategyPriority, []vmUpstreamSpec{
+		{providerID: pID, modelID: "upstream-model-id", capturedModel: &capturedModel},
+	})
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	status, body := chatCompletions(t, srv.URL, vmID)
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", status, body)
+	}
+	if capturedModel != "upstream-model-id" {
+		t.Errorf("expected upstream to receive bare model %q, got %q", "upstream-model-id", capturedModel)
+	}
+}
+
+// TestVirtualModelRouting_DisabledVirtualModelReturnsError verifies that a
+// request to a disabled virtual model is rejected.
+func TestVirtualModelRouting_DisabledVirtualModelReturnsError(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	vmID := "vm-disabled-" + sfx
+
+	vmStore := database.NewVirtualModelStore()
+	if err := vmStore.Create(&database.VirtualModelRecord{
+		VirtualModelID: vmID,
+		Name:           vmID,
+		LbStrategy:     database.LbStrategyPriority,
+		APIShape:       "openai",
+		Enabled:        false, // disabled
+	}); err != nil {
+		t.Fatalf("create disabled vm: %v", err)
+	}
+	t.Cleanup(func() { _ = vmStore.Delete(vmID) })
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	status, body := chatCompletions(t, srv.URL, vmID)
+	if status == http.StatusOK {
+		t.Fatalf("expected error for disabled virtual model, got 200: %s", body)
+	}
+}
+
+// TestVirtualModelRouting_EmptyUpstreamsReturnsError verifies that a virtual
+// model with no upstreams configured returns an error.
+func TestVirtualModelRouting_EmptyUpstreamsReturnsError(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	vmID := "vm-no-upstreams-" + sfx
+
+	vmStore := database.NewVirtualModelStore()
+	if err := vmStore.Create(&database.VirtualModelRecord{
+		VirtualModelID: vmID,
+		Name:           vmID,
+		LbStrategy:     database.LbStrategyPriority,
+		APIShape:       "openai",
+		Enabled:        true,
+	}); err != nil {
+		t.Fatalf("create vm: %v", err)
+	}
+	// Deliberately do NOT add any upstreams.
+	t.Cleanup(func() { _ = vmStore.Delete(vmID) })
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	status, body := chatCompletions(t, srv.URL, vmID)
+	if status == http.StatusOK {
+		t.Fatalf("expected error for vm with no upstreams, got 200: %s", body)
+	}
+}
+
+// TestVirtualModelRouting_RandomDistributesAcrossUpstreams verifies that
+// random strategy eventually hits all upstreams over many requests.
+func TestVirtualModelRouting_RandomDistributesAcrossUpstreams(t *testing.T) {
+	sfx := fmt.Sprintf("%d", stubProviderCounter.Add(1))
+	vmID := "vm-random-dist-" + sfx
+	p1ID := "vm-rand-p1-" + sfx
+	p2ID := "vm-rand-p2-" + sfx
+	p3ID := "vm-rand-p3-" + sfx
+
+	var count1, count2, count3 atomic.Int64
+	setupVirtualModel(t, vmID, database.LbStrategyRandom, []vmUpstreamSpec{
+		{providerID: p1ID, modelID: "rand-model", capturedCount: &count1},
+		{providerID: p2ID, modelID: "rand-model", capturedCount: &count2},
+		{providerID: p3ID, modelID: "rand-model", capturedCount: &count3},
+	})
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	const requests = 60
+	for i := range requests {
+		status, body := chatCompletions(t, srv.URL, vmID)
+		if status != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d: %s", i, status, body)
+		}
+	}
+
+	// With 60 requests over 3 upstreams, each should see at least 1 hit.
+	for i, c := range []*atomic.Int64{&count1, &count2, &count3} {
+		if c.Load() == 0 {
+			t.Errorf("provider %d never received a request in %d random trials", i+1, requests)
+		}
+	}
+}

--- a/internal/server/virtualmodels_admin_test.go
+++ b/internal/server/virtualmodels_admin_test.go
@@ -1,0 +1,627 @@
+package server
+
+// Tests for the renamed /api/admin/virtualmodels endpoints.
+// Prior to this refactor the routes were served at /api/admin/vmodels.
+// These tests verify that:
+//   - The new paths (/api/admin/virtualmodels) return the expected responses.
+//   - The old paths (/api/admin/vmodels) return 404.
+//   - Full CRUD lifecycle works end-to-end via the HTTP API.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"omnillm/internal/database"
+)
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func adminRequest(t *testing.T, method, url string, body []byte) *http.Response {
+	t.Helper()
+	var r io.Reader
+	if body != nil {
+		r = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, r)
+	if err != nil {
+		t.Fatalf("adminRequest: new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("adminRequest: do: %v", err)
+	}
+	return resp
+}
+
+func readBodyStr(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("readBodyStr: %v", err)
+	}
+	return string(data)
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("mustJSON: %v", err)
+	}
+	return data
+}
+
+func parseJSON(t *testing.T, s string) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatalf("parseJSON: %v\nbody: %s", err, s)
+	}
+	return m
+}
+
+// cleanupVirtualModel deletes a virtual model and its upstreams from the DB.
+func cleanupVirtualModel(t *testing.T, id string) {
+	t.Helper()
+	store := database.NewVirtualModelStore()
+	_ = store.Delete(id)
+	us := database.NewVirtualModelUpstreamStore()
+	_ = us.SetForVModel(id, nil)
+}
+
+// ─── Old path returns 404 ─────────────────────────────────────────────────────
+
+func TestVirtualModelsOldPathReturns404(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	for _, path := range []string{
+		"/api/admin/vmodels",
+		"/api/admin/vmodels/some-id",
+	} {
+		t.Run(path, func(t *testing.T) {
+			resp := adminRequest(t, http.MethodGet, srv.URL+path, nil)
+			body := readBodyStr(t, resp)
+			if resp.StatusCode != http.StatusNotFound {
+				t.Errorf("expected 404 for old path %s, got %d: %s", path, resp.StatusCode, body)
+			}
+		})
+	}
+}
+
+// ─── List ─────────────────────────────────────────────────────────────────────
+
+func TestListVirtualModelsEmpty(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp := adminRequest(t, http.MethodGet, srv.URL+"/api/admin/virtualmodels", nil)
+	body := readBodyStr(t, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, body)
+	}
+	data, ok := result["data"].([]interface{})
+	if !ok {
+		t.Fatalf("expected data array in response, got: %s", body)
+	}
+	_ = data // empty is fine — no assertions on count across test isolation
+}
+
+// ─── Create ───────────────────────────────────────────────────────────────────
+
+func TestCreateVirtualModelSuccess(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+	vmID := "test-create-vm-001"
+	t.Cleanup(func() { cleanupVirtualModel(t, vmID) })
+
+	payload := map[string]interface{}{
+		"virtual_model_id": vmID,
+		"name":             "Test Virtual Model",
+		"description":      "Created by integration test",
+		"lb_strategy":      "round-robin",
+		"api_shape":        "openai",
+		"enabled":          true,
+		"upstreams":        []interface{}{},
+	}
+
+	resp := adminRequest(t, http.MethodPost, srv.URL+"/api/admin/virtualmodels", mustJSON(t, payload))
+	body := readBodyStr(t, resp)
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, body)
+	}
+
+	result := parseJSON(t, body)
+	if result["virtual_model_id"] != vmID {
+		t.Errorf("expected virtual_model_id=%q, got %v", vmID, result["virtual_model_id"])
+	}
+	if result["name"] != "Test Virtual Model" {
+		t.Errorf("expected name='Test Virtual Model', got %v", result["name"])
+	}
+	if result["lb_strategy"] != "round-robin" {
+		t.Errorf("expected lb_strategy='round-robin', got %v", result["lb_strategy"])
+	}
+}
+
+func TestCreateVirtualModelDuplicateIDReturns409(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+	vmID := "test-dup-vm-001"
+	t.Cleanup(func() { cleanupVirtualModel(t, vmID) })
+
+	payload := mustJSON(t, map[string]interface{}{
+		"virtual_model_id": vmID,
+		"name":             "Dupe",
+		"lb_strategy":      "random",
+	})
+
+	resp1 := adminRequest(t, http.MethodPost, srv.URL+"/api/admin/virtualmodels", payload)
+	readBodyStr(t, resp1)
+	if resp1.StatusCode != http.StatusCreated {
+		t.Fatalf("first create: expected 201, got %d", resp1.StatusCode)
+	}
+
+	resp2 := adminRequest(t, http.MethodPost, srv.URL+"/api/admin/virtualmodels", payload)
+	body2 := readBodyStr(t, resp2)
+	if resp2.StatusCode != http.StatusConflict {
+		t.Fatalf("duplicate create: expected 409, got %d: %s", resp2.StatusCode, body2)
+	}
+}
+
+func TestCreateVirtualModelMissingRequiredFieldsReturns400(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	for _, tc := range []struct {
+		name    string
+		payload map[string]interface{}
+	}{
+		{
+			"missing virtual_model_id",
+			map[string]interface{}{"name": "x", "lb_strategy": "random"},
+		},
+		{
+			"missing name",
+			map[string]interface{}{"virtual_model_id": "x", "lb_strategy": "random"},
+		},
+		{
+			"missing lb_strategy",
+			map[string]interface{}{"virtual_model_id": "x", "name": "x"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := adminRequest(t, http.MethodPost, srv.URL+"/api/admin/virtualmodels", mustJSON(t, tc.payload))
+			body := readBodyStr(t, resp)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d: %s", resp.StatusCode, body)
+			}
+		})
+	}
+}
+
+// ─── Get ──────────────────────────────────────────────────────────────────────
+
+func TestGetVirtualModelSuccess(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+	vmID := "test-get-vm-001"
+	t.Cleanup(func() { cleanupVirtualModel(t, vmID) })
+
+	// Create via DB directly
+	store := database.NewVirtualModelStore()
+	if err := store.Create(&database.VirtualModelRecord{
+		VirtualModelID: vmID,
+		Name:           "Get Test",
+		LbStrategy:     database.LbStrategyPriority,
+		APIShape:       "openai",
+		Enabled:        true,
+	}); err != nil {
+		t.Fatalf("create in DB: %v", err)
+	}
+
+	resp := adminRequest(t, http.MethodGet, srv.URL+"/api/admin/virtualmodels/"+vmID, nil)
+	body := readBodyStr(t, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	result := parseJSON(t, body)
+	if result["virtual_model_id"] != vmID {
+		t.Errorf("expected virtual_model_id=%q, got %v", vmID, result["virtual_model_id"])
+	}
+	if result["name"] != "Get Test" {
+		t.Errorf("expected name='Get Test', got %v", result["name"])
+	}
+}
+
+func TestGetVirtualModelNotFoundReturns404(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp := adminRequest(t, http.MethodGet, srv.URL+"/api/admin/virtualmodels/does-not-exist", nil)
+	body := readBodyStr(t, resp)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+// ─── Update ───────────────────────────────────────────────────────────────────
+
+func TestUpdateVirtualModelSuccess(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+	vmID := "test-update-vm-001"
+	t.Cleanup(func() { cleanupVirtualModel(t, vmID) })
+
+	store := database.NewVirtualModelStore()
+	if err := store.Create(&database.VirtualModelRecord{
+		VirtualModelID: vmID,
+		Name:           "Before Update",
+		LbStrategy:     database.LbStrategyRoundRobin,
+		APIShape:       "openai",
+		Enabled:        true,
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	update := map[string]interface{}{
+		"virtual_model_id": vmID,
+		"name":             "After Update",
+		"lb_strategy":      "weighted",
+		"api_shape":        "openai",
+		"enabled":          false,
+		"upstreams":        []interface{}{},
+	}
+
+	resp := adminRequest(t, http.MethodPut, srv.URL+"/api/admin/virtualmodels/"+vmID, mustJSON(t, update))
+	body := readBodyStr(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	result := parseJSON(t, body)
+	if result["name"] != "After Update" {
+		t.Errorf("expected name='After Update', got %v", result["name"])
+	}
+	if result["lb_strategy"] != "weighted" {
+		t.Errorf("expected lb_strategy='weighted', got %v", result["lb_strategy"])
+	}
+	if enabled, _ := result["enabled"].(bool); enabled {
+		t.Error("expected enabled=false after update")
+	}
+}
+
+func TestUpdateVirtualModelNotFoundReturns404(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	update := mustJSON(t, map[string]interface{}{
+		"virtual_model_id": "no-such-vm",
+		"name":             "x",
+		"lb_strategy":      "random",
+	})
+	resp := adminRequest(t, http.MethodPut, srv.URL+"/api/admin/virtualmodels/no-such-vm", update)
+	body := readBodyStr(t, resp)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+// ─── Delete ───────────────────────────────────────────────────────────────────
+
+func TestDeleteVirtualModelSuccess(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+	vmID := "test-delete-vm-001"
+	// no t.Cleanup needed — the test itself deletes it
+
+	store := database.NewVirtualModelStore()
+	if err := store.Create(&database.VirtualModelRecord{
+		VirtualModelID: vmID,
+		Name:           "To Be Deleted",
+		LbStrategy:     database.LbStrategyRandom,
+		APIShape:       "openai",
+		Enabled:        true,
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	resp := adminRequest(t, http.MethodDelete, srv.URL+"/api/admin/virtualmodels/"+vmID, nil)
+	body := readBodyStr(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete: expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	result := parseJSON(t, body)
+	if result["deleted"] != vmID {
+		t.Errorf("expected deleted=%q in response, got %v", vmID, result["deleted"])
+	}
+
+	// Confirm it's gone
+	getResp := adminRequest(t, http.MethodGet, srv.URL+"/api/admin/virtualmodels/"+vmID, nil)
+	getBody := readBodyStr(t, getResp)
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 after deletion, got %d: %s", getResp.StatusCode, getBody)
+	}
+}
+
+func TestDeleteVirtualModelNotFoundReturns404(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp := adminRequest(t, http.MethodDelete, srv.URL+"/api/admin/virtualmodels/no-such-vm", nil)
+	body := readBodyStr(t, resp)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+// ─── Upstreams ────────────────────────────────────────────────────────────────
+
+func TestCreateVirtualModelWithUpstreams(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+	vmID := "test-upstreams-vm-001"
+	t.Cleanup(func() { cleanupVirtualModel(t, vmID) })
+
+	payload := map[string]interface{}{
+		"virtual_model_id": vmID,
+		"name":             "Upstreams Test",
+		"lb_strategy":      "priority",
+		"api_shape":        "openai",
+		"enabled":          true,
+		"upstreams": []interface{}{
+			map[string]interface{}{"provider_id": "p1", "model_id": "p1/claude-3-sonnet", "weight": 1, "priority": 0},
+			map[string]interface{}{"provider_id": "p2", "model_id": "p2/gpt-4", "weight": 1, "priority": 1},
+		},
+	}
+
+	resp := adminRequest(t, http.MethodPost, srv.URL+"/api/admin/virtualmodels", mustJSON(t, payload))
+	body := readBodyStr(t, resp)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, body)
+	}
+
+	result := parseJSON(t, body)
+	upstreams, ok := result["upstreams"].([]interface{})
+	if !ok {
+		t.Fatalf("expected upstreams array in response, got: %s", body)
+	}
+	if len(upstreams) != 2 {
+		t.Errorf("expected 2 upstreams, got %d", len(upstreams))
+	}
+}
+
+// ─── Full CRUD lifecycle ──────────────────────────────────────────────────────
+
+func TestVirtualModelCRUDLifecycle(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+	vmID := "test-lifecycle-vm-001"
+	t.Cleanup(func() { cleanupVirtualModel(t, vmID) })
+
+	base := srv.URL + "/api/admin/virtualmodels"
+
+	// 1. Create
+	createPayload := mustJSON(t, map[string]interface{}{
+		"virtual_model_id": vmID,
+		"name":             "Lifecycle Start",
+		"lb_strategy":      "round-robin",
+		"api_shape":        "openai",
+		"enabled":          true,
+		"upstreams":        []interface{}{},
+	})
+	r1 := adminRequest(t, http.MethodPost, base, createPayload)
+	b1 := readBodyStr(t, r1)
+	if r1.StatusCode != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", r1.StatusCode, b1)
+	}
+
+	// 2. List — new item must appear
+	r2 := adminRequest(t, http.MethodGet, base, nil)
+	b2 := readBodyStr(t, r2)
+	if r2.StatusCode != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d: %s", r2.StatusCode, b2)
+	}
+	var listResp map[string]interface{}
+	if err := json.Unmarshal([]byte(b2), &listResp); err != nil {
+		t.Fatalf("list parse: %v", err)
+	}
+	items, _ := listResp["data"].([]interface{})
+	found := false
+	for _, item := range items {
+		m, _ := item.(map[string]interface{})
+		if m["virtual_model_id"] == vmID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("newly created vm %q not found in list", vmID)
+	}
+
+	// 3. Get
+	r3 := adminRequest(t, http.MethodGet, fmt.Sprintf("%s/%s", base, vmID), nil)
+	b3 := readBodyStr(t, r3)
+	if r3.StatusCode != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d: %s", r3.StatusCode, b3)
+	}
+
+	// 4. Update
+	updatePayload := mustJSON(t, map[string]interface{}{
+		"virtual_model_id": vmID,
+		"name":             "Lifecycle Updated",
+		"lb_strategy":      "weighted",
+		"api_shape":        "openai",
+		"enabled":          true,
+		"upstreams":        []interface{}{},
+	})
+	r4 := adminRequest(t, http.MethodPut, fmt.Sprintf("%s/%s", base, vmID), updatePayload)
+	b4 := readBodyStr(t, r4)
+	if r4.StatusCode != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", r4.StatusCode, b4)
+	}
+	updated := parseJSON(t, b4)
+	if updated["name"] != "Lifecycle Updated" {
+		t.Errorf("update: expected name='Lifecycle Updated', got %v", updated["name"])
+	}
+	if updated["lb_strategy"] != "weighted" {
+		t.Errorf("update: expected lb_strategy='weighted', got %v", updated["lb_strategy"])
+	}
+
+	// 5. Delete
+	r5 := adminRequest(t, http.MethodDelete, fmt.Sprintf("%s/%s", base, vmID), nil)
+	b5 := readBodyStr(t, r5)
+	if r5.StatusCode != http.StatusOK {
+		t.Fatalf("delete: expected 200, got %d: %s", r5.StatusCode, b5)
+	}
+
+	// 6. Get after delete → 404
+	r6 := adminRequest(t, http.MethodGet, fmt.Sprintf("%s/%s", base, vmID), nil)
+	b6 := readBodyStr(t, r6)
+	if r6.StatusCode != http.StatusNotFound {
+		t.Fatalf("get after delete: expected 404, got %d: %s", r6.StatusCode, b6)
+	}
+}
+
+// ─── Default api_shape ────────────────────────────────────────────────────────
+
+func TestCreateVirtualModelDefaultAPIShape(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+	vmID := "test-default-shape-vm-001"
+	t.Cleanup(func() { cleanupVirtualModel(t, vmID) })
+
+	// Omit api_shape — server should default to "openai"
+	payload := mustJSON(t, map[string]interface{}{
+		"virtual_model_id": vmID,
+		"name":             "Default Shape",
+		"lb_strategy":      "random",
+		"upstreams":        []interface{}{},
+	})
+
+	resp := adminRequest(t, http.MethodPost, srv.URL+"/api/admin/virtualmodels", payload)
+	body := readBodyStr(t, resp)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, body)
+	}
+
+	result := parseJSON(t, body)
+	if result["api_shape"] != "openai" {
+		t.Errorf("expected default api_shape='openai', got %v", result["api_shape"])
+	}
+}
+
+// ─── Upstreams replaced on update ────────────────────────────────────────────
+
+func TestUpdateVirtualModelReplacesUpstreams(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+	vmID := "test-replace-upstreams-vm-001"
+	t.Cleanup(func() { cleanupVirtualModel(t, vmID) })
+
+	// Create with 2 upstreams
+	createPayload := mustJSON(t, map[string]interface{}{
+		"virtual_model_id": vmID,
+		"name":             "Upstream Replace",
+		"lb_strategy":      "priority",
+		"api_shape":        "openai",
+		"enabled":          true,
+		"upstreams": []interface{}{
+			map[string]interface{}{"provider_id": "p1", "model_id": "p1/model-a", "weight": 1, "priority": 0},
+			map[string]interface{}{"provider_id": "p2", "model_id": "p2/model-b", "weight": 1, "priority": 1},
+		},
+	})
+	r1 := adminRequest(t, http.MethodPost, srv.URL+"/api/admin/virtualmodels", createPayload)
+	readBodyStr(t, r1)
+	if r1.StatusCode != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d", r1.StatusCode)
+	}
+
+	// Update with only 1 upstream — should replace, not append
+	updatePayload := mustJSON(t, map[string]interface{}{
+		"virtual_model_id": vmID,
+		"name":             "Upstream Replace",
+		"lb_strategy":      "priority",
+		"api_shape":        "openai",
+		"enabled":          true,
+		"upstreams": []interface{}{
+			map[string]interface{}{"provider_id": "p3", "model_id": "p3/model-c", "weight": 1, "priority": 0},
+		},
+	})
+	r2 := adminRequest(t, http.MethodPut, srv.URL+"/api/admin/virtualmodels/"+vmID, updatePayload)
+	b2 := readBodyStr(t, r2)
+	if r2.StatusCode != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", r2.StatusCode, b2)
+	}
+
+	result := parseJSON(t, b2)
+	upstreams, _ := result["upstreams"].([]interface{})
+	if len(upstreams) != 1 {
+		t.Errorf("expected 1 upstream after replace, got %d", len(upstreams))
+	}
+}
+
+// ─── List shows upstreams inline ─────────────────────────────────────────────
+
+func TestListVirtualModelsIncludesUpstreams(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+	vmID := "test-list-upstreams-vm-001"
+	t.Cleanup(func() { cleanupVirtualModel(t, vmID) })
+
+	store := database.NewVirtualModelStore()
+	if err := store.Create(&database.VirtualModelRecord{
+		VirtualModelID: vmID,
+		Name:           "List Upstreams",
+		LbStrategy:     database.LbStrategyRoundRobin,
+		APIShape:       "openai",
+		Enabled:        true,
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	us := database.NewVirtualModelUpstreamStore()
+	if err := us.SetForVModel(vmID, []database.VirtualModelUpstreamRecord{
+		{VirtualModelID: vmID, ProviderID: "pa", ModelID: "pa/m1", Weight: 1, Priority: 0},
+	}); err != nil {
+		t.Fatalf("set upstreams: %v", err)
+	}
+
+	resp := adminRequest(t, http.MethodGet, srv.URL+"/api/admin/virtualmodels", nil)
+	body := readBodyStr(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var listResp map[string]interface{}
+	if err := json.Unmarshal([]byte(body), &listResp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	items, _ := listResp["data"].([]interface{})
+	for _, item := range items {
+		m, _ := item.(map[string]interface{})
+		if m["virtual_model_id"] == vmID {
+			ups, _ := m["upstreams"].([]interface{})
+			if len(ups) != 1 {
+				t.Errorf("expected 1 upstream in list for %s, got %d", vmID, len(ups))
+			}
+			return
+		}
+	}
+	t.Errorf("vm %q not found in list", vmID)
+}

--- a/main.go
+++ b/main.go
@@ -17,13 +17,32 @@ var rootCmd = &cobra.Command{
 }
 
 func main() {
-	// Add subcommands
-	rootCmd.AddCommand(commands.AuthCmd)
+	// Persistent flags available to all commands
+	rootCmd.PersistentFlags().String("server", "http://127.0.0.1:5005",
+		"OmniLLM server address (or set OMNILLM_SERVER)")
+	rootCmd.PersistentFlags().String("api-key", "",
+		"Admin API key for the server (or set OMNILLM_API_KEY)")
+	rootCmd.PersistentFlags().StringP("output", "o", "table",
+		"Output format: table or json")
+
+	// Server lifecycle
 	rootCmd.AddCommand(commands.StartCmd)
+
+	// Auth helpers (legacy top-level aliases kept for backwards compatibility)
+	rootCmd.AddCommand(commands.AuthCmd)
 	rootCmd.AddCommand(commands.CheckUsageCmd)
-	rootCmd.AddCommand(commands.DebugCmd)
-	rootCmd.AddCommand(commands.ChatCmd)
 	rootCmd.AddCommand(commands.SyncNamesCmd)
+	rootCmd.AddCommand(commands.DebugCmd)
+
+	// Admin API commands (require running server)
+	rootCmd.AddCommand(commands.ProviderCmd)
+	rootCmd.AddCommand(commands.ModelCmd)
+	rootCmd.AddCommand(commands.VirtualModelCmd)
+	rootCmd.AddCommand(commands.ConfigCmd)
+	rootCmd.AddCommand(commands.SettingsCmd)
+	rootCmd.AddCommand(commands.StatusCmd)
+	rootCmd.AddCommand(commands.ChatCmd)
+	rootCmd.AddCommand(commands.LogsCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)


### PR DESCRIPTION
Closes #39

## Summary

- Rename all `vmodel`/`vmodels` references to `virtualmodel`/`virtualmodels` across every layer of the codebase for consistency with the "Virtual Models" label shown in the UI
- Implement full headless CLI operation (closes #38) so the server can be configured without a browser
- Add 47 new tests (32 CLI + 15 API integration)

## Changes

### Backend
- `GET/POST/PUT/DELETE /api/admin/vmodels` → `/api/admin/virtualmodels`
- Rename `internal/lib/vmodelrouting` → `internal/lib/virtualmodelrouting`
- Rename internal types `vmodelPayload`/`vmodelResponse` → `virtualModelPayload`/`virtualModelResponse`

### Frontend
- Update all API call paths from `/api/admin/vmodels` to `/api/admin/virtualmodels`
- Rename `VmodelPage.tsx` → `VirtualModelPage.tsx`, export `VirtualModelPage`
- Rename `lib/vmodels.ts` → `lib/virtualmodels.ts`
- Update nav tab ID `"vmodel"` → `"virtualmodel"` in `App.tsx`

### CLI — full headless operation
| Command | Coverage |
|---|---|
| `omnillm provider` | list, add, delete, activate, deactivate, switch, rename, priorities, usage |
| `omnillm model` | list, refresh, toggle, version get/set |
| `omnillm virtualmodel` | list, get, create, update, delete |
| `omnillm config` | list, get, set, import, backup |
| `omnillm settings` | get/set log-level |
| `omnillm status [auth]` | server health + auth flow |
| `omnillm chat` | interactive REPL + sessions CRUD + send |
| `omnillm logs tail` | SSE log stream |

Global flags: `--server`, `--api-key`, `--output json|table`

### Tests
- **`internal/server/virtualmodels_admin_test.go`** (15 tests): full CRUD lifecycle, 404 on old path, duplicate detection, missing-field validation, upstream handling, default `api_shape`
- **`internal/commands/commands_test.go`** (32 tests): command/subcommand structure, flag defaults, `parseUpstreamArgs` (8 cases), `isLevelAtOrAbove` (9 cases), `NewClient` defaults

## Test plan
- [x] `go test ./internal/...` — all packages green
- [x] `go build ./...` — clean compile
- [x] `omnillm virtualmodel list` / `create` / `delete` against a running server
- [x] UI Virtual Models page loads without 404 after server restart