### PR TITLE
Add metering dashboard and tracking

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { useMediaQuery } from "@/lib/useMediaQuery"
 import { ChatPage } from "@/pages/ChatPage"
 import { ConfigPage } from "@/pages/ConfigPage"
 import { LoggingPage } from "@/pages/LoggingPage"
+import { MeteringPage } from "@/pages/MeteringPage"
 import { ProvidersPage } from "@/pages/ProvidersPage"
 import { AboutPage } from "@/pages/SettingsPage"
 import { VirtualModelPage } from "@/pages/VirtualModelPage"
@@ -34,6 +35,7 @@ type Tab =
   | "providers"
   | "chat"
   | "logging"
+  | "metering"
   | "virtualmodel"
   | "config"
   | "about"
@@ -56,6 +58,7 @@ function isTab(value: string): value is Tab {
     value === "providers"
     || value === "chat"
     || value === "logging"
+    || value === "metering"
     || value === "virtualmodel"
     || value === "config"
     || value === "about"
@@ -122,6 +125,7 @@ export default function AppComponent() {
       { id: "providers" as const, label: t("nav:providers"), icon: Database },
       { id: "chat" as const, label: t("nav:chat"), icon: MessageSquare },
       { id: "logging" as const, label: t("nav:logging"), icon: BarChart3 },
+      { id: "metering" as const, label: "Metering", icon: BarChart3 },
       {
         id: "virtualmodel" as const,
         label: t("nav:virtualModels"),
@@ -590,6 +594,7 @@ export default function AppComponent() {
                   )}
                   {tab === "chat" && <ChatPage showToast={showToast} />}
                   {tab === "logging" && <LoggingPage showToast={showToast} />}
+                  {tab === "metering" && <MeteringPage showToast={showToast} />}
                   {tab === "virtualmodel" && (
                     <VirtualModelPage showToast={showToast} />
                   )}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -544,7 +544,7 @@ export interface MeteringBreakdownItem {
 }
 
 export interface MeteringLogsResponse {
-  items: Array<MeteringRecord>
+  items: Array<MeteringRecord> | null
   total: number
   page: number
   page_size: number
@@ -581,12 +581,12 @@ export const getMeteringStats = (params: MeteringQuery = {}) =>
   )
 
 export const getMeteringByModel = (params: MeteringQuery = {}) =>
-  apiFetch<{ items: Array<MeteringBreakdownItem> }>(
+  apiFetch<{ items: Array<MeteringBreakdownItem> | null }>(
     `/api/admin/metering/by-model${buildQueryString(params)}`,
   )
 
 export const getMeteringByProvider = (params: MeteringQuery = {}) =>
-  apiFetch<{ items: Array<MeteringBreakdownItem> }>(
+  apiFetch<{ items: Array<MeteringBreakdownItem> | null }>(
     `/api/admin/metering/by-provider${buildQueryString(params)}`,
   )
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -505,6 +505,91 @@ export const getUsage = () => apiFetch<UsageData>("/usage")
 export const getProviderUsage = (id: string) =>
   apiFetch<UsageData>(`/api/admin/providers/${id}/usage`)
 
+// ─── Metering ─────────────────────────────────────────────────────────────────
+
+export interface MeteringRecord {
+  id: number
+  request_id: string
+  model_id: string
+  model_used: string
+  provider_id: string
+  api_shape: string
+  input_tokens: number
+  output_tokens: number
+  total_tokens: number
+  latency_ms: number
+  is_stream: boolean
+  status_code: number
+  error_message: string
+  created_at: string
+}
+
+export interface MeteringStats {
+  total_requests: number
+  total_input_tokens: number
+  total_output_tokens: number
+  total_tokens: number
+  avg_latency_ms: number
+  error_count: number
+}
+
+export interface MeteringBreakdownItem {
+  model_id?: string
+  provider_id?: string
+  requests: number
+  input_tokens: number
+  output_tokens: number
+  total_tokens: number
+  avg_latency_ms: number
+}
+
+export interface MeteringLogsResponse {
+  items: Array<MeteringRecord>
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface MeteringQuery {
+  model_id?: string
+  provider_id?: string
+  api_shape?: string
+  since?: string
+  until?: string
+  page?: number
+  page_size?: number
+}
+
+function buildQueryString(params: MeteringQuery): string {
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === "") continue
+    search.set(key, String(value))
+  }
+  const query = search.toString()
+  return query ? `?${query}` : ""
+}
+
+export const getMeteringLogs = (params: MeteringQuery = {}) =>
+  apiFetch<MeteringLogsResponse>(
+    `/api/admin/metering/logs${buildQueryString(params)}`,
+  )
+
+export const getMeteringStats = (params: MeteringQuery = {}) =>
+  apiFetch<MeteringStats>(
+    `/api/admin/metering/stats${buildQueryString(params)}`,
+  )
+
+export const getMeteringByModel = (params: MeteringQuery = {}) =>
+  apiFetch<{ items: Array<MeteringBreakdownItem> }>(
+    `/api/admin/metering/by-model${buildQueryString(params)}`,
+  )
+
+export const getMeteringByProvider = (params: MeteringQuery = {}) =>
+  apiFetch<{ items: Array<MeteringBreakdownItem> }>(
+    `/api/admin/metering/by-provider${buildQueryString(params)}`,
+  )
+
 // ─── Log level ────────────────────────────────────────────────────────────────
 
 export const getLogLevel = async () => {

--- a/frontend/src/pages/MeteringPage.tsx
+++ b/frontend/src/pages/MeteringPage.tsx
@@ -240,14 +240,14 @@ export function MeteringPage({
     value.setHours(value.getHours() - 24)
     return isoInputValue(value)
   }, [now])
-  const defaultUntil = useMemo(() => isoInputValue(now), [now])
 
   const [since, setSince] = useState(defaultSince)
-  const [until, setUntil] = useState(defaultUntil)
+  const [until, setUntil] = useState("")
   const [modelId, setModelId] = useState("")
   const [providerId, setProviderId] = useState("")
   const [apiShape, setAPIShape] = useState("")
   const [page, setPage] = useState(1)
+  const [reloadKey, setReloadKey] = useState(0)
   const [loading, setLoading] = useState(true)
   const [stats, setStats] = useState<MeteringStats | null>(null)
   const [logs, setLogs] = useState<MeteringLogsResponse | null>(null)
@@ -264,7 +264,7 @@ export function MeteringPage({
       page,
       page_size: 50,
     }),
-    [apiShape, modelId, page, providerId, since, until],
+    [apiShape, modelId, page, providerId, reloadKey, since, until],
   )
 
   useEffect(() => {
@@ -343,7 +343,10 @@ export function MeteringPage({
         </div>
         <button
           className="btn btn-ghost btn-sm"
-          onClick={() => setPage(1)}
+          onClick={() => {
+            setPage(1)
+            setReloadKey((value) => value + 1)
+          }}
           disabled={loading}
         >
           Refresh

--- a/frontend/src/pages/MeteringPage.tsx
+++ b/frontend/src/pages/MeteringPage.tsx
@@ -113,9 +113,11 @@ function BreakdownTable({
 }: {
   title: string
   keyLabel: "model" | "provider"
-  items: Array<MeteringBreakdownItem>
+  items: Array<MeteringBreakdownItem> | null | undefined
   valueKey: "model_id" | "provider_id"
 }) {
+  const safeItems = items ?? []
+
   return (
     <Card>
       <div
@@ -146,7 +148,7 @@ function BreakdownTable({
             fontFamily: "var(--font-mono)",
           }}
         >
-          {items.length} rows
+          {safeItems.length} rows
         </span>
       </div>
       <div style={{ overflowX: "auto" }}>
@@ -179,7 +181,7 @@ function BreakdownTable({
             </tr>
           </thead>
           <tbody>
-            {items.length === 0 && (
+            {safeItems.length === 0 && (
               <tr>
                 <td
                   colSpan={6}
@@ -193,7 +195,7 @@ function BreakdownTable({
                 </td>
               </tr>
             )}
-            {items.map((item, index) => (
+            {safeItems.map((item, index) => (
               <tr key={`${item[valueKey] ?? "unknown"}-${index}`}>
                 <td
                   style={{
@@ -278,9 +280,9 @@ export function MeteringPage({
       .then(([nextStats, nextLogs, nextByModel, nextByProvider]) => {
         if (cancelled) return
         setStats(nextStats)
-        setLogs(nextLogs)
-        setByModel(nextByModel.items)
-        setByProvider(nextByProvider.items)
+        setLogs({ ...nextLogs, items: nextLogs.items ?? [] })
+        setByModel(nextByModel.items ?? [])
+        setByProvider(nextByProvider.items ?? [])
       })
       .catch((e: unknown) => {
         if (cancelled) return
@@ -301,6 +303,7 @@ export function MeteringPage({
 
   const totalPages =
     logs ? Math.max(1, Math.ceil(logs.total / logs.page_size)) : 1
+  const logItems = logs?.items ?? []
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
@@ -553,7 +556,7 @@ export function MeteringPage({
               </tr>
             </thead>
             <tbody>
-              {!loading && (logs?.items.length ?? 0) === 0 && (
+              {!loading && logItems.length === 0 && (
                 <tr>
                   <td
                     colSpan={10}
@@ -567,7 +570,7 @@ export function MeteringPage({
                   </td>
                 </tr>
               )}
-              {logs?.items.map((row: MeteringRecord) => (
+              {logItems.map((row: MeteringRecord) => (
                 <tr key={row.id}>
                   <td style={cellStyle}>{formatDateTime(row.created_at)}</td>
                   <td style={cellStyle}>{row.model_id}</td>

--- a/frontend/src/pages/MeteringPage.tsx
+++ b/frontend/src/pages/MeteringPage.tsx
@@ -1,0 +1,650 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react"
+
+import {
+  getMeteringByModel,
+  getMeteringByProvider,
+  getMeteringLogs,
+  getMeteringStats,
+  type MeteringBreakdownItem,
+  type MeteringLogsResponse,
+  type MeteringQuery,
+  type MeteringRecord,
+  type MeteringStats,
+} from "@/api"
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat().format(value)
+}
+
+function formatLatency(value: number) {
+  return `${Math.round(value)} ms`
+}
+
+function formatDateTime(value: string) {
+  if (!value) return "—"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
+function isoInputValue(date: Date) {
+  return date.toISOString().slice(0, 16)
+}
+
+function Card({
+  children,
+  style,
+}: {
+  children: React.ReactNode
+  style?: CSSProperties
+}) {
+  return (
+    <section
+      style={{
+        background: "var(--color-bg-elevated)",
+        borderRadius: "var(--radius-lg)",
+        border: "1px solid var(--color-separator)",
+        boxShadow: "var(--shadow-card)",
+        overflow: "hidden",
+        ...style,
+      }}
+    >
+      {children}
+    </section>
+  )
+}
+
+function StatCard({
+  label,
+  value,
+  accent,
+  subtext,
+}: {
+  label: string
+  value: string
+  accent: string
+  subtext?: string
+}) {
+  return (
+    <Card style={{ padding: 18, borderTop: `2px solid ${accent}` }}>
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: "var(--color-text-tertiary)",
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          marginTop: 10,
+          fontSize: 28,
+          fontWeight: 700,
+          color: accent,
+          fontFamily: "var(--font-mono)",
+          letterSpacing: "-0.03em",
+        }}
+      >
+        {value}
+      </div>
+      {subtext && (
+        <div
+          style={{
+            marginTop: 8,
+            fontSize: 12,
+            color: "var(--color-text-secondary)",
+          }}
+        >
+          {subtext}
+        </div>
+      )}
+    </Card>
+  )
+}
+
+function BreakdownTable({
+  title,
+  keyLabel,
+  items,
+  valueKey,
+}: {
+  title: string
+  keyLabel: "model" | "provider"
+  items: Array<MeteringBreakdownItem>
+  valueKey: "model_id" | "provider_id"
+}) {
+  return (
+    <Card>
+      <div
+        style={{
+          padding: "14px 16px",
+          borderBottom: "1px solid var(--color-separator)",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div>
+          <h2
+            style={{
+              margin: 0,
+              fontSize: 15,
+              fontWeight: 700,
+              color: "var(--color-text)",
+            }}
+          >
+            {title}
+          </h2>
+        </div>
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--color-text-tertiary)",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          {items.length} rows
+        </span>
+      </div>
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ background: "rgba(255,255,255,0.02)" }}>
+              {[
+                keyLabel,
+                "requests",
+                "input",
+                "output",
+                "total",
+                "avg latency",
+              ].map((label) => (
+                <th
+                  key={label}
+                  style={{
+                    textAlign: "left",
+                    padding: "10px 14px",
+                    fontSize: 11,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.06em",
+                    color: "var(--color-text-tertiary)",
+                    borderBottom: "1px solid var(--color-separator)",
+                  }}
+                >
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 && (
+              <tr>
+                <td
+                  colSpan={6}
+                  style={{
+                    padding: "24px 14px",
+                    color: "var(--color-text-secondary)",
+                    textAlign: "center",
+                  }}
+                >
+                  No data yet.
+                </td>
+              </tr>
+            )}
+            {items.map((item, index) => (
+              <tr key={`${item[valueKey] ?? "unknown"}-${index}`}>
+                <td
+                  style={{
+                    padding: "12px 14px",
+                    borderBottom: "1px solid var(--color-separator)",
+                    color: "var(--color-text)",
+                    fontWeight: 600,
+                  }}
+                >
+                  {item[valueKey] ?? "—"}
+                </td>
+                <td style={cellStyle}>{formatNumber(item.requests)}</td>
+                <td style={cellStyle}>{formatNumber(item.input_tokens)}</td>
+                <td style={cellStyle}>{formatNumber(item.output_tokens)}</td>
+                <td style={cellStyle}>{formatNumber(item.total_tokens)}</td>
+                <td style={cellStyle}>{formatLatency(item.avg_latency_ms)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  )
+}
+
+const cellStyle: CSSProperties = {
+  padding: "12px 14px",
+  borderBottom: "1px solid var(--color-separator)",
+  color: "var(--color-text-secondary)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+}
+
+export function MeteringPage({
+  showToast,
+}: {
+  showToast: (msg: string, type?: "success" | "error") => void
+}) {
+  const now = useMemo(() => new Date(), [])
+  const defaultSince = useMemo(() => {
+    const value = new Date(now)
+    value.setHours(value.getHours() - 24)
+    return isoInputValue(value)
+  }, [now])
+  const defaultUntil = useMemo(() => isoInputValue(now), [now])
+
+  const [since, setSince] = useState(defaultSince)
+  const [until, setUntil] = useState(defaultUntil)
+  const [modelId, setModelId] = useState("")
+  const [providerId, setProviderId] = useState("")
+  const [apiShape, setAPIShape] = useState("")
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(true)
+  const [stats, setStats] = useState<MeteringStats | null>(null)
+  const [logs, setLogs] = useState<MeteringLogsResponse | null>(null)
+  const [byModel, setByModel] = useState<Array<MeteringBreakdownItem>>([])
+  const [byProvider, setByProvider] = useState<Array<MeteringBreakdownItem>>([])
+
+  const query = useMemo<MeteringQuery>(
+    () => ({
+      since: since ? new Date(since).toISOString() : undefined,
+      until: until ? new Date(until).toISOString() : undefined,
+      model_id: modelId || undefined,
+      provider_id: providerId || undefined,
+      api_shape: apiShape || undefined,
+      page,
+      page_size: 50,
+    }),
+    [apiShape, modelId, page, providerId, since, until],
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+
+    Promise.all([
+      getMeteringStats(query),
+      getMeteringLogs(query),
+      getMeteringByModel(query),
+      getMeteringByProvider(query),
+    ])
+      .then(([nextStats, nextLogs, nextByModel, nextByProvider]) => {
+        if (cancelled) return
+        setStats(nextStats)
+        setLogs(nextLogs)
+        setByModel(nextByModel.items)
+        setByProvider(nextByProvider.items)
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return
+        showToast(
+          "Failed to load metering data: "
+            + (e instanceof Error ? e.message : String(e)),
+          "error",
+        )
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [query, showToast])
+
+  const totalPages =
+    logs ? Math.max(1, Math.ceil(logs.total / logs.page_size)) : 1
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          gap: 16,
+          flexWrap: "wrap",
+        }}
+      >
+        <div>
+          <h1
+            style={{
+              margin: 0,
+              fontFamily: "var(--font-display)",
+              fontWeight: 700,
+              fontSize: 28,
+              letterSpacing: "-0.02em",
+              color: "var(--color-text)",
+            }}
+          >
+            Metering
+          </h1>
+          <p
+            style={{
+              margin: "8px 0 0",
+              fontSize: 14,
+              color: "var(--color-text-secondary)",
+              maxWidth: 720,
+            }}
+          >
+            Request-level usage data captured after CIF responses finalize, with
+            token totals, latency, provider attribution, and raw request logs.
+          </p>
+        </div>
+        <button
+          className="btn btn-ghost btn-sm"
+          onClick={() => setPage(1)}
+          disabled={loading}
+        >
+          Refresh
+        </button>
+      </div>
+
+      <Card style={{ padding: 18 }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+            gap: 12,
+          }}
+        >
+          <label style={fieldStyle}>
+            <span style={labelStyle}>Since</span>
+            <input
+              className="sys-input"
+              type="datetime-local"
+              value={since}
+              onChange={(e) => {
+                setSince(e.target.value)
+                setPage(1)
+              }}
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={labelStyle}>Until</span>
+            <input
+              className="sys-input"
+              type="datetime-local"
+              value={until}
+              onChange={(e) => {
+                setUntil(e.target.value)
+                setPage(1)
+              }}
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={labelStyle}>Model</span>
+            <input
+              className="sys-input"
+              value={modelId}
+              onChange={(e) => {
+                setModelId(e.target.value)
+                setPage(1)
+              }}
+              placeholder="claude-3-7-sonnet"
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={labelStyle}>Provider</span>
+            <input
+              className="sys-input"
+              value={providerId}
+              onChange={(e) => {
+                setProviderId(e.target.value)
+                setPage(1)
+              }}
+              placeholder="provider instance id"
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={labelStyle}>API shape</span>
+            <select
+              className="sys-select"
+              value={apiShape}
+              onChange={(e) => {
+                setAPIShape(e.target.value)
+                setPage(1)
+              }}
+            >
+              <option value="">All</option>
+              <option value="openai">openai</option>
+              <option value="anthropic">anthropic</option>
+            </select>
+          </label>
+        </div>
+      </Card>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(210px, 1fr))",
+          gap: 14,
+        }}
+      >
+        <StatCard
+          label="Requests"
+          value={formatNumber(stats?.total_requests ?? 0)}
+          accent="var(--color-blue)"
+          subtext="Completed requests in the selected window"
+        />
+        <StatCard
+          label="Total tokens"
+          value={formatNumber(stats?.total_tokens ?? 0)}
+          accent="var(--color-green)"
+          subtext={`${formatNumber(stats?.total_input_tokens ?? 0)} in / ${formatNumber(stats?.total_output_tokens ?? 0)} out`}
+        />
+        <StatCard
+          label="Avg latency"
+          value={formatLatency(stats?.avg_latency_ms ?? 0)}
+          accent="var(--color-orange)"
+          subtext="Wall-clock latency across successful and failed requests"
+        />
+        <StatCard
+          label="Errors"
+          value={formatNumber(stats?.error_count ?? 0)}
+          accent="var(--color-red)"
+          subtext="Requests recorded with a status code ≥ 400"
+        />
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
+          gap: 16,
+        }}
+      >
+        <BreakdownTable
+          title="By model"
+          keyLabel="model"
+          items={byModel}
+          valueKey="model_id"
+        />
+        <BreakdownTable
+          title="By provider"
+          keyLabel="provider"
+          items={byProvider}
+          valueKey="provider_id"
+        />
+      </div>
+
+      <Card>
+        <div
+          style={{
+            padding: "14px 16px",
+            borderBottom: "1px solid var(--color-separator)",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 12,
+            flexWrap: "wrap",
+          }}
+        >
+          <div>
+            <h2
+              style={{
+                margin: 0,
+                fontSize: 15,
+                fontWeight: 700,
+                color: "var(--color-text)",
+              }}
+            >
+              Request log
+            </h2>
+            <p
+              style={{
+                margin: "6px 0 0",
+                fontSize: 12,
+                color: "var(--color-text-secondary)",
+              }}
+            >
+              Raw metering rows captured from OpenAI and Anthropic response
+              paths.
+            </p>
+          </div>
+          <div
+            style={{
+              fontSize: 11,
+              color: "var(--color-text-tertiary)",
+              fontFamily: "var(--font-mono)",
+            }}
+          >
+            {loading ? "Loading…" : `${logs?.total ?? 0} rows`}
+          </div>
+        </div>
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ background: "rgba(255,255,255,0.02)" }}>
+                {[
+                  "time",
+                  "model",
+                  "provider",
+                  "shape",
+                  "input",
+                  "output",
+                  "total",
+                  "latency",
+                  "status",
+                  "stream",
+                ].map((label) => (
+                  <th
+                    key={label}
+                    style={{
+                      textAlign: "left",
+                      padding: "10px 14px",
+                      fontSize: 11,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.06em",
+                      color: "var(--color-text-tertiary)",
+                      borderBottom: "1px solid var(--color-separator)",
+                    }}
+                  >
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {!loading && (logs?.items.length ?? 0) === 0 && (
+                <tr>
+                  <td
+                    colSpan={10}
+                    style={{
+                      padding: "28px 16px",
+                      textAlign: "center",
+                      color: "var(--color-text-secondary)",
+                    }}
+                  >
+                    No metering records yet.
+                  </td>
+                </tr>
+              )}
+              {logs?.items.map((row: MeteringRecord) => (
+                <tr key={row.id}>
+                  <td style={cellStyle}>{formatDateTime(row.created_at)}</td>
+                  <td style={cellStyle}>{row.model_id}</td>
+                  <td style={cellStyle}>{row.provider_id}</td>
+                  <td style={cellStyle}>{row.api_shape}</td>
+                  <td style={cellStyle}>{formatNumber(row.input_tokens)}</td>
+                  <td style={cellStyle}>{formatNumber(row.output_tokens)}</td>
+                  <td style={cellStyle}>{formatNumber(row.total_tokens)}</td>
+                  <td style={cellStyle}>{formatLatency(row.latency_ms)}</td>
+                  <td
+                    style={{
+                      ...cellStyle,
+                      color:
+                        row.status_code >= 400 ?
+                          "var(--color-red)"
+                        : "var(--color-green)",
+                    }}
+                  >
+                    {row.status_code}
+                  </td>
+                  <td style={cellStyle}>{row.is_stream ? "yes" : "no"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 12,
+            padding: "12px 16px",
+            borderTop: "1px solid var(--color-separator)",
+            flexWrap: "wrap",
+          }}
+        >
+          <div
+            style={{
+              fontSize: 12,
+              color: "var(--color-text-secondary)",
+            }}
+          >
+            Page {logs?.page ?? page} of {totalPages}
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button
+              className="btn btn-ghost btn-sm"
+              disabled={page <= 1 || loading}
+              onClick={() => setPage((value) => Math.max(1, value - 1))}
+            >
+              Previous
+            </button>
+            <button
+              className="btn btn-ghost btn-sm"
+              disabled={page >= totalPages || loading}
+              onClick={() => setPage((value) => value + 1)}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+const fieldStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 6,
+}
+
+const labelStyle: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "var(--color-text-tertiary)",
+}

--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -180,6 +180,24 @@ func (db *Database) createTables() error {
 			updated_at       DATETIME NOT NULL DEFAULT (datetime('now')),
 			FOREIGN KEY (virtual_model_id) REFERENCES virtual_models (virtual_model_id) ON DELETE CASCADE
 		)`,
+
+		// Per-request metering log — one row per completed API call.
+		`CREATE TABLE IF NOT EXISTS request_logs (
+			id            INTEGER PRIMARY KEY AUTOINCREMENT,
+			request_id    TEXT    NOT NULL DEFAULT '',
+			model_id      TEXT    NOT NULL DEFAULT '',
+			model_used    TEXT    NOT NULL DEFAULT '',
+			provider_id   TEXT    NOT NULL DEFAULT '',
+			api_shape     TEXT    NOT NULL DEFAULT 'openai',
+			input_tokens  INTEGER NOT NULL DEFAULT 0,
+			output_tokens INTEGER NOT NULL DEFAULT 0,
+			total_tokens  INTEGER NOT NULL DEFAULT 0,
+			latency_ms    INTEGER NOT NULL DEFAULT 0,
+			is_stream     INTEGER NOT NULL DEFAULT 0,
+			status_code   INTEGER NOT NULL DEFAULT 200,
+			error_message TEXT    NOT NULL DEFAULT '',
+			created_at    DATETIME NOT NULL DEFAULT (datetime('now'))
+		)`,
 	}
 
 	for _, q := range tables {
@@ -205,6 +223,9 @@ func (db *Database) createTables() error {
 		`CREATE INDEX IF NOT EXISTS idx_chat_messages_session_created_at  ON chat_messages (session_id, created_at, message_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_virtual_model_upstreams_vmodel_id ON virtual_model_upstreams (virtual_model_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_virtual_model_upstreams_ordering  ON virtual_model_upstreams (virtual_model_id, priority, id)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_logs_created_at           ON request_logs (created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_logs_model_created_at     ON request_logs (model_id, created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_logs_provider_created_at  ON request_logs (provider_id, created_at)`,
 	}
 
 	for _, q := range indexes {
@@ -272,6 +293,30 @@ var migrations = []migration{
 		`CREATE INDEX IF NOT EXISTS idx_chat_sessions_updated_at ON chat_sessions (updated_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_chat_messages_session_created_at ON chat_messages (session_id, created_at, message_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_virtual_model_upstreams_ordering ON virtual_model_upstreams (virtual_model_id, priority, id)`,
+	}},
+	// v7: add request_logs table for per-request metering. The table is also
+	// created in createTables for fresh databases; this migration handles
+	// existing databases that pre-date it.
+	{7, []string{
+		`CREATE TABLE IF NOT EXISTS request_logs (
+			id            INTEGER PRIMARY KEY AUTOINCREMENT,
+			request_id    TEXT    NOT NULL DEFAULT '',
+			model_id      TEXT    NOT NULL DEFAULT '',
+			model_used    TEXT    NOT NULL DEFAULT '',
+			provider_id   TEXT    NOT NULL DEFAULT '',
+			api_shape     TEXT    NOT NULL DEFAULT 'openai',
+			input_tokens  INTEGER NOT NULL DEFAULT 0,
+			output_tokens INTEGER NOT NULL DEFAULT 0,
+			total_tokens  INTEGER NOT NULL DEFAULT 0,
+			latency_ms    INTEGER NOT NULL DEFAULT 0,
+			is_stream     INTEGER NOT NULL DEFAULT 0,
+			status_code   INTEGER NOT NULL DEFAULT 200,
+			error_message TEXT    NOT NULL DEFAULT '',
+			created_at    DATETIME NOT NULL DEFAULT (datetime('now'))
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_logs_created_at          ON request_logs (created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_logs_model_created_at    ON request_logs (model_id, created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_logs_provider_created_at ON request_logs (provider_id, created_at)`,
 	}},
 }
 

--- a/internal/database/store_metering.go
+++ b/internal/database/store_metering.go
@@ -1,0 +1,225 @@
+package database
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// InsertMeteringRecord writes one request_logs row.
+func (db *Database) InsertMeteringRecord(r MeteringRecord) error {
+	_, err := db.db.Exec(
+		`INSERT INTO request_logs
+			(request_id, model_id, model_used, provider_id, api_shape,
+			 input_tokens, output_tokens, total_tokens,
+			 latency_ms, is_stream, status_code, error_message, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.RequestID, r.ModelID, r.ModelUsed, r.ProviderID, r.APIShape,
+		r.InputTokens, r.OutputTokens, r.TotalTokens,
+		r.LatencyMS, boolToInt(r.IsStream), r.StatusCode, r.ErrorMessage,
+		r.CreatedAt.UTC().Format(time.RFC3339),
+	)
+	return err
+}
+
+// MeteringFilter holds optional filters for metering queries.
+type MeteringFilter struct {
+	ModelID    string
+	ProviderID string
+	APIShape   string
+	Since      time.Time
+	Until      time.Time
+}
+
+// ListMeteringRecords returns paginated request_logs rows newest-first.
+func (db *Database) ListMeteringRecords(f MeteringFilter, limit, offset int) ([]MeteringRecord, int64, error) {
+	where, args := meteringWhere(f)
+
+	// count
+	var total int64
+	countSQL := "SELECT COUNT(*) FROM request_logs" + where
+	if err := db.db.QueryRow(countSQL, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("metering count: %w", err)
+	}
+
+	// rows
+	querySQL := `SELECT id, request_id, model_id, model_used, provider_id, api_shape,
+		input_tokens, output_tokens, total_tokens, latency_ms, is_stream,
+		status_code, error_message, created_at
+		FROM request_logs` + where +
+		` ORDER BY id DESC LIMIT ? OFFSET ?`
+	args = append(args, limit, offset)
+
+	rows, err := db.db.Query(querySQL, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("metering list: %w", err)
+	}
+	defer rows.Close()
+
+	var records []MeteringRecord
+	for rows.Next() {
+		var r MeteringRecord
+		var isStream int
+		var createdAt string
+		if err := rows.Scan(
+			&r.ID, &r.RequestID, &r.ModelID, &r.ModelUsed, &r.ProviderID, &r.APIShape,
+			&r.InputTokens, &r.OutputTokens, &r.TotalTokens, &r.LatencyMS, &isStream,
+			&r.StatusCode, &r.ErrorMessage, &createdAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("metering scan: %w", err)
+		}
+		r.IsStream = isStream == 1
+		r.CreatedAt = parseTime(createdAt)
+		records = append(records, r)
+	}
+	return records, total, rows.Err()
+}
+
+// MeteringStats holds aggregate usage numbers.
+type MeteringStats struct {
+	TotalRequests int64   `json:"total_requests"`
+	TotalInput    int64   `json:"total_input_tokens"`
+	TotalOutput   int64   `json:"total_output_tokens"`
+	TotalTokens   int64   `json:"total_tokens"`
+	AvgLatencyMS  float64 `json:"avg_latency_ms"`
+	ErrorCount    int64   `json:"error_count"`
+}
+
+// GetMeteringStats returns aggregate stats for the given filter window.
+func (db *Database) GetMeteringStats(f MeteringFilter) (MeteringStats, error) {
+	where, args := meteringWhere(f)
+	sql := `SELECT
+		COUNT(*),
+		COALESCE(SUM(input_tokens),  0),
+		COALESCE(SUM(output_tokens), 0),
+		COALESCE(SUM(total_tokens),  0),
+		COALESCE(AVG(latency_ms),    0),
+		COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0)
+		FROM request_logs` + where
+	var s MeteringStats
+	err := db.db.QueryRow(sql, args...).Scan(
+		&s.TotalRequests, &s.TotalInput, &s.TotalOutput,
+		&s.TotalTokens, &s.AvgLatencyMS, &s.ErrorCount,
+	)
+	return s, err
+}
+
+// ModelBreakdown holds per-model aggregate usage.
+type ModelBreakdown struct {
+	ModelID      string  `json:"model_id"`
+	Requests     int64   `json:"requests"`
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+	TotalTokens  int64   `json:"total_tokens"`
+	AvgLatencyMS float64 `json:"avg_latency_ms"`
+}
+
+// GetMeteringByModel returns per-model breakdown for the given filter window.
+func (db *Database) GetMeteringByModel(f MeteringFilter) ([]ModelBreakdown, error) {
+	where, args := meteringWhere(f)
+	sql := `SELECT model_id,
+		COUNT(*),
+		COALESCE(SUM(input_tokens),  0),
+		COALESCE(SUM(output_tokens), 0),
+		COALESCE(SUM(total_tokens),  0),
+		COALESCE(AVG(latency_ms),    0)
+		FROM request_logs` + where +
+		` GROUP BY model_id ORDER BY SUM(total_tokens) DESC`
+	rows, err := db.db.Query(sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("metering by-model: %w", err)
+	}
+	defer rows.Close()
+	var result []ModelBreakdown
+	for rows.Next() {
+		var b ModelBreakdown
+		if err := rows.Scan(&b.ModelID, &b.Requests, &b.InputTokens, &b.OutputTokens, &b.TotalTokens, &b.AvgLatencyMS); err != nil {
+			return nil, err
+		}
+		result = append(result, b)
+	}
+	return result, rows.Err()
+}
+
+// ProviderBreakdown holds per-provider aggregate usage.
+type ProviderBreakdown struct {
+	ProviderID   string  `json:"provider_id"`
+	Requests     int64   `json:"requests"`
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+	TotalTokens  int64   `json:"total_tokens"`
+	AvgLatencyMS float64 `json:"avg_latency_ms"`
+}
+
+// GetMeteringByProvider returns per-provider breakdown for the given filter window.
+func (db *Database) GetMeteringByProvider(f MeteringFilter) ([]ProviderBreakdown, error) {
+	where, args := meteringWhere(f)
+	sql := `SELECT provider_id,
+		COUNT(*),
+		COALESCE(SUM(input_tokens),  0),
+		COALESCE(SUM(output_tokens), 0),
+		COALESCE(SUM(total_tokens),  0),
+		COALESCE(AVG(latency_ms),    0)
+		FROM request_logs` + where +
+		` GROUP BY provider_id ORDER BY SUM(total_tokens) DESC`
+	rows, err := db.db.Query(sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("metering by-provider: %w", err)
+	}
+	defer rows.Close()
+	var result []ProviderBreakdown
+	for rows.Next() {
+		var b ProviderBreakdown
+		if err := rows.Scan(&b.ProviderID, &b.Requests, &b.InputTokens, &b.OutputTokens, &b.TotalTokens, &b.AvgLatencyMS); err != nil {
+			return nil, err
+		}
+		result = append(result, b)
+	}
+	return result, rows.Err()
+}
+
+// meteringWhere builds a WHERE clause and args slice from a MeteringFilter.
+func meteringWhere(f MeteringFilter) (string, []any) {
+	var clauses []string
+	var args []any
+
+	if f.ModelID != "" {
+		clauses = append(clauses, "model_id = ?")
+		args = append(args, f.ModelID)
+	}
+	if f.ProviderID != "" {
+		clauses = append(clauses, "provider_id = ?")
+		args = append(args, f.ProviderID)
+	}
+	if f.APIShape != "" {
+		clauses = append(clauses, "api_shape = ?")
+		args = append(args, f.APIShape)
+	}
+	if !f.Since.IsZero() {
+		clauses = append(clauses, "created_at >= ?")
+		args = append(args, f.Since.UTC().Format(time.RFC3339))
+	}
+	if !f.Until.IsZero() {
+		clauses = append(clauses, "created_at <= ?")
+		args = append(args, f.Until.UTC().Format(time.RFC3339))
+	}
+
+	if len(clauses) == 0 {
+		return "", args
+	}
+	var sb strings.Builder
+	sb.WriteString(" WHERE ")
+	sb.WriteString(clauses[0])
+	for _, c := range clauses[1:] {
+		sb.WriteString(" AND ")
+		sb.WriteString(c)
+	}
+	return sb.String(), args
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/database/types.go
+++ b/internal/database/types.go
@@ -129,3 +129,21 @@ type VirtualModelUpstreamRecord struct {
 	Priority       int       `json:"priority"`
 	CreatedAt      time.Time `json:"created_at"`
 }
+
+// MeteringRecord holds per-request usage data recorded after each API call.
+type MeteringRecord struct {
+	ID           int64     `json:"id"`
+	RequestID    string    `json:"request_id"`
+	ModelID      string    `json:"model_id"`      // canonical model name as requested
+	ModelUsed    string    `json:"model_used"`    // actual model reported by provider
+	ProviderID   string    `json:"provider_id"`   // provider instance_id
+	APIShape     string    `json:"api_shape"`     // "openai" | "anthropic"
+	InputTokens  int       `json:"input_tokens"`
+	OutputTokens int       `json:"output_tokens"`
+	TotalTokens  int       `json:"total_tokens"`
+	LatencyMS    int64     `json:"latency_ms"`
+	IsStream     bool      `json:"is_stream"`
+	StatusCode   int       `json:"status_code"`  // 200 on success, 4xx/5xx on error
+	ErrorMessage string    `json:"error_message"`
+	CreatedAt    time.Time `json:"created_at"`
+}

--- a/internal/routes/admin_metering.go
+++ b/internal/routes/admin_metering.go
@@ -1,0 +1,108 @@
+package routes
+
+import (
+	"net/http"
+	"omnillm/internal/database"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func SetupMeteringRoutes(router *gin.RouterGroup) {
+	router.GET("/metering/logs", handleMeteringLogs)
+	router.GET("/metering/stats", handleMeteringStats)
+	router.GET("/metering/by-model", handleMeteringByModel)
+	router.GET("/metering/by-provider", handleMeteringByProvider)
+}
+
+// parseMeteringFilter reads common query params shared by all metering endpoints.
+func parseMeteringFilter(c *gin.Context) database.MeteringFilter {
+	f := database.MeteringFilter{
+		ModelID:    c.Query("model_id"),
+		ProviderID: c.Query("provider_id"),
+		APIShape:   c.Query("api_shape"),
+	}
+	if s := c.Query("since"); s != "" {
+		if ts, err := time.Parse(time.RFC3339, s); err == nil {
+			f.Since = ts
+		}
+	}
+	if s := c.Query("until"); s != "" {
+		if ts, err := time.Parse(time.RFC3339, s); err == nil {
+			f.Until = ts
+		}
+	}
+	return f
+}
+
+// GET /api/admin/metering/logs?model_id=&provider_id=&api_shape=&since=&until=&page=1&page_size=50
+func handleMeteringLogs(c *gin.Context) {
+	f := parseMeteringFilter(c)
+
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "50"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 500 {
+		pageSize = 50
+	}
+	offset := (page - 1) * pageSize
+
+	db := database.GetDatabase()
+	records, total, err := db.ListMeteringRecords(f, pageSize, offset)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"items":     records,
+		"total":     total,
+		"page":      page,
+		"page_size": pageSize,
+	})
+}
+
+// GET /api/admin/metering/stats?model_id=&provider_id=&api_shape=&since=&until=
+func handleMeteringStats(c *gin.Context) {
+	f := parseMeteringFilter(c)
+
+	db := database.GetDatabase()
+	stats, err := db.GetMeteringStats(f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, stats)
+}
+
+// GET /api/admin/metering/by-model?since=&until=
+func handleMeteringByModel(c *gin.Context) {
+	f := parseMeteringFilter(c)
+
+	db := database.GetDatabase()
+	breakdown, err := db.GetMeteringByModel(f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"items": breakdown})
+}
+
+// GET /api/admin/metering/by-provider?since=&until=
+func handleMeteringByProvider(c *gin.Context) {
+	f := parseMeteringFilter(c)
+
+	db := database.GetDatabase()
+	breakdown, err := db.GetMeteringByProvider(f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"items": breakdown})
+}

--- a/internal/routes/admin_routes.go
+++ b/internal/routes/admin_routes.go
@@ -58,6 +58,9 @@ func SetupAdminRoutes(router *gin.RouterGroup, port int) {
 	// Logs streaming
 	router.GET("/logs/stream", handleLogsStream)
 
+	// Metering / usage data
+	SetupMeteringRoutes(router)
+
 	// Config file management
 	router.GET("/config", handleGetConfigFiles)
 	router.GET("/config/:name", handleGetConfig)

--- a/internal/routes/chat.go
+++ b/internal/routes/chat.go
@@ -198,6 +198,7 @@ func handleNonStreamingResponse(c *gin.Context, adapter types.ProviderAdapter, c
 	}
 
 	logCompletedResponse("openai", requestID, originalModel, response.Model, providerID, false, response.StopReason, response.Usage, startTime)
+	recordUsage(requestID, originalModel, response.Model, providerID, "openai", response.Usage, time.Since(startTime).Milliseconds(), false, http.StatusOK, "")
 
 	c.JSON(http.StatusOK, openaiResp)
 	return nil
@@ -260,6 +261,7 @@ func handleStreamingResponse(c *gin.Context, adapter types.ProviderAdapter, cano
 					Int("output_tokens", outputTokens).
 					Int64("latency_ms", time.Since(startTime).Milliseconds()).
 					Msg("\x1b[32m<--\x1b[0m RESPONSE stream")
+				recordUsage(requestID, originalModel, modelUsed, providerID, "openai", endEvt.Usage, time.Since(startTime).Milliseconds(), true, http.StatusOK, "")
 				return false
 			}
 

--- a/internal/routes/messages.go
+++ b/internal/routes/messages.go
@@ -197,6 +197,7 @@ func handleAnthropicNonStreamingResponse(c *gin.Context, adapter types.ProviderA
 		Int("output_tokens", outputTokens).
 		Int64("latency_ms", time.Since(startTime).Milliseconds()).
 		Msg("\x1b[32m<--\x1b[0m RESPONSE")
+	recordUsage(requestID, originalModel, response.Model, providerID, "anthropic", response.Usage, time.Since(startTime).Milliseconds(), false, http.StatusOK, "")
 
 	c.JSON(http.StatusOK, anthropicResp)
 	return nil
@@ -286,6 +287,7 @@ func handleAnthropicStreamingResponse(c *gin.Context, adapter types.ProviderAdap
 					Int("output_tokens", outputTokens).
 					Int64("latency_ms", time.Since(startTime).Milliseconds()).
 					Msg("\x1b[32m<--\x1b[0m RESPONSE stream")
+				recordUsage(requestID, originalModel, modelUsed, providerID, "anthropic", endEvt.Usage, time.Since(startTime).Milliseconds(), true, http.StatusOK, "")
 				return false
 			}
 

--- a/internal/routes/metering.go
+++ b/internal/routes/metering.go
@@ -1,0 +1,58 @@
+package routes
+
+import (
+	"omnillm/internal/cif"
+	"omnillm/internal/database"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// recordUsage writes a metering row asynchronously after a completed request.
+// It is called from the four response handlers (streaming + non-streaming,
+// OpenAI + Anthropic shapes).  Errors are logged but never returned — metering
+// must never break the request path.
+func recordUsage(
+	requestID string,
+	modelID string, // canonical model as the caller requested
+	modelUsed string, // actual model reported by the provider
+	providerID string,
+	apiShape string,
+	usage *cif.CIFUsage,
+	latencyMS int64,
+	isStream bool,
+	statusCode int,
+	errMsg string,
+) {
+	inputTokens := 0
+	outputTokens := 0
+	if usage != nil {
+		inputTokens = usage.InputTokens
+		outputTokens = usage.OutputTokens
+	}
+
+	rec := database.MeteringRecord{
+		RequestID:    requestID,
+		ModelID:      modelID,
+		ModelUsed:    modelUsed,
+		ProviderID:   providerID,
+		APIShape:     apiShape,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		TotalTokens:  inputTokens + outputTokens,
+		LatencyMS:    latencyMS,
+		IsStream:     isStream,
+		StatusCode:   statusCode,
+		ErrorMessage: errMsg,
+		CreatedAt:    time.Now().UTC(),
+	}
+
+	go func() {
+		db := database.GetDatabase()
+		if err := db.InsertMeteringRecord(rec); err != nil {
+			log.Error().Err(err).
+				Str("request_id", requestID).
+				Msg("Failed to record metering data")
+		}
+	}()
+}


### PR DESCRIPTION
## Summary
- add backend metering persistence and admin endpoints for request logs, aggregate stats, and model/provider breakdowns
- add the admin Metering page with summary cards, breakdown tables, and paginated request log rows
- fix the page's default time filtering and refresh behavior so new request logs stay visible while the dashboard is open

## Test plan
- [x] bun run typecheck
- [x] verify `/api/admin/metering/*` endpoints return 200 responses from the running backend
- [x] verify `http://localhost:5080/admin/#metering` shows live stats, breakdowns, and request log rows in the browser