### PR TITLE
Add i18n translations for metering page and max rows limit

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -125,7 +125,7 @@ export default function AppComponent() {
       { id: "providers" as const, label: t("nav:providers"), icon: Database },
       { id: "chat" as const, label: t("nav:chat"), icon: MessageSquare },
       { id: "logging" as const, label: t("nav:logging"), icon: BarChart3 },
-      { id: "metering" as const, label: "Metering", icon: BarChart3 },
+      { id: "metering" as const, label: t("nav:metering"), icon: BarChart3 },
       {
         id: "virtualmodel" as const,
         label: t("nav:virtualModels"),

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -3,10 +3,10 @@ import { initReactI18next } from "react-i18next"
 
 import en_about from "./locales/en/about.json"
 import en_chat from "./locales/en/chat.json"
-// Import translation files
 import en_common from "./locales/en/common.json"
 import en_config from "./locales/en/config.json"
 import en_logging from "./locales/en/logging.json"
+import en_metering from "./locales/en/metering.json"
 import en_nav from "./locales/en/nav.json"
 import en_providers from "./locales/en/providers.json"
 import en_virtualmodel from "./locales/en/virtualmodel.json"
@@ -15,6 +15,7 @@ import zh_chat from "./locales/zh/chat.json"
 import zh_common from "./locales/zh/common.json"
 import zh_config from "./locales/zh/config.json"
 import zh_logging from "./locales/zh/logging.json"
+import zh_metering from "./locales/zh/metering.json"
 import zh_nav from "./locales/zh/nav.json"
 import zh_providers from "./locales/zh/providers.json"
 import zh_virtualmodel from "./locales/zh/virtualmodel.json"
@@ -54,6 +55,7 @@ const resources = {
     virtualmodel: en_virtualmodel,
     logging: en_logging,
     about: en_about,
+    metering: en_metering,
   },
   zh: {
     common: zh_common,
@@ -64,6 +66,7 @@ const resources = {
     virtualmodel: zh_virtualmodel,
     logging: zh_logging,
     about: zh_about,
+    metering: zh_metering,
   },
 }
 
@@ -81,6 +84,7 @@ void i18n.use(initReactI18next).init({
     "virtualmodel",
     "logging",
     "about",
+    "metering",
   ],
   interpolation: {
     escapeValue: false, // React already prevents XSS

--- a/frontend/src/locales/en/metering.json
+++ b/frontend/src/locales/en/metering.json
@@ -1,0 +1,53 @@
+{
+  "title": "Metering",
+  "description": "Request-level usage data captured after CIF responses finalize, with token totals, latency, provider attribution, and raw request logs.",
+  "byModel": "By model",
+  "byProvider": "By provider",
+  "requestLog": "Request log",
+  "requestLogDescription": "Raw metering rows captured from OpenAI and Anthropic response paths.",
+  "stats": {
+    "requests": "Requests",
+    "requestsSubtext": "Completed requests in the selected window",
+    "totalTokens": "Total tokens",
+    "avgLatency": "Avg latency",
+    "avgLatencySubtext": "Wall-clock latency across successful and failed requests",
+    "errors": "Errors",
+    "errorsSubtext": "Requests recorded with a status code ≥ 400"
+  },
+  "filters": {
+    "since": "Since",
+    "until": "Until",
+    "model": "Model",
+    "provider": "Provider",
+    "apiShape": "API shape",
+    "all": "All",
+    "allModels": "All models",
+    "allProviders": "All providers",
+    "rowsPerPage": "Rows per page",
+    "maxRows": "Max rows"
+  },
+  "table": {
+    "model": "model",
+    "provider": "provider",
+    "requests": "requests",
+    "input": "input",
+    "output": "output",
+    "total": "total",
+    "avgLatency": "avg latency",
+    "time": "time",
+    "shape": "shape",
+    "latency": "latency",
+    "status": "status",
+    "stream": "stream",
+    "noData": "No data yet.",
+    "noRecords": "No metering records yet."
+  },
+  "pagination": {
+    "page": "Page {{current}} of {{total}}",
+    "previous": "Previous",
+    "next": "Next",
+    "rows": "{{count}} rows",
+    "loading": "Loading…"
+  },
+  "refresh": "Refresh"
+}

--- a/frontend/src/locales/en/nav.json
+++ b/frontend/src/locales/en/nav.json
@@ -4,5 +4,6 @@
   "logging": "Logging",
   "virtualModels": "Virtual Models",
   "toolConfig": "Tool Config",
-  "about": "About"
+  "about": "About",
+  "metering": "Metering"
 }

--- a/frontend/src/locales/zh/metering.json
+++ b/frontend/src/locales/zh/metering.json
@@ -1,0 +1,53 @@
+{
+  "title": "计量",
+  "description": "CIF 响应完成后的请求级使用数据，包含令牌总数、延迟、提供者归属和原始请求日志。",
+  "byModel": "按模型",
+  "byProvider": "按提供者",
+  "requestLog": "请求日志",
+  "requestLogDescription": "从 OpenAI 和 Anthropic 响应路径捕获的原始计量行。",
+  "stats": {
+    "requests": "请求数",
+    "requestsSubtext": "所选时间窗口内完成的请求",
+    "totalTokens": "总令牌数",
+    "avgLatency": "平均延迟",
+    "avgLatencySubtext": "成功和失败请求的端到端延迟",
+    "errors": "错误数",
+    "errorsSubtext": "状态码 ≥ 400 的请求"
+  },
+  "filters": {
+    "since": "开始时间",
+    "until": "结束时间",
+    "model": "模型",
+    "provider": "提供者",
+    "apiShape": "API 类型",
+    "all": "全部",
+    "allModels": "全部模型",
+    "allProviders": "全部提供者",
+    "rowsPerPage": "每页行数",
+    "maxRows": "最大行数"
+  },
+  "table": {
+    "model": "模型",
+    "provider": "提供者",
+    "requests": "请求数",
+    "input": "输入",
+    "output": "输出",
+    "total": "总计",
+    "avgLatency": "平均延迟",
+    "time": "时间",
+    "shape": "类型",
+    "latency": "延迟",
+    "status": "状态",
+    "stream": "流式",
+    "noData": "暂无数据。",
+    "noRecords": "暂无计量记录。"
+  },
+  "pagination": {
+    "page": "第 {{current}} 页，共 {{total}} 页",
+    "previous": "上一页",
+    "next": "下一页",
+    "rows": "{{count}} 行",
+    "loading": "加载中…"
+  },
+  "refresh": "刷新"
+}

--- a/frontend/src/locales/zh/nav.json
+++ b/frontend/src/locales/zh/nav.json
@@ -4,5 +4,6 @@
   "logging": "日志",
   "virtualModels": "虚拟模型",
   "toolConfig": "工具配置",
-  "about": "关于"
+  "about": "关于",
+  "metering": "计量"
 }

--- a/frontend/src/pages/MeteringPage.tsx
+++ b/frontend/src/pages/MeteringPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, type CSSProperties } from "react"
+import { useTranslation } from "react-i18next"
 
 import {
   getMeteringByModel,
@@ -115,10 +116,11 @@ function BreakdownTable({
   valueKey,
 }: {
   title: string
-  keyLabel: "model" | "provider"
+  keyLabel: string
   items: Array<MeteringBreakdownItem> | null | undefined
   valueKey: "model_id" | "provider_id"
 }) {
+  const { t } = useTranslation("metering")
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(5)
   const safeItems = items ?? []
@@ -166,7 +168,7 @@ function BreakdownTable({
               whiteSpace: "nowrap",
             }}
           >
-            Rows per page
+            {t("filters.rowsPerPage")}
             <select
               className="sys-select"
               style={{ fontSize: 12, padding: "2px 6px" }}
@@ -185,7 +187,7 @@ function BreakdownTable({
               fontFamily: "var(--font-mono)",
             }}
           >
-            {safeItems.length} rows
+            {t("pagination.rows", { count: safeItems.length })}
           </span>
         </div>
       </div>
@@ -195,11 +197,11 @@ function BreakdownTable({
             <tr style={{ background: "rgba(255,255,255,0.02)" }}>
               {[
                 keyLabel,
-                "requests",
-                "input",
-                "output",
-                "total",
-                "avg latency",
+                t("table.requests"),
+                t("table.input"),
+                t("table.output"),
+                t("table.total"),
+                t("table.avgLatency"),
               ].map((label) => (
                 <th
                   key={label}
@@ -229,7 +231,7 @@ function BreakdownTable({
                     textAlign: "center",
                   }}
                 >
-                  No data yet.
+                  {t("table.noData")}
                 </td>
               </tr>
             )}
@@ -267,7 +269,7 @@ function BreakdownTable({
           }}
         >
           <div style={{ fontSize: 12, color: "var(--color-text-secondary)" }}>
-            Page {page} of {totalPages}
+            {t("pagination.page", { current: page, total: totalPages })}
           </div>
           <div style={{ display: "flex", gap: 8 }}>
             <button
@@ -275,14 +277,14 @@ function BreakdownTable({
               disabled={page <= 1}
               onClick={() => setPage((p) => Math.max(1, p - 1))}
             >
-              Previous
+              {t("pagination.previous")}
             </button>
             <button
               className="btn btn-ghost btn-sm"
               disabled={page >= totalPages}
               onClick={() => setPage((p) => p + 1)}
             >
-              Next
+              {t("pagination.next")}
             </button>
           </div>
         </div>
@@ -304,6 +306,7 @@ export function MeteringPage({
 }: {
   showToast: (msg: string, type?: "success" | "error") => void
 }) {
+  const { t } = useTranslation("metering")
   const now = useMemo(() => new Date(), [])
   const defaultSince = useMemo(() => {
     const value = new Date(now)
@@ -318,6 +321,7 @@ export function MeteringPage({
   const [apiShape, setAPIShape] = useState("")
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(50)
+  const [maxRows, setMaxRows] = useState(500)
   const [reloadKey, setReloadKey] = useState(0)
   const [loading, setLoading] = useState(true)
   const [stats, setStats] = useState<MeteringStats | null>(null)
@@ -409,7 +413,7 @@ export function MeteringPage({
 
   const totalPages =
     logs ? Math.max(1, Math.ceil(logs.total / logs.page_size)) : 1
-  const logItems = logs?.items ?? []
+  const logItems = (logs?.items ?? []).slice(0, maxRows || undefined)
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
@@ -433,7 +437,7 @@ export function MeteringPage({
               color: "var(--color-text)",
             }}
           >
-            Metering
+            {t("title")}
           </h1>
           <p
             style={{
@@ -443,8 +447,7 @@ export function MeteringPage({
               maxWidth: 720,
             }}
           >
-            Request-level usage data captured after CIF responses finalize, with
-            token totals, latency, provider attribution, and raw request logs.
+            {t("description")}
           </p>
         </div>
         <button
@@ -455,7 +458,7 @@ export function MeteringPage({
           }}
           disabled={loading}
         >
-          Refresh
+          {t("refresh")}
         </button>
       </div>
 
@@ -468,7 +471,7 @@ export function MeteringPage({
           }}
         >
           <label style={fieldStyle}>
-            <span style={labelStyle}>Since</span>
+            <span style={labelStyle}>{t("filters.since")}</span>
             <input
               className="sys-input"
               type="datetime-local"
@@ -480,7 +483,7 @@ export function MeteringPage({
             />
           </label>
           <label style={fieldStyle}>
-            <span style={labelStyle}>Until</span>
+            <span style={labelStyle}>{t("filters.until")}</span>
             <input
               className="sys-input"
               type="datetime-local"
@@ -492,7 +495,7 @@ export function MeteringPage({
             />
           </label>
           <label style={fieldStyle}>
-            <span style={labelStyle}>Model</span>
+            <span style={labelStyle}>{t("filters.model")}</span>
             <SearchableSelect
               options={modelOptions}
               value={modelId}
@@ -500,11 +503,11 @@ export function MeteringPage({
                 setModelId(v)
                 setPage(1)
               }}
-              placeholder="All models"
+              placeholder={t("filters.allModels")}
             />
           </label>
           <label style={fieldStyle}>
-            <span style={labelStyle}>Provider</span>
+            <span style={labelStyle}>{t("filters.provider")}</span>
             <SearchableSelect
               options={providerOptions}
               value={providerId}
@@ -512,11 +515,11 @@ export function MeteringPage({
                 setProviderId(v)
                 setPage(1)
               }}
-              placeholder="All providers"
+              placeholder={t("filters.allProviders")}
             />
           </label>
           <label style={fieldStyle}>
-            <span style={labelStyle}>API shape</span>
+            <span style={labelStyle}>{t("filters.apiShape")}</span>
             <select
               className="sys-select"
               value={apiShape}
@@ -525,7 +528,7 @@ export function MeteringPage({
                 setPage(1)
               }}
             >
-              <option value="">All</option>
+              <option value="">{t("filters.all")}</option>
               <option value="openai">openai</option>
               <option value="anthropic">anthropic</option>
             </select>
@@ -541,28 +544,28 @@ export function MeteringPage({
         }}
       >
         <StatCard
-          label="Requests"
+          label={t("stats.requests")}
           value={formatNumber(stats?.total_requests ?? 0)}
           accent="var(--color-blue)"
-          subtext="Completed requests in the selected window"
+          subtext={t("stats.requestsSubtext")}
         />
         <StatCard
-          label="Total tokens"
+          label={t("stats.totalTokens")}
           value={formatNumber(stats?.total_tokens ?? 0)}
           accent="var(--color-green)"
           subtext={`${formatNumber(stats?.total_input_tokens ?? 0)} in / ${formatNumber(stats?.total_output_tokens ?? 0)} out`}
         />
         <StatCard
-          label="Avg latency"
+          label={t("stats.avgLatency")}
           value={formatLatency(stats?.avg_latency_ms ?? 0)}
           accent="var(--color-orange)"
-          subtext="Wall-clock latency across successful and failed requests"
+          subtext={t("stats.avgLatencySubtext")}
         />
         <StatCard
-          label="Errors"
+          label={t("stats.errors")}
           value={formatNumber(stats?.error_count ?? 0)}
           accent="var(--color-red)"
-          subtext="Requests recorded with a status code ≥ 400"
+          subtext={t("stats.errorsSubtext")}
         />
       </div>
 
@@ -574,14 +577,14 @@ export function MeteringPage({
         }}
       >
         <BreakdownTable
-          title="By model"
-          keyLabel="model"
+          title={t("byModel")}
+          keyLabel={t("table.model")}
           items={byModel}
           valueKey="model_id"
         />
         <BreakdownTable
-          title="By provider"
-          keyLabel="provider"
+          title={t("byProvider")}
+          keyLabel={t("table.provider")}
           items={byProvider}
           valueKey="provider_id"
         />
@@ -607,7 +610,7 @@ export function MeteringPage({
                 color: "var(--color-text)",
               }}
             >
-              Request log
+              {t("requestLog")}
             </h2>
             <p
               style={{
@@ -616,8 +619,7 @@ export function MeteringPage({
                 color: "var(--color-text-secondary)",
               }}
             >
-              Raw metering rows captured from OpenAI and Anthropic response
-              paths.
+              {t("requestLogDescription")}
             </p>
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
@@ -632,7 +634,7 @@ export function MeteringPage({
                 whiteSpace: "nowrap",
               }}
             >
-              Rows per page
+              {t("filters.rowsPerPage")}
               <select
                 className="sys-select"
                 style={{ fontSize: 12, padding: "2px 6px" }}
@@ -647,6 +649,33 @@ export function MeteringPage({
                 <option value={50}>50</option>
               </select>
             </label>
+            <label
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 6,
+                fontSize: 12,
+                color: "var(--color-text-secondary)",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {t("filters.maxRows")}
+              <select
+                className="sys-select"
+                style={{ fontSize: 12, padding: "2px 6px" }}
+                value={maxRows}
+                onChange={(e) => {
+                  setMaxRows(Number(e.target.value))
+                  setPage(1)
+                }}
+              >
+                <option value={500}>500</option>
+                <option value={1000}>1000</option>
+                <option value={2000}>2000</option>
+                <option value={0}>All</option>
+              </select>
+            </label>
             <div
               style={{
                 fontSize: 11,
@@ -654,7 +683,10 @@ export function MeteringPage({
                 fontFamily: "var(--font-mono)",
               }}
             >
-              {loading ? "Loading…" : `${logs?.total ?? 0} rows`}
+              {loading ?
+                t("pagination.loading")
+              : `${logs?.total ?? 0} ${t("pagination.rows", { count: logs?.total ?? 0 })}`
+              }
             </div>
           </div>
         </div>
@@ -663,16 +695,16 @@ export function MeteringPage({
             <thead>
               <tr style={{ background: "rgba(255,255,255,0.02)" }}>
                 {[
-                  "time",
-                  "model",
-                  "provider",
-                  "shape",
-                  "input",
-                  "output",
-                  "total",
-                  "latency",
-                  "status",
-                  "stream",
+                  t("table.time"),
+                  t("table.model"),
+                  t("table.provider"),
+                  t("table.shape"),
+                  t("table.input"),
+                  t("table.output"),
+                  t("table.total"),
+                  t("table.latency"),
+                  t("table.status"),
+                  t("table.stream"),
                 ].map((label) => (
                   <th
                     key={label}
@@ -702,7 +734,7 @@ export function MeteringPage({
                       color: "var(--color-text-secondary)",
                     }}
                   >
-                    No metering records yet.
+                    {t("table.noRecords")}
                   </td>
                 </tr>
               )}
@@ -745,7 +777,10 @@ export function MeteringPage({
           }}
         >
           <div style={{ fontSize: 12, color: "var(--color-text-secondary)" }}>
-            Page {logs?.page ?? page} of {totalPages}
+            {t("pagination.page", {
+              current: logs?.page ?? page,
+              total: totalPages,
+            })}
           </div>
           <div style={{ display: "flex", gap: 8 }}>
             <button
@@ -753,14 +788,14 @@ export function MeteringPage({
               disabled={page <= 1 || loading}
               onClick={() => setPage((value) => Math.max(1, value - 1))}
             >
-              Previous
+              {t("pagination.previous")}
             </button>
             <button
               className="btn btn-ghost btn-sm"
               disabled={page >= totalPages || loading}
               onClick={() => setPage((value) => value + 1)}
             >
-              Next
+              {t("pagination.next")}
             </button>
           </div>
         </div>


### PR DESCRIPTION
Closes #63

## Summary
- add Chinese translations for the entire metering page (title, description, filters, stat cards, tables, pagination)
- translate the "Metering" nav entry
- add a max rows selector (500/1000/2000/All) for the request log table

## Test plan
- [x] lint passes during commit hooks
- [x] translation keys registered in i18n.ts
- [x] both en/zh locale files created