### PR TITLE
chore: update default port to 5000 and sync README with latest CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ OpenAI-style (`/v1/chat/completions`, `/v1/models`, `/v1/embeddings`, `/v1/respo
 
 Manage multiple providers simultaneously. Switch the active backend without restarting. Provider priorities enable automatic failover — when a provider fails mid-request, OmniLLM transparently tries the next candidate in priority order.
 
+**Provider-prefix model routing** — When multiple providers serve the same model name, you can disambiguate by prefixing the model with a provider ID or subtitle (e.g., `provider-id:gpt-4o`). This works for both direct model names and virtual model upstreams, and is resolved automatically by the model routing layer.
+
 ### Virtual models
 
 Define abstract model IDs that map to specific provider models with configurable load-balancing strategies (round-robin, random, priority, weighted). This creates an abstraction layer between application code and upstream providers, enabling model swaps without touching client configuration.
@@ -257,7 +259,7 @@ Clients / Agents / Internal Apps
    ├─────────────────────────────────────────┤
    │  Admin Console + SSE/WS Log Streaming   │
    │  SQLite Persistence (provider, tokens,  │
-   │  configs, chat sessions, vmodels)       │
+   │  configs, chat sessions, virtual models)       │
    └─────────────────────────────────────────┘
             |
             v
@@ -278,7 +280,7 @@ Clients / Agents / Internal Apps
 | **Providers** | `internal/providers/` | Per-provider implementations (Copilot, Alibaba, Azure, Google, Kimi, Antigravity, OpenAI-Compatible, Generic) |
 | **Registry** | `internal/registry/` | Thread-safe `ProviderRegistry` — manages registered providers, active provider selection, failover |
 | **Model Routing** | `internal/lib/modelrouting/` | Resolves model names to candidate providers with caching |
-| **Virtual Model Routing** | `internal/lib/vmodelrouting/` | Routes abstract virtual model IDs to specific provider models with load-balancing strategies |
+| **Virtual Model Routing** | `internal/lib/virtualmodelrouting/` | Routes abstract virtual model IDs to specific provider models with load-balancing strategies |
 | **Database** | `internal/database/` | SQLite persistence via `modernc.org/sqlite` (pure Go, no CGO) — provider instances, tokens, configs, chat sessions, virtual models |
 | **Security** | `internal/security/` | SSRF protection for OpenAI-compatible endpoints |
 | **Rate Limiting** | `internal/lib/ratelimit/` | Configurable rate limiter with optional queue-on-reject behavior |
@@ -370,13 +372,21 @@ External config file editing (Claude Code, OpenCode, etc.) is disabled by defaul
 | `auth` | Authenticate providers without starting the server |
 | `check-usage` | Print GitHub Copilot usage/quota information |
 | `debug` | Print runtime, version, and path diagnostics |
-| `chat` | Launch an interactive provider chat shell |
+| `sync-names` | Refresh provider display names from live API metadata |
+| `provider` | Manage LLM provider instances (list, add, delete, activate, deactivate, switch, rename, priorities, usage) |
+| `model` | Manage models for a provider (list, refresh, toggle, version) |
+| `virtualmodel` | Manage virtual model aliases with load-balancing (list, get, create, update, delete) |
+| `config` | Manage external tool config files (list, get, set, import, backup) |
+| `settings` | View and update server settings (get, set) |
+| `status` | Show server and auth status |
+| `chat` | Interactive chat REPL or manage saved chat sessions (sessions, send) |
+| `logs` | Stream or view server logs (tail) |
 
 ### `start` options
 
 | Option | Alias | Default | Description |
 |---|---|---|---|
-| `--port` | `-p` | `5005` | Listening port |
+| `--port` | `-p` | `5000` | Listening port |
 | `--provider` | | `github-copilot` | Active provider |
 | `--verbose` | `-v` | `false` | Enable verbose logging |
 | `--account-type` | `-a` | `individual` | Copilot plan (`individual`, `business`, `enterprise`) |
@@ -462,11 +472,11 @@ External config file editing (Claude Code, OpenCode, etc.) is disabled by defaul
 | `PUT` | `/api/admin/config/:name` | Save a config file |
 | `POST` | `/api/admin/config/:name/import` | Import config from uploaded file |
 | `POST` | `/api/admin/config/:name/backup` | Create timestamped backup in same directory |
-| `GET` | `/api/admin/vmodels` | List virtual models |
-| `POST` | `/api/admin/vmodels` | Create virtual model |
-| `GET` | `/api/admin/vmodels/:id` | Get virtual model detail |
-| `PUT` | `/api/admin/vmodels/:id` | Update virtual model |
-| `DELETE` | `/api/admin/vmodels/:id` | Delete virtual model |
+| `GET` | `/api/admin/virtualmodels` | List virtual models |
+| `POST` | `/api/admin/virtualmodels` | Create virtual model |
+| `GET` | `/api/admin/virtualmodels/:id` | Get virtual model detail |
+| `PUT` | `/api/admin/virtualmodels/:id` | Update virtual model |
+| `DELETE` | `/api/admin/virtualmodels/:id` | Delete virtual model |
 
 ---
 

--- a/internal/commands/client.go
+++ b/internal/commands/client.go
@@ -27,7 +27,7 @@ func NewClient(cmd *cobra.Command) *Client {
 		server = v
 	}
 	if server == "" {
-		server = "http://127.0.0.1:5005"
+		server = "http://127.0.0.1:5000"
 	}
 	server = strings.TrimRight(server, "/")
 

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -477,6 +477,6 @@ func TestNewClientDefaultServer(t *testing.T) {
 	t.Setenv("OMNILLM_API_KEY", "")
 
 	// The default is embedded in NewClient; verify the constant matches what start uses
-	const expectedDefault = "http://127.0.0.1:5005"
+	const expectedDefault = "http://127.0.0.1:5000"
 	_ = expectedDefault // guard against renaming without updating
 }

--- a/internal/commands/start.go
+++ b/internal/commands/start.go
@@ -107,7 +107,7 @@ var StartCmd = &cobra.Command{
 }
 
 func init() {
-	StartCmd.Flags().IntP("port", "p", 5005, "Port to listen on")
+	StartCmd.Flags().IntP("port", "p", 5000, "Port to listen on")
 	StartCmd.Flags().String("host", "127.0.0.1", "IP or hostname to bind the server to")
 	StartCmd.Flags().BoolP("verbose", "v", false, "Enable verbose logging")
 	StartCmd.Flags().StringP("account-type", "a", "individual", "Account type to use (individual, business, enterprise)")

--- a/internal/commands/start_test.go
+++ b/internal/commands/start_test.go
@@ -10,8 +10,8 @@ func TestStartCmdDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get port flag: %v", err)
 	}
-	if port != 5005 {
-		t.Fatalf("expected default port 5005, got %d", port)
+	if port != 5000 {
+		t.Fatalf("expected default port 5000, got %d", port)
 	}
 
 	provider, err := StartCmd.Flags().GetString("provider")
@@ -37,7 +37,7 @@ func TestStartCmdRejectsInvalidPort(t *testing.T) {
 func TestStartCmdRejectsInvalidRateLimit(t *testing.T) {
 	cmd := *StartCmd
 	cmd.SilenceUsage = true
-	cmd.SetArgs([]string{"--port", "5005", "--rate-limit", "bad"})
+	cmd.SetArgs([]string{"--port", "5000", "--rate-limit", "bad"})
 
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "invalid argument \"bad\"") {

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ var rootCmd = &cobra.Command{
 
 func main() {
 	// Persistent flags available to all commands
-	rootCmd.PersistentFlags().String("server", "http://127.0.0.1:5005",
+	rootCmd.PersistentFlags().String("server", "http://127.0.0.1:5000",
 		"OmniLLM server address (or set OMNILLM_SERVER)")
 	rootCmd.PersistentFlags().String("api-key", "",
 		"Admin API key for the server (or set OMNILLM_API_KEY)")


### PR DESCRIPTION
## Summary

Two small housekeeping changes:

1. **Default port 5005 → 5000** — The server `--port` flag, CLI `--server` flag, and `NewClient` fallback all defaulted to port 5005, but the frontend and development scripts use port 5000. This mismatch causes confusing "connection refused" errors when running CLI commands against the default server.

2. **README sync** — The README was missing documentation for several CLI commands that were added in the vmodel-to-virtualmodel refactor: `provider`, `model`, `virtualmodel`, `config`, `settings`, `status`, `chat`, `logs`, and `sync-names`. Also updated:
   - Admin API routes from `/api/admin/vmodels` to `/api/admin/virtualmodels`
   - Architecture table from `vmodelrouting` to `virtualmodelrouting`
   - Added provider-prefix model routing documentation
   - Fixed `vmodels` → `virtual models` in the architecture diagram

## Changes

| File | Change |
|---|---|
| `main.go` | persistent `--server` flag default 5005→5000 |
| `internal/commands/client.go` | `NewClient` fallback URL 5005→5000 |
| `internal/commands/start.go` | `--port` flag default 5005→5000 |
| `internal/commands/start_test.go` | test assertions updated |
| `internal/commands/commands_test.go` | test constant updated |
| `README.md` | full sync with current CLI and API surface |

Closes #41