### PR TITLE
Improve metering page filtering and pagination

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -590,6 +590,16 @@ export const getMeteringByProvider = (params: MeteringQuery = {}) =>
     `/api/admin/metering/by-provider${buildQueryString(params)}`,
   )
 
+export const getMeteringModels = (params: MeteringQuery = {}) =>
+  apiFetch<{ items: Array<string> | null }>(
+    `/api/admin/metering/models${buildQueryString(params)}`,
+  )
+
+export const getMeteringProviders = (params: MeteringQuery = {}) =>
+  apiFetch<{ items: Array<string> | null }>(
+    `/api/admin/metering/providers${buildQueryString(params)}`,
+  )
+
 // ─── Log level ────────────────────────────────────────────────────────────────
 
 export const getLogLevel = async () => {

--- a/frontend/src/components/SearchableSelect.tsx
+++ b/frontend/src/components/SearchableSelect.tsx
@@ -1,0 +1,250 @@
+import { Search, ChevronDown, X } from "lucide-react"
+import { useEffect, useState, useRef, useMemo, useCallback } from "react"
+
+interface SearchableSelectProps {
+  options: Array<string>
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+}
+
+function getOptionBackground(isHighlighted: boolean, isSelected: boolean) {
+  if (isHighlighted) return "var(--color-surface-2)"
+  if (isSelected) return "var(--color-blue-fill)"
+  return "transparent"
+}
+
+export function SearchableSelect({
+  options,
+  value,
+  onChange,
+  placeholder = "Select...",
+}: SearchableSelectProps) {
+  const [open, setOpen] = useState(false)
+  const [filter, setFilter] = useState("")
+  const [highlighted, setHighlighted] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const filtered = useMemo(() => {
+    if (!filter) return options
+    const lower = filter.toLowerCase()
+    return options.filter((o) => o.toLowerCase().includes(lower))
+  }, [options, filter])
+
+  const close = useCallback(() => {
+    setOpen(false)
+    setFilter("")
+  }, [])
+
+  useEffect(() => {
+    setHighlighted(0)
+  }, [filter])
+
+  useEffect(() => {
+    if (!open) return
+    inputRef.current?.focus()
+  }, [open])
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (
+        containerRef.current
+        && !containerRef.current.contains(e.target as Node)
+      )
+        close()
+    }
+    document.addEventListener("mousedown", handler)
+    return () => document.removeEventListener("mousedown", handler)
+  }, [close])
+
+  const select = useCallback(
+    (v: string) => {
+      onChange(v)
+      close()
+    },
+    [onChange, close],
+  )
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowDown": {
+        e.preventDefault()
+        setHighlighted((prev) => Math.min(prev + 1, filtered.length - 1))
+        break
+      }
+      case "ArrowUp": {
+        e.preventDefault()
+        setHighlighted((prev) => Math.max(prev - 1, 0))
+        break
+      }
+      case "Enter": {
+        e.preventDefault()
+        if (filtered[highlighted]) select(filtered[highlighted])
+        break
+      }
+      case "Escape": {
+        close()
+        break
+      }
+      default: {
+        break
+      }
+    }
+  }
+
+  return (
+    <div ref={containerRef} style={{ position: "relative" }}>
+      <button
+        type="button"
+        className="sys-select"
+        onClick={() => setOpen((prev) => !prev)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+          width: "100%",
+          textAlign: "left",
+        }}
+      >
+        <span
+          style={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            color: value ? "var(--color-text)" : "var(--color-text-tertiary)",
+          }}
+        >
+          {value || placeholder}
+        </span>
+        <span
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            flexShrink: 0,
+          }}
+        >
+          {value && (
+            <span
+              role="button"
+              aria-label="Clear selection"
+              onClick={(e) => {
+                e.stopPropagation()
+                onChange("")
+                setFilter("")
+                setOpen(false)
+              }}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 18,
+                height: 18,
+                borderRadius: 999,
+                color: "var(--color-text-tertiary)",
+              }}
+            >
+              <X size={12} />
+            </span>
+          )}
+          <ChevronDown
+            size={14}
+            style={{
+              opacity: 0.5,
+              transform: open ? "rotate(180deg)" : "rotate(0deg)",
+              transition: "transform 0.15s",
+            }}
+          />
+        </span>
+      </button>
+
+      {open && (
+        <div
+          style={{
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            right: 0,
+            zIndex: 200,
+            marginTop: 4,
+            background: "var(--color-surface)",
+            border: "1px solid var(--color-separator)",
+            borderRadius: "var(--radius-md)",
+            boxShadow: "var(--shadow-modal)",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              padding: "8px 10px",
+              borderBottom: "1px solid var(--color-separator)",
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <Search
+              size={14}
+              style={{ color: "var(--color-text-tertiary)", flexShrink: 0 }}
+            />
+            <input
+              ref={inputRef}
+              type="text"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Filter..."
+              style={{
+                flex: 1,
+                background: "transparent",
+                border: "none",
+                color: "var(--color-text)",
+                fontSize: 13,
+                fontFamily: "inherit",
+                outline: "none",
+              }}
+            />
+          </div>
+          <div style={{ maxHeight: 200, overflowY: "auto" }}>
+            {filtered.length === 0 ?
+              <div
+                style={{
+                  padding: "10px 12px",
+                  fontSize: 12,
+                  color: "var(--color-text-tertiary)",
+                  textAlign: "center",
+                }}
+              >
+                No matches
+              </div>
+            : filtered.map((opt, i) => (
+                <div
+                  key={opt}
+                  onClick={() => select(opt)}
+                  onMouseEnter={() => setHighlighted(i)}
+                  style={{
+                    padding: "8px 12px",
+                    fontSize: 13,
+                    cursor: "pointer",
+                    background: getOptionBackground(
+                      i === highlighted,
+                      opt === value,
+                    ),
+                    color:
+                      opt === value && i !== highlighted ?
+                        "white"
+                      : "var(--color-text)",
+                  }}
+                >
+                  {opt}
+                </div>
+              ))
+            }
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/MeteringPage.tsx
+++ b/frontend/src/pages/MeteringPage.tsx
@@ -4,6 +4,8 @@ import {
   getMeteringByModel,
   getMeteringByProvider,
   getMeteringLogs,
+  getMeteringModels,
+  getMeteringProviders,
   getMeteringStats,
   type MeteringBreakdownItem,
   type MeteringLogsResponse,
@@ -11,6 +13,7 @@ import {
   type MeteringRecord,
   type MeteringStats,
 } from "@/api"
+import { SearchableSelect } from "@/components/SearchableSelect"
 
 function formatNumber(value: number) {
   return new Intl.NumberFormat().format(value)
@@ -116,7 +119,15 @@ function BreakdownTable({
   items: Array<MeteringBreakdownItem> | null | undefined
   valueKey: "model_id" | "provider_id"
 }) {
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(5)
   const safeItems = items ?? []
+  const totalPages = Math.max(1, Math.ceil(safeItems.length / pageSize))
+
+  useEffect(() => {
+    setPage(1)
+  }, [items, pageSize])
+  const pageItems = safeItems.slice((page - 1) * pageSize, page * pageSize)
 
   return (
     <Card>
@@ -127,6 +138,8 @@ function BreakdownTable({
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
+          gap: 12,
+          flexWrap: "wrap",
         }}
       >
         <div>
@@ -141,15 +154,40 @@ function BreakdownTable({
             {title}
           </h2>
         </div>
-        <span
-          style={{
-            fontSize: 11,
-            color: "var(--color-text-tertiary)",
-            fontFamily: "var(--font-mono)",
-          }}
-        >
-          {safeItems.length} rows
-        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <label
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 6,
+              fontSize: 12,
+              color: "var(--color-text-secondary)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            Rows per page
+            <select
+              className="sys-select"
+              style={{ fontSize: 12, padding: "2px 6px" }}
+              value={pageSize}
+              onChange={(e) => setPageSize(Number(e.target.value))}
+            >
+              <option value={5}>5</option>
+              <option value={10}>10</option>
+              <option value={15}>15</option>
+            </select>
+          </label>
+          <span
+            style={{
+              fontSize: 11,
+              color: "var(--color-text-tertiary)",
+              fontFamily: "var(--font-mono)",
+            }}
+          >
+            {safeItems.length} rows
+          </span>
+        </div>
       </div>
       <div style={{ overflowX: "auto" }}>
         <table style={{ width: "100%", borderCollapse: "collapse" }}>
@@ -195,7 +233,7 @@ function BreakdownTable({
                 </td>
               </tr>
             )}
-            {safeItems.map((item, index) => (
+            {pageItems.map((item, index) => (
               <tr key={`${item[valueKey] ?? "unknown"}-${index}`}>
                 <td
                   style={{
@@ -217,6 +255,38 @@ function BreakdownTable({
           </tbody>
         </table>
       </div>
+      {totalPages > 1 && (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 12,
+            padding: "10px 16px",
+            borderTop: "1px solid var(--color-separator)",
+          }}
+        >
+          <div style={{ fontSize: 12, color: "var(--color-text-secondary)" }}>
+            Page {page} of {totalPages}
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button
+              className="btn btn-ghost btn-sm"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+            >
+              Previous
+            </button>
+            <button
+              className="btn btn-ghost btn-sm"
+              disabled={page >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
     </Card>
   )
 }
@@ -247,12 +317,15 @@ export function MeteringPage({
   const [providerId, setProviderId] = useState("")
   const [apiShape, setAPIShape] = useState("")
   const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(50)
   const [reloadKey, setReloadKey] = useState(0)
   const [loading, setLoading] = useState(true)
   const [stats, setStats] = useState<MeteringStats | null>(null)
   const [logs, setLogs] = useState<MeteringLogsResponse | null>(null)
   const [byModel, setByModel] = useState<Array<MeteringBreakdownItem>>([])
   const [byProvider, setByProvider] = useState<Array<MeteringBreakdownItem>>([])
+  const [modelOptions, setModelOptions] = useState<Array<string>>([])
+  const [providerOptions, setProviderOptions] = useState<Array<string>>([])
 
   const query = useMemo<MeteringQuery>(
     () => ({
@@ -262,9 +335,29 @@ export function MeteringPage({
       provider_id: providerId || undefined,
       api_shape: apiShape || undefined,
       page,
-      page_size: 50,
+      page_size: pageSize,
     }),
-    [apiShape, modelId, page, providerId, reloadKey, since, until],
+    [apiShape, modelId, page, pageSize, providerId, reloadKey, since, until],
+  )
+
+  const modelOptionsQuery = useMemo<MeteringQuery>(
+    () => ({
+      since: since ? new Date(since).toISOString() : undefined,
+      until: until ? new Date(until).toISOString() : undefined,
+      provider_id: providerId || undefined,
+      api_shape: apiShape || undefined,
+    }),
+    [apiShape, providerId, reloadKey, since, until],
+  )
+
+  const providerOptionsQuery = useMemo<MeteringQuery>(
+    () => ({
+      since: since ? new Date(since).toISOString() : undefined,
+      until: until ? new Date(until).toISOString() : undefined,
+      model_id: modelId || undefined,
+      api_shape: apiShape || undefined,
+    }),
+    [apiShape, modelId, reloadKey, since, until],
   )
 
   useEffect(() => {
@@ -276,14 +369,27 @@ export function MeteringPage({
       getMeteringLogs(query),
       getMeteringByModel(query),
       getMeteringByProvider(query),
+      getMeteringModels(modelOptionsQuery),
+      getMeteringProviders(providerOptionsQuery),
     ])
-      .then(([nextStats, nextLogs, nextByModel, nextByProvider]) => {
-        if (cancelled) return
-        setStats(nextStats)
-        setLogs({ ...nextLogs, items: nextLogs.items ?? [] })
-        setByModel(nextByModel.items ?? [])
-        setByProvider(nextByProvider.items ?? [])
-      })
+      .then(
+        ([
+          nextStats,
+          nextLogs,
+          nextByModel,
+          nextByProvider,
+          nextModels,
+          nextProviders,
+        ]) => {
+          if (cancelled) return
+          setStats(nextStats)
+          setLogs({ ...nextLogs, items: nextLogs.items ?? [] })
+          setByModel(nextByModel.items ?? [])
+          setByProvider(nextByProvider.items ?? [])
+          setModelOptions(nextModels.items ?? [])
+          setProviderOptions(nextProviders.items ?? [])
+        },
+      )
       .catch((e: unknown) => {
         if (cancelled) return
         showToast(
@@ -299,7 +405,7 @@ export function MeteringPage({
     return () => {
       cancelled = true
     }
-  }, [query, showToast])
+  }, [modelOptionsQuery, providerOptionsQuery, query, showToast])
 
   const totalPages =
     logs ? Math.max(1, Math.ceil(logs.total / logs.page_size)) : 1
@@ -353,7 +459,7 @@ export function MeteringPage({
         </button>
       </div>
 
-      <Card style={{ padding: 18 }}>
+      <Card style={{ padding: 18, overflow: "visible" }}>
         <div
           style={{
             display: "grid",
@@ -387,26 +493,26 @@ export function MeteringPage({
           </label>
           <label style={fieldStyle}>
             <span style={labelStyle}>Model</span>
-            <input
-              className="sys-input"
+            <SearchableSelect
+              options={modelOptions}
               value={modelId}
-              onChange={(e) => {
-                setModelId(e.target.value)
+              onChange={(v) => {
+                setModelId(v)
                 setPage(1)
               }}
-              placeholder="claude-3-7-sonnet"
+              placeholder="All models"
             />
           </label>
           <label style={fieldStyle}>
             <span style={labelStyle}>Provider</span>
-            <input
-              className="sys-input"
+            <SearchableSelect
+              options={providerOptions}
               value={providerId}
-              onChange={(e) => {
-                setProviderId(e.target.value)
+              onChange={(v) => {
+                setProviderId(v)
                 setPage(1)
               }}
-              placeholder="provider instance id"
+              placeholder="All providers"
             />
           </label>
           <label style={fieldStyle}>
@@ -490,7 +596,6 @@ export function MeteringPage({
             justifyContent: "space-between",
             alignItems: "center",
             gap: 12,
-            flexWrap: "wrap",
           }}
         >
           <div>
@@ -515,14 +620,42 @@ export function MeteringPage({
               paths.
             </p>
           </div>
-          <div
-            style={{
-              fontSize: 11,
-              color: "var(--color-text-tertiary)",
-              fontFamily: "var(--font-mono)",
-            }}
-          >
-            {loading ? "Loading…" : `${logs?.total ?? 0} rows`}
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <label
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 6,
+                fontSize: 12,
+                color: "var(--color-text-secondary)",
+                whiteSpace: "nowrap",
+              }}
+            >
+              Rows per page
+              <select
+                className="sys-select"
+                style={{ fontSize: 12, padding: "2px 6px" }}
+                value={pageSize}
+                onChange={(e) => {
+                  setPageSize(Number(e.target.value))
+                  setPage(1)
+                }}
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </label>
+            <div
+              style={{
+                fontSize: 11,
+                color: "var(--color-text-tertiary)",
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              {loading ? "Loading…" : `${logs?.total ?? 0} rows`}
+            </div>
           </div>
         </div>
         <div style={{ overflowX: "auto" }}>
@@ -611,12 +744,7 @@ export function MeteringPage({
             flexWrap: "wrap",
           }}
         >
-          <div
-            style={{
-              fontSize: 12,
-              color: "var(--color-text-secondary)",
-            }}
-          >
+          <div style={{ fontSize: 12, color: "var(--color-text-secondary)" }}>
             Page {logs?.page ?? page} of {totalPages}
           </div>
           <div style={{ display: "flex", gap: 8 }}>

--- a/internal/database/store_metering.go
+++ b/internal/database/store_metering.go
@@ -223,3 +223,43 @@ func boolToInt(b bool) int {
 	}
 	return 0
 }
+
+// GetDistinctMeteringModels returns distinct model_ids from request_logs within the filter window.
+func (db *Database) GetDistinctMeteringModels(f MeteringFilter) ([]string, error) {
+	where, args := meteringWhere(f)
+	sql := `SELECT DISTINCT model_id FROM request_logs` + where + ` ORDER BY model_id`
+	rows, err := db.db.Query(sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("distinct models: %w", err)
+	}
+	defer rows.Close()
+	var result []string
+	for rows.Next() {
+		var m string
+		if err := rows.Scan(&m); err != nil {
+			return nil, err
+		}
+		result = append(result, m)
+	}
+	return result, rows.Err()
+}
+
+// GetDistinctMeteringProviders returns distinct provider_ids from request_logs within the filter window.
+func (db *Database) GetDistinctMeteringProviders(f MeteringFilter) ([]string, error) {
+	where, args := meteringWhere(f)
+	sql := `SELECT DISTINCT provider_id FROM request_logs` + where + ` ORDER BY provider_id`
+	rows, err := db.db.Query(sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("distinct providers: %w", err)
+	}
+	defer rows.Close()
+	var result []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, err
+		}
+		result = append(result, p)
+	}
+	return result, rows.Err()
+}

--- a/internal/routes/admin_metering.go
+++ b/internal/routes/admin_metering.go
@@ -14,6 +14,8 @@ func SetupMeteringRoutes(router *gin.RouterGroup) {
 	router.GET("/metering/stats", handleMeteringStats)
 	router.GET("/metering/by-model", handleMeteringByModel)
 	router.GET("/metering/by-provider", handleMeteringByProvider)
+	router.GET("/metering/models", handleMeteringModels)
+	router.GET("/metering/providers", handleMeteringProviders)
 }
 
 // parseMeteringFilter reads common query params shared by all metering endpoints.
@@ -105,4 +107,32 @@ func handleMeteringByProvider(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"items": breakdown})
+}
+
+// GET /api/admin/metering/models?since=&until=
+func handleMeteringModels(c *gin.Context) {
+	f := parseMeteringFilter(c)
+
+	db := database.GetDatabase()
+	models, err := db.GetDistinctMeteringModels(f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"items": models})
+}
+
+// GET /api/admin/metering/providers?since=&until=
+func handleMeteringProviders(c *gin.Context) {
+	f := parseMeteringFilter(c)
+
+	db := database.GetDatabase()
+	providers, err := db.GetDistinctMeteringProviders(f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"items": providers})
 }


### PR DESCRIPTION
Closes #61

## Summary
- add searchable model and provider filters with reset support on the metering page
- add configurable rows-per-page controls for request logs and for the by-model and by-provider tables
- add metering endpoints to return model and provider filter options based on the selected time window and companion filters

## Test plan
- [x] build backend routes and storage helpers locally
- [x] type-check frontend changes locally
- [x] verify lint passes during commit hooks