### PR TITLE
fix(copilot): route GPT-5 models to Responses API

### DIFF
--- a/internal/providers/copilot/adapter.go
+++ b/internal/providers/copilot/adapter.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"omnillm/internal/cif"
 	"omnillm/internal/lib/modelrouting"
+	"omnillm/internal/providers/openaicompat"
 	"omnillm/internal/providers/types"
 
 	"github.com/rs/zerolog/log"
@@ -25,11 +28,61 @@ func (a *CopilotAdapter) GetProvider() types.Provider {
 }
 
 func (a *CopilotAdapter) Execute(ctx context.Context, request *cif.CanonicalRequest) (*cif.CanonicalResponse, error) {
+	model := ""
+	if request != nil {
+		model = a.RemapModel(request.Model)
+	}
+	if !a.forceChatCompletions(request) && a.shouldUseResponsesAPI(model) {
+		return a.executeResponses(ctx, request)
+	}
 	return a.executeOpenAI(ctx, request)
 }
 
 func (a *CopilotAdapter) ExecuteStream(ctx context.Context, request *cif.CanonicalRequest) (<-chan cif.CIFStreamEvent, error) {
+	model := ""
+	if request != nil {
+		model = a.RemapModel(request.Model)
+	}
+	if !a.forceChatCompletions(request) && a.shouldUseResponsesAPI(model) {
+		return a.executeResponsesStream(ctx, request)
+	}
 	return a.executeOpenAIStream(ctx, request)
+}
+
+// shouldUseResponsesAPI returns true for Copilot-hosted models that are only
+// reachable via /responses. The GPT-5 family is currently Responses-only on
+// Copilot; the prefix match is intentionally generic so future GPT-5.x
+// variants don't regress like gpt-5.5 did.
+func (a *CopilotAdapter) shouldUseResponsesAPI(model string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "gpt-5")
+}
+
+// forceChatCompletions honours an explicit caller override that disables the
+// Responses-API auto-routing.
+func (a *CopilotAdapter) forceChatCompletions(request *cif.CanonicalRequest) bool {
+	return request != nil &&
+		request.Extensions != nil &&
+		request.Extensions.ForceChatCompletions != nil &&
+		*request.Extensions.ForceChatCompletions
+}
+
+// isUnsupportedChatCompletionsModel detects Copilot's
+// `unsupported_api_for_model` 400 so we can fall back to /responses for
+// Responses-only models that don't match shouldUseResponsesAPI.
+func (a *CopilotAdapter) isUnsupportedChatCompletionsModel(apiErr *copilotAPIError) bool {
+	if apiErr == nil || apiErr.statusCode != http.StatusBadRequest {
+		return false
+	}
+	var payload copilotErrorEnvelope
+	if err := json.Unmarshal(apiErr.body, &payload); err == nil {
+		if payload.Error.Code == "unsupported_api_for_model" {
+			return true
+		}
+		if strings.Contains(strings.ToLower(payload.Error.Message), "/chat/completions") {
+			return true
+		}
+	}
+	return strings.Contains(strings.ToLower(string(apiErr.body)), "unsupported_api_for_model")
 }
 
 func (a *CopilotAdapter) RemapModel(canonicalModel string) string {
@@ -72,6 +125,13 @@ func (a *CopilotAdapter) executeOpenAIWithRetry(ctx context.Context, request *ci
 		apiErr := &copilotAPIError{statusCode: resp.StatusCode, body: body}
 		if allowAuthRetry && a.shouldRetryAfterAuthError(request, apiErr) && a.refreshTokenForRetry("chat.completions") {
 			return a.executeOpenAIWithRetry(ctx, request, false)
+		}
+		if !a.forceChatCompletions(request) && a.isUnsupportedChatCompletionsModel(apiErr) {
+			log.Info().
+				Str("model", request.Model).
+				Str("provider", a.provider.GetInstanceID()).
+				Msg("Copilot model requires responses API, retrying request")
+			return a.executeResponses(ctx, request)
 		}
 		return nil, apiErr
 	}
@@ -122,6 +182,13 @@ func (a *CopilotAdapter) executeOpenAIStreamWithRetry(ctx context.Context, reque
 		apiErr := &copilotAPIError{statusCode: resp.StatusCode, body: body}
 		if allowAuthRetry && a.shouldRetryAfterAuthError(request, apiErr) && a.refreshTokenForRetry("chat.completions-stream") {
 			return a.executeOpenAIStreamWithRetry(ctx, request, false)
+		}
+		if !a.forceChatCompletions(request) && a.isUnsupportedChatCompletionsModel(apiErr) {
+			log.Info().
+				Str("model", request.Model).
+				Str("provider", a.provider.GetInstanceID()).
+				Msg("Copilot model requires responses API for streaming, retrying request")
+			return a.executeResponsesStream(ctx, request)
 		}
 		return nil, apiErr
 	}
@@ -213,4 +280,70 @@ func (a *CopilotAdapter) refreshTokenForRetry(endpoint string) bool {
 		Str("endpoint", endpoint).
 		Msg("Refreshed Copilot token after upstream auth error, retrying request")
 	return true
+}
+
+// responsesURL appends the Copilot Responses-API path to the provider base URL.
+func (a *CopilotAdapter) responsesURL() string {
+	return fmt.Sprintf("%s/responses", a.provider.GetBaseURL())
+}
+
+// buildResponsesPayload constructs the Copilot Responses-API payload by
+// delegating to the shared openaicompat helper. Tool name sanitization that
+// applies to /chat/completions is intentionally skipped here — the Responses
+// path forwards canonical tool names directly. If Copilot ever enforces the
+// same name pattern on /responses, plumb the existing copilotToolNameMapper
+// through this call.
+func (a *CopilotAdapter) buildResponsesPayload(request *cif.CanonicalRequest, stream bool) map[string]interface{} {
+	return openaicompat.BuildResponsesPayload(a.RemapModel(request.Model), request, stream, openaicompat.ResponsesConfig{})
+}
+
+func (a *CopilotAdapter) executeResponses(ctx context.Context, request *cif.CanonicalRequest) (*cif.CanonicalResponse, error) {
+	return a.executeResponsesWithRetry(ctx, request, true)
+}
+
+func (a *CopilotAdapter) executeResponsesWithRetry(ctx context.Context, request *cif.CanonicalRequest, allowAuthRetry bool) (*cif.CanonicalResponse, error) {
+	payload := a.buildResponsesPayload(request, false)
+	resp, err := openaicompat.ExecuteResponses(ctx, a.responsesURL(), a.requestHeaders(request), payload)
+	if err != nil {
+		if allowAuthRetry {
+			if apiErr := copilotAPIErrorFromOpenAICompat(err); apiErr != nil &&
+				a.shouldRetryAfterAuthError(request, apiErr) &&
+				a.refreshTokenForRetry("responses") {
+				return a.executeResponsesWithRetry(ctx, request, false)
+			}
+		}
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (a *CopilotAdapter) executeResponsesStream(ctx context.Context, request *cif.CanonicalRequest) (<-chan cif.CIFStreamEvent, error) {
+	return a.executeResponsesStreamWithRetry(ctx, request, true)
+}
+
+func (a *CopilotAdapter) executeResponsesStreamWithRetry(ctx context.Context, request *cif.CanonicalRequest, allowAuthRetry bool) (<-chan cif.CIFStreamEvent, error) {
+	payload := a.buildResponsesPayload(request, true)
+	eventCh, err := openaicompat.StreamResponses(ctx, a.responsesURL(), a.requestHeaders(request), payload)
+	if err != nil {
+		if allowAuthRetry {
+			if apiErr := copilotAPIErrorFromOpenAICompat(err); apiErr != nil &&
+				a.shouldRetryAfterAuthError(request, apiErr) &&
+				a.refreshTokenForRetry("responses-stream") {
+				return a.executeResponsesStreamWithRetry(ctx, request, false)
+			}
+		}
+		return nil, err
+	}
+	return eventCh, nil
+}
+
+// copilotAPIErrorFromOpenAICompat lifts the openaicompat APIError into the
+// Copilot-local error type so existing auth-retry helpers can reason about
+// status codes without importing openaicompat in their signatures.
+func copilotAPIErrorFromOpenAICompat(err error) *copilotAPIError {
+	var compatErr *openaicompat.APIError
+	if !errors.As(err, &compatErr) || compatErr == nil {
+		return nil
+	}
+	return &copilotAPIError{statusCode: compatErr.StatusCode, body: compatErr.Body}
 }

--- a/internal/providers/copilot/copilot_test.go
+++ b/internal/providers/copilot/copilot_test.go
@@ -320,3 +320,175 @@ func TestCopilotAdapterExecuteStream_DisableAuthRetryMakesSingleAttempt(t *testi
 	}
 }
 
+func TestCopilotAdapterExecute_GPT5FamilyRoutesToResponsesEndpoint(t *testing.T) {
+	var capturedPath string
+	var capturedPayload map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&capturedPayload)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_gpt5","model":"gpt-5.5","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","content":[{"type":"output_text","text":"pong"}]}],"usage":{"input_tokens":3,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	provider := NewGitHubCopilotProvider("github-copilot-test", "")
+	provider.baseURL = server.URL
+	provider.token = "test-token"
+	adapter := provider.GetAdapter().(*CopilotAdapter)
+
+	resp, err := adapter.Execute(context.Background(), &cif.CanonicalRequest{
+		Model: "gpt-5.5",
+		Messages: []cif.CIFMessage{
+			cif.CIFUserMessage{
+				Role: "user",
+				Content: []cif.CIFContentPart{
+					cif.CIFTextPart{Type: "text", Text: "ping"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if capturedPath != "/responses" {
+		t.Fatalf("expected /responses for gpt-5 family, got %q", capturedPath)
+	}
+	if model, _ := capturedPayload["model"].(string); model != "gpt-5.5" {
+		t.Fatalf("expected upstream model gpt-5.5, got %#v", capturedPayload["model"])
+	}
+	if resp == nil || resp.ID != "resp_gpt5" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+}
+
+func TestCopilotAdapterExecute_RoutesResponsesUsingRemappedModel(t *testing.T) {
+	var capturedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_remap","model":"gpt-5.5","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","content":[{"type":"output_text","text":"pong"}]}],"usage":{"input_tokens":3,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	provider := NewGitHubCopilotProvider("github-copilot-test", "")
+	provider.baseURL = server.URL
+	provider.token = "test-token"
+	adapter := provider.GetAdapter().(*CopilotAdapter)
+
+	resp, err := adapter.Execute(context.Background(), &cif.CanonicalRequest{
+		Model: "  gpt-5.5  ",
+		Messages: []cif.CIFMessage{
+			cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "ping"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if capturedPath != "/responses" {
+		t.Fatalf("expected /responses for remapped gpt-5.5, got %q", capturedPath)
+	}
+	if resp == nil || resp.ID != "resp_remap" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+}
+
+func TestCopilotAdapterExecute_NonGPT5StaysOnChatCompletions(t *testing.T) {
+	var capturedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":    "chatcmpl_nongpt5",
+			"model": "claude-haiku-4.5",
+			"choices": []map[string]interface{}{{
+				"index": 0,
+				"message": map[string]interface{}{
+					"role":    "assistant",
+					"content": "ok",
+				},
+				"finish_reason": "stop",
+			}},
+		})
+	}))
+	defer server.Close()
+
+	provider := NewGitHubCopilotProvider("github-copilot-test", "")
+	provider.baseURL = server.URL
+	provider.token = "test-token"
+	adapter := provider.GetAdapter().(*CopilotAdapter)
+
+	if _, err := adapter.Execute(context.Background(), &cif.CanonicalRequest{
+		Model: "claude-haiku-4.5",
+		Messages: []cif.CIFMessage{
+			cif.CIFUserMessage{
+				Role: "user",
+				Content: []cif.CIFContentPart{
+					cif.CIFTextPart{Type: "text", Text: "ping"},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if capturedPath != "/chat/completions" {
+		t.Fatalf("expected /chat/completions for non-gpt-5 model, got %q", capturedPath)
+	}
+}
+
+func TestCopilotAdapterExecute_FallsBackToResponsesOnUnsupportedAPIError(t *testing.T) {
+	var paths []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/chat/completions":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"error": map[string]interface{}{
+					"message": `model "future-responses-only" is not accessible via the /chat/completions endpoint`,
+					"code":    "unsupported_api_for_model",
+				},
+			})
+		case "/responses":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp_fallback","model":"future-responses-only","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":2,"output_tokens":1}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewGitHubCopilotProvider("github-copilot-test", "")
+	provider.baseURL = server.URL
+	provider.token = "test-token"
+	adapter := provider.GetAdapter().(*CopilotAdapter)
+
+	resp, err := adapter.Execute(context.Background(), &cif.CanonicalRequest{
+		// Note: model name does NOT match the gpt-5 prefix — exercises the
+		// upstream-error fallback path rather than shouldUseResponsesAPI.
+		Model: "future-responses-only",
+		Messages: []cif.CIFMessage{
+			cif.CIFUserMessage{
+				Role: "user",
+				Content: []cif.CIFContentPart{
+					cif.CIFTextPart{Type: "text", Text: "ping"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if resp == nil || resp.ID != "resp_fallback" {
+		t.Fatalf("unexpected fallback response: %#v", resp)
+	}
+	if len(paths) != 2 || paths[0] != "/chat/completions" || paths[1] != "/responses" {
+		t.Fatalf("expected chat→responses fallback, got %v", paths)
+	}
+}

--- a/internal/routes/copilot_compat.go
+++ b/internal/routes/copilot_compat.go
@@ -1,6 +1,8 @@
 package routes
 
 import (
+	"strings"
+
 	"omnillm/internal/cif"
 	"omnillm/internal/providers/types"
 )
@@ -15,7 +17,13 @@ func applyGitHubCopilotSingleUpstreamMode(provider types.Provider, request *cif.
 	}
 
 	trueValue := true
-	request.Extensions.ForceChatCompletions = &trueValue
+	// Copilot GPT-5 family models are Responses-only upstream. Do not force
+	// chat completions for those models, or the provider can never switch to
+	// /responses and upstream returns `unsupported_api_for_model`.
+	model := strings.ToLower(strings.TrimSpace(request.Model))
+	if !strings.HasPrefix(model, "gpt-5") {
+		request.Extensions.ForceChatCompletions = &trueValue
+	}
 	request.Extensions.DisableAuthRetry = &trueValue
 	request.Extensions.DisableStreamingFallback = &trueValue
 }


### PR DESCRIPTION
## Summary
- route GitHub Copilot GPT-5-family models to `/responses` instead of forcing `/chat/completions`
- keep compatibility behavior for non-GPT-5 Copilot models
- add fallback from chat completions to responses when upstream returns `unsupported_api_for_model`

## Related issue
- Closes #50

## Test plan
- [x] `go test ./internal/providers/copilot/...`
- [x] `go test ./internal/routes/...`
- [x] `go build ./...`
- [x] Manual repro confirmed: `gpt-5.5` no longer pinned to `/chat/completions`