### PR TITLE
fix: correct Copilot tool use stop reason and normalize Anthropic tool IDs

### DIFF
--- a/docs/COPILOT_CLAUDE_TOOL_USE_FIX.md
+++ b/docs/COPILOT_CLAUDE_TOOL_USE_FIX.md
@@ -1,0 +1,46 @@
+# Copilot Claude Tool Use Fix
+
+## Context
+
+Claude-family models routed through GitHub Copilot can return OpenAI-compatible tool calls with provider-specific details that do not map cleanly to Anthropic clients. Claude Code reported that some Claude tool calls could not be parsed when using Anthropic `/v1/messages` streaming through OmniLLM.
+
+## What Changed
+
+Before:
+
+- Copilot chat-completions streaming only accepted `id`, did not preserve provider `tool_calls[].index` for argument continuations, and could drop arguments emitted in the first tool-call chunk.
+- Copilot non-streaming responses only accepted `id`, not `call_id`.
+- Anthropic serialization forwarded Copilot tool ids such as `tooluse_...` unchanged.
+
+After:
+
+- Copilot streaming accepts `id` and `call_id`, maps argument deltas by provider index, preserves same-chunk arguments, and upgrades `[DONE]` or `stop` endings to tool use when tool calls were observed.
+- Copilot non-streaming accepts `call_id` and upgrades malformed `stop` responses to tool use when tool calls are present.
+- Anthropic responses normalize outbound tool-use ids to Anthropic-style `toolu_...` ids.
+
+## Why It Is Critical
+
+Claude Code depends on Anthropic-compatible tool-use SSE blocks. If the tool id or argument stream is malformed, the local client cannot execute tools, so agent workflows fail immediately after the model requests tool use.
+
+## Affected Files
+
+- `internal/providers/copilot/sse_parser.go`
+- `internal/providers/copilot/payload.go`
+- `internal/providers/copilot/copilot_test.go`
+- `internal/serialization/to_anthropic.go`
+- `internal/serialization/serialization_test.go`
+- `internal/serialization/serialization_master_test.go`
+
+## Validation
+
+- `go test ./internal/serialization`
+- `go test ./internal/providers/copilot`
+- `go test ./internal/ingestion ./internal/serialization ./internal/providers/shared ./internal/providers/openaicompat ./internal/providers/copilot ./internal/server`
+- `bun test tests/claude-code-qwen-tooluse.test.ts`
+- Live Claude Agent SDK checks against patched backend on port 5100:
+  - `claude-haiku-4.5` emitted and executed `Read`
+  - `claude-sonnet-4.6` emitted and executed `Read`
+
+## Commit Range
+
+Pending commit.

--- a/internal/providers/copilot/copilot_test.go
+++ b/internal/providers/copilot/copilot_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"omnillm/internal/providers/shared"
 	ghservice "omnillm/internal/services/github"
 )
 
@@ -536,6 +537,142 @@ func TestCopilotAdapterExecute_NonGPT5StaysOnChatCompletions(t *testing.T) {
 
 	if capturedPath != "/chat/completions" {
 		t.Fatalf("expected /chat/completions for non-gpt-5 model, got %q", capturedPath)
+	}
+}
+
+func TestCopilotAdapterExecute_ClaudeToolCallsUpgradeStopAndAcceptCallID(t *testing.T) {
+	models := []string{"claude-haiku-4.5", "claude-sonnet-4.6"}
+
+	for _, model := range models {
+		t.Run(model, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/chat/completions" {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    "chatcmpl_tool",
+					"model": model,
+					"choices": []map[string]interface{}{{
+						"index": 0,
+						"message": map[string]interface{}{
+							"role": "assistant",
+							"tool_calls": []map[string]interface{}{{
+								"call_id": "call_weather",
+								"type":    "function",
+								"function": map[string]interface{}{
+									"name":      "get_weather",
+									"arguments": `{"location":"Shanghai"}`,
+								},
+							}},
+						},
+						"finish_reason": "stop",
+					}},
+				})
+			}))
+			defer server.Close()
+
+			provider := NewGitHubCopilotProvider("github-copilot-test", "")
+			provider.baseURL = server.URL
+			provider.token = "test-token"
+			adapter := provider.GetAdapter().(*CopilotAdapter)
+
+			resp, err := adapter.Execute(context.Background(), &cif.CanonicalRequest{
+				Model: model,
+				Messages: []cif.CIFMessage{
+					cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "weather"}}},
+				},
+				Tools: []cif.CIFTool{{Name: "get_weather"}},
+			})
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if resp.StopReason != cif.StopReasonToolUse {
+				t.Fatalf("expected tool_use stop reason, got %v", resp.StopReason)
+			}
+			if len(resp.Content) != 1 {
+				t.Fatalf("expected one content part, got %#v", resp.Content)
+			}
+			toolCall, ok := resp.Content[0].(cif.CIFToolCallPart)
+			if !ok {
+				t.Fatalf("expected tool call, got %T", resp.Content[0])
+			}
+			if toolCall.ToolCallID != "call_weather" || toolCall.ToolName != "get_weather" {
+				t.Fatalf("unexpected tool call: %#v", toolCall)
+			}
+			if toolCall.ToolArguments["location"] != "Shanghai" {
+				t.Fatalf("unexpected tool args: %#v", toolCall.ToolArguments)
+			}
+		})
+	}
+}
+
+func TestCopilotAdapterExecuteStream_ClaudeToolCallsPreserveIndexedArguments(t *testing.T) {
+	models := []string{"claude-haiku-4.5", "claude-sonnet-4.6"}
+
+	for _, model := range models {
+		t.Run(model, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/chat/completions" {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(strings.TrimSpace(`
+data: {"id":"chatcmpl_tool_stream","model":"`+model+`","choices":[{"index":0,"delta":{"role":"assistant"}}]}
+
+data: {"id":"chatcmpl_tool_stream","model":"`+model+`","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"call_id":"call_weather","type":"function","function":{"name":"get_weather","arguments":"{\"location\""}}]}}]}
+
+data: {"id":"chatcmpl_tool_stream","model":"`+model+`","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":":\"Shanghai\"}"}}]}}]}
+
+data: [DONE]
+				`) + "\n\n"))
+			}))
+			defer server.Close()
+
+			provider := NewGitHubCopilotProvider("github-copilot-test", "")
+			provider.baseURL = server.URL
+			provider.token = "test-token"
+			adapter := provider.GetAdapter().(*CopilotAdapter)
+			forceChatCompletions := true
+
+			eventCh, err := adapter.ExecuteStream(context.Background(), &cif.CanonicalRequest{
+				Model: model,
+				Messages: []cif.CIFMessage{
+					cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "weather"}}},
+				},
+				Tools:  []cif.CIFTool{{Name: "get_weather"}},
+				Stream: true,
+				Extensions: &cif.Extensions{
+					ForceChatCompletions: &forceChatCompletions,
+				},
+			})
+			if err != nil {
+				t.Fatalf("ExecuteStream returned error: %v", err)
+			}
+
+			resp, err := shared.CollectStream(eventCh)
+			if err != nil {
+				t.Fatalf("CollectStream returned error: %v", err)
+			}
+			if resp.StopReason != cif.StopReasonToolUse {
+				t.Fatalf("expected tool_use stop reason, got %v", resp.StopReason)
+			}
+			if len(resp.Content) != 1 {
+				t.Fatalf("expected one content part, got %#v", resp.Content)
+			}
+			toolCall, ok := resp.Content[0].(cif.CIFToolCallPart)
+			if !ok {
+				t.Fatalf("expected tool call, got %T", resp.Content[0])
+			}
+			if toolCall.ToolCallID != "call_weather" || toolCall.ToolName != "get_weather" {
+				t.Fatalf("unexpected tool call: %#v", toolCall)
+			}
+			if toolCall.ToolArguments["location"] != "Shanghai" {
+				t.Fatalf("unexpected tool args: %#v", toolCall.ToolArguments)
+			}
+		})
 	}
 }
 

--- a/internal/providers/copilot/payload.go
+++ b/internal/providers/copilot/payload.go
@@ -246,6 +246,9 @@ func (a *CopilotAdapter) convertOpenAIToCIF(openaiResp map[string]interface{}, t
 
 			if message, ok := choice["message"].(map[string]interface{}); ok {
 				response.Content = a.convertOpenAIMessageToCIF(message, toolNameMapper)
+				if response.StopReason != cif.StopReasonToolUse && containsToolCall(response.Content) {
+					response.StopReason = cif.StopReasonToolUse
+				}
 			}
 		}
 	}
@@ -279,6 +282,9 @@ func (a *CopilotAdapter) convertOpenAIMessageToCIF(message map[string]interface{
 			if toolCall, ok := tc.(map[string]interface{}); ok {
 				if function, ok := toolCall["function"].(map[string]interface{}); ok {
 					id, _ := toolCall["id"].(string)
+					if id == "" {
+						id, _ = toolCall["call_id"].(string)
+					}
 					name, _ := function["name"].(string)
 					args, _ := function["arguments"].(string)
 
@@ -297,4 +303,13 @@ func (a *CopilotAdapter) convertOpenAIMessageToCIF(message map[string]interface{
 	}
 
 	return parts
+}
+
+func containsToolCall(parts []cif.CIFContentPart) bool {
+	for _, part := range parts {
+		if _, ok := part.(cif.CIFToolCallPart); ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/providers/copilot/sse_parser.go
+++ b/internal/providers/copilot/sse_parser.go
@@ -19,6 +19,8 @@ func (a *CopilotAdapter) parseOpenAISSE(body io.ReadCloser, eventCh chan cif.CIF
 	scanner.Buffer(make([]byte, 0, 4*1024), 1024*1024)
 	var streamStartSent bool
 	var contentBlockIndex int
+	providerToolIndexToBlock := map[int]int{}
+	toolCallsSeen := map[int]bool{}
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -28,9 +30,13 @@ func (a *CopilotAdapter) parseOpenAISSE(body io.ReadCloser, eventCh chan cif.CIF
 
 		data := strings.TrimPrefix(line, "data: ")
 		if data == "[DONE]" {
+			stopReason := cif.StopReasonEndTurn
+			if len(toolCallsSeen) > 0 {
+				stopReason = cif.StopReasonToolUse
+			}
 			eventCh <- cif.CIFStreamEnd{
 				Type:       "stream_end",
-				StopReason: cif.StopReasonEndTurn,
+				StopReason: stopReason,
 			}
 			return
 		}
@@ -73,9 +79,14 @@ func (a *CopilotAdapter) parseOpenAISSE(body io.ReadCloser, eventCh chan cif.CIF
 				}
 			}
 
+			stopReason := a.convertOpenAIStopReason(finishReason)
+			if stopReason != cif.StopReasonToolUse && len(toolCallsSeen) > 0 {
+				stopReason = cif.StopReasonToolUse
+			}
+
 			eventCh <- cif.CIFStreamEnd{
 				Type:       "stream_end",
-				StopReason: a.convertOpenAIStopReason(finishReason),
+				StopReason: stopReason,
 				Usage:      usage,
 			}
 			return
@@ -108,8 +119,20 @@ func (a *CopilotAdapter) parseOpenAISSE(body io.ReadCloser, eventCh chan cif.CIF
 					continue
 				}
 
-				if id, ok := tcMap["id"].(string); ok && id != "" {
+				providerIdx := 0
+				if idxRaw, ok := tcMap["index"].(float64); ok {
+					providerIdx = int(idxRaw)
+				}
+
+				id, _ := tcMap["id"].(string)
+				if id == "" {
+					id, _ = tcMap["call_id"].(string)
+				}
+
+				if id != "" {
 					contentBlockIndex++
+					providerToolIndexToBlock[providerIdx] = contentBlockIndex
+					toolCallsSeen[providerIdx] = true
 					funcMap, _ := tcMap["function"].(map[string]interface{})
 					name, _ := funcMap["name"].(string)
 
@@ -127,11 +150,27 @@ func (a *CopilotAdapter) parseOpenAISSE(body io.ReadCloser, eventCh chan cif.CIF
 							PartialJSON: "",
 						},
 					}
+					if funcMap != nil {
+						if args, ok := funcMap["arguments"].(string); ok && args != "" {
+							eventCh <- cif.CIFContentDelta{
+								Type:  "content_delta",
+								Index: contentBlockIndex,
+								Delta: cif.ToolArgumentsDelta{
+									Type:        "tool_arguments_delta",
+									PartialJSON: args,
+								},
+							}
+						}
+					}
 				} else if funcMap, ok := tcMap["function"].(map[string]interface{}); ok {
 					if args, ok := funcMap["arguments"].(string); ok && args != "" {
+						blockIndex, exists := providerToolIndexToBlock[providerIdx]
+						if !exists {
+							continue
+						}
 						eventCh <- cif.CIFContentDelta{
 							Type:  "content_delta",
-							Index: contentBlockIndex,
+							Index: blockIndex,
 							Delta: cif.ToolArgumentsDelta{
 								Type:        "tool_arguments_delta",
 								PartialJSON: args,

--- a/internal/serialization/serialization_master_test.go
+++ b/internal/serialization/serialization_master_test.go
@@ -227,7 +227,7 @@ func TestConvertCIFEventToAnthropicSSE_ToolUseLifecycle(t *testing.T) {
 		t.Fatalf("unexpected content block start: %#v", events[1])
 	}
 	contentBlock := events[1]["content_block"].(map[string]interface{})
-	if contentBlock["type"] != "tool_use" || contentBlock["id"] != "call_123" {
+	if contentBlock["type"] != "tool_use" || contentBlock["id"] != "toolu_call_123" {
 		t.Fatalf("unexpected anthropic tool block: %#v", contentBlock)
 	}
 
@@ -247,6 +247,42 @@ func TestConvertCIFEventToAnthropicSSE_ToolUseLifecycle(t *testing.T) {
 	}
 	if events[5]["type"] != "message_stop" {
 		t.Fatalf("unexpected final event: %#v", events[5])
+	}
+}
+
+func TestConvertCIFEventToAnthropicSSE_NormalizesCopilotToolUseID(t *testing.T) {
+	state := CreateAnthropicStreamState()
+	_, err := ConvertCIFEventToAnthropicSSE(cif.CIFStreamStart{
+		Type:  "stream_start",
+		ID:    "stream_123",
+		Model: "claude-haiku-4.5",
+	}, state)
+	if err != nil {
+		t.Fatalf("unexpected start error: %v", err)
+	}
+
+	events, err := ConvertCIFEventToAnthropicSSE(cif.CIFContentDelta{
+		Type:  "content_delta",
+		Index: 0,
+		ContentBlock: cif.CIFToolCallPart{
+			Type:       "tool_call",
+			ToolCallID: "tooluse_abc123",
+			ToolName:   "Read",
+		},
+		Delta: cif.ToolArgumentsDelta{
+			Type:        "tool_arguments_delta",
+			PartialJSON: `{"file_path":"README.md"}`,
+		},
+	}, state)
+	if err != nil {
+		t.Fatalf("unexpected delta error: %v", err)
+	}
+	if len(events) < 1 {
+		t.Fatalf("expected content block start event")
+	}
+	contentBlock := events[0]["content_block"].(map[string]interface{})
+	if contentBlock["id"] != "toolu_abc123" {
+		t.Fatalf("expected normalized tool use id, got %#v", contentBlock["id"])
 	}
 }
 
@@ -318,7 +354,7 @@ func TestConvertCIFEventToAnthropicSSE_SuppressThinkingBlocks(t *testing.T) {
 	var foundToolUse bool
 	for _, evt := range allEvents {
 		if cb, ok := evt["content_block"].(map[string]interface{}); ok {
-			if cb["type"] == "tool_use" && cb["id"] == "call_agent_1" {
+			if cb["type"] == "tool_use" && cb["id"] == "toolu_call_agent_1" {
 				foundToolUse = true
 			}
 		}

--- a/internal/serialization/serialization_test.go
+++ b/internal/serialization/serialization_test.go
@@ -260,6 +260,33 @@ func TestSerializeToAnthropic_ToolUseBlock(t *testing.T) {
 	}
 }
 
+func TestSerializeToAnthropic_NormalizesCopilotToolUseID(t *testing.T) {
+	resp := &cif.CanonicalResponse{
+		ID:    "msg_tooluse",
+		Model: "claude-haiku-4.5",
+		Content: []cif.CIFContentPart{
+			cif.CIFToolCallPart{
+				Type:          "tool_call",
+				ToolCallID:    "tooluse_abc123",
+				ToolName:      "Read",
+				ToolArguments: map[string]interface{}{"file_path": "README.md"},
+			},
+		},
+		StopReason: cif.StopReasonToolUse,
+	}
+
+	out, err := SerializeToAnthropic(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Content) != 1 {
+		t.Fatalf("expected one content block, got %d", len(out.Content))
+	}
+	if out.Content[0].ID != "toolu_abc123" {
+		t.Fatalf("expected normalized tool use id, got %q", out.Content[0].ID)
+	}
+}
+
 func TestSerializeToAnthropic_UsageFields(t *testing.T) {
 	resp := &cif.CanonicalResponse{
 		ID:         "msg_003",

--- a/internal/serialization/to_anthropic.go
+++ b/internal/serialization/to_anthropic.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"omnillm/internal/cif"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 )
@@ -52,7 +53,7 @@ func SerializeToAnthropicWithSuppression(response *cif.CanonicalResponse, suppre
 		case cif.CIFToolCallPart:
 			content = append(content, AnthropicContentBlock{
 				Type:  "tool_use",
-				ID:    p.ToolCallID,
+				ID:    normalizeAnthropicToolUseID(p.ToolCallID),
 				Name:  p.ToolName,
 				Input: p.ToolArguments,
 			})
@@ -324,13 +325,27 @@ func createContentBlockStartEvent(contentBlock cif.CIFContentPart, index int) ma
 			"index": index,
 			"content_block": map[string]interface{}{
 				"type":  "tool_use",
-				"id":    cb.ToolCallID,
+				"id":    normalizeAnthropicToolUseID(cb.ToolCallID),
 				"name":  cb.ToolName,
 				"input": map[string]interface{}{},
 			},
 		}
 	default:
 		return nil
+	}
+}
+
+func normalizeAnthropicToolUseID(id string) string {
+	id = strings.TrimSpace(id)
+	switch {
+	case id == "":
+		return "toolu_empty"
+	case strings.HasPrefix(id, "toolu_"):
+		return id
+	case strings.HasPrefix(id, "tooluse_"):
+		return "toolu_" + strings.TrimPrefix(id, "tooluse_")
+	default:
+		return "toolu_" + id
 	}
 }
 

--- a/internal/server/alibaba_provider_integration_test.go
+++ b/internal/server/alibaba_provider_integration_test.go
@@ -803,7 +803,7 @@ func TestAlibabaQwen36PlusProviderIntegration(t *testing.T) {
 		var firstArgs strings.Builder
 		for _, evt := range firstEvents {
 			if contentBlock, ok := evt.Data["content_block"].(map[string]interface{}); ok {
-				if contentBlock["type"] == "tool_use" && contentBlock["name"] == "Read" && contentBlock["id"] == "call_qwen_read" {
+				if contentBlock["type"] == "tool_use" && contentBlock["name"] == "Read" && contentBlock["id"] == "toolu_call_qwen_read" {
 					firstToolUse = true
 				}
 				if contentBlock["type"] == "thinking" {
@@ -853,7 +853,7 @@ func TestAlibabaQwen36PlusProviderIntegration(t *testing.T) {
 		secondResp := postJSON(
 			t,
 			backend.URL+"/v1/messages",
-			`{"model":"qwen3.6-plus","stream":true,"max_tokens":512,"tools":[{"name":"Read","input_schema":{"type":"object","properties":{"file_path":{"type":"string"}},"required":["file_path"]}}],"messages":[{"role":"user","content":"Explain codebase in detail"},{"role":"assistant","content":[{"type":"tool_use","id":"call_qwen_read","name":"Read","input":{"file_path":"README.md"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_qwen_read","content":"README.md says this project exposes OpenAI and Anthropic compatible endpoints over a shared CIF routing core."}]}]}`,
+			`{"model":"qwen3.6-plus","stream":true,"max_tokens":512,"tools":[{"name":"Read","input_schema":{"type":"object","properties":{"file_path":{"type":"string"}},"required":["file_path"]}}],"messages":[{"role":"user","content":"Explain codebase in detail"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_call_qwen_read","name":"Read","input":{"file_path":"README.md"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_call_qwen_read","content":"README.md says this project exposes OpenAI and Anthropic compatible endpoints over a shared CIF routing core."}]}]}`,
 			map[string]string{"anthropic-version": "2023-06-01"},
 		)
 		secondBody := readBody(t, secondResp)
@@ -948,7 +948,7 @@ func TestAlibabaQwen36PlusProviderIntegration(t *testing.T) {
 			t.Fatalf("expected one upstream assistant tool_call, got %#v", assistantMsg)
 		}
 		assistantToolCall, _ := assistantToolCalls[0].(map[string]interface{})
-		if id, _ := assistantToolCall["id"].(string); id != "call_qwen_read" {
+		if id, _ := assistantToolCall["id"].(string); id != "toolu_call_qwen_read" {
 			t.Fatalf("unexpected upstream tool call id: %#v", assistantToolCall)
 		}
 		assistantFunction, _ := assistantToolCall["function"].(map[string]interface{})
@@ -963,7 +963,7 @@ func TestAlibabaQwen36PlusProviderIntegration(t *testing.T) {
 		if role, _ := toolMsg["role"].(string); role != "tool" {
 			t.Fatalf("expected upstream tool role message, got %#v", toolMsg)
 		}
-		if toolCallID, _ := toolMsg["tool_call_id"].(string); toolCallID != "call_qwen_read" {
+		if toolCallID, _ := toolMsg["tool_call_id"].(string); toolCallID != "toolu_call_qwen_read" {
 			t.Fatalf("unexpected upstream tool_call_id: %#v", toolMsg)
 		}
 		if content, _ := toolMsg["content"].(string); !strings.Contains(content, "shared CIF routing core") {

--- a/internal/server/openaicompat_provider_integration_test.go
+++ b/internal/server/openaicompat_provider_integration_test.go
@@ -210,7 +210,7 @@ func TestOpenAICompatibleAnthropicStreamingIsBufferedDownstream(t *testing.T) {
 	var firstArgs strings.Builder
 	for _, evt := range firstEvents {
 		if contentBlock, ok := evt.Data["content_block"].(map[string]interface{}); ok {
-			if contentBlock["type"] == "tool_use" && contentBlock["name"] == "Read" && contentBlock["id"] == "call_readme" {
+			if contentBlock["type"] == "tool_use" && contentBlock["name"] == "Read" && contentBlock["id"] == "toolu_call_readme" {
 				firstToolUse = true
 			}
 		}

--- a/internal/server/requested_models_tool_use_test.go
+++ b/internal/server/requested_models_tool_use_test.go
@@ -137,7 +137,7 @@ func assertRequestedModelAnthropicToolUse(t *testing.T, serverURL, modelID strin
 	if payload.StopReason == nil || *payload.StopReason != "tool_use" {
 		t.Fatalf("anthropic messages: unexpected stop reason for %s: %#v", modelID, payload.StopReason)
 	}
-	if len(payload.Content) != 1 || payload.Content[0].Type != "tool_use" || payload.Content[0].ID != "call_weather" || payload.Content[0].Name != "get_weather" {
+	if len(payload.Content) != 1 || payload.Content[0].Type != "tool_use" || payload.Content[0].ID != "toolu_call_weather" || payload.Content[0].Name != "get_weather" {
 		t.Fatalf("anthropic messages: unexpected tool payload for %s: %#v", modelID, payload.Content)
 	}
 	if payload.Content[0].Input["location"] != "Shanghai" {


### PR DESCRIPTION
- Fix SSE parser to set stop_reason=tool_use when tool calls are present,
  even when upstream sends stop_reason=stop
- Handle call_id as fallback when id is missing in tool call payloads
- Track per-provider tool index to block index mapping in streaming
- Flush initial tool arguments in the same block-start event if present
- Normalize Anthropic tool_use IDs to toolu_ prefix in serialization
- Add tests covering Copilot Claude tool use and serialization edge cases
