### PR TITLE
Fix Copilot Claude tool-call parse path

### DIFF
--- a/docs/COPILOT_CLAUDE_TOOL_USE_PARSE_FIX.md
+++ b/docs/COPILOT_CLAUDE_TOOL_USE_PARSE_FIX.md
@@ -1,0 +1,47 @@
+# Copilot Claude Tool-Use Parse Fix
+
+## Context
+
+Claude Code requests routed through OmniLLM's Anthropic /v1/messages compatibility path could fail with:
+
+- The model's tool call could not be parsed (retry also failed).
+
+The issue reproduced on localhost:5000 for GitHub Copilot-backed Claude models, including claude-haiku-4.5 and claude-sonnet-4.6.
+
+## What Changed
+
+Before:
+
+- Copilot Anthropic streaming for Claude models was buffered through the non-streaming execution path.
+- That buffered path could produce a response with stop_reason: "tool_use" or inish_reason: "tool_calls" even when the serialized body only contained assistant text and no actual tool-call block.
+- Claude Code rejected that payload as an invalid tool call.
+
+After:
+
+- Anthropic streaming for Copilot Claude models stays on the native chat-completions streaming path instead of buffering.
+- OpenAI and Anthropic serializers now downgrade 	ool_use / 	ool_calls to a normal completion when no actual tool-call block exists, preventing impossible payload shapes from reaching clients.
+- Regression tests now cover both the Copilot Anthropic-Claude streaming path and the dangling stop-reason serialization guard.
+
+## Why It Is Critical
+
+This is a tool-use compatibility fix for Claude Code. When OmniLLM emits a tool-use stop reason without a real tool payload, agent workflows fail immediately and the client cannot continue execution. That breaks core repository-inspection and coding flows on the local proxy.
+
+## Affected Files
+
+- internal/providers/copilot/adapter.go
+- internal/providers/copilot/copilot_test.go
+- internal/serialization/to_openai.go
+- internal/serialization/to_anthropic.go
+- internal/serialization/serialization_test.go
+
+## Validation
+
+- go test ./internal/providers/copilot
+- go test ./internal/serialization
+- Live Claude Agent SDK checks against http://127.0.0.1:5000:
+  - claude-haiku-4.5 emitted valid tool calls and no longer failed with the parse error
+  - claude-sonnet-4.6 emitted valid tool calls and no longer failed with the parse error
+
+## Commit Range
+
+Pending commit.

--- a/internal/providers/copilot/adapter.go
+++ b/internal/providers/copilot/adapter.go
@@ -59,10 +59,19 @@ func (a *CopilotAdapter) ExecuteStream(ctx context.Context, request *cif.Canonic
 }
 
 func (a *CopilotAdapter) shouldBufferAnthropicStreaming(request *cif.CanonicalRequest) bool {
-	return request != nil &&
-		request.Extensions != nil &&
-		request.Extensions.InboundAPIShape != nil &&
-		strings.EqualFold(strings.TrimSpace(*request.Extensions.InboundAPIShape), "anthropic")
+	if request == nil || request.Extensions == nil || request.Extensions.InboundAPIShape == nil {
+		return false
+	}
+
+	if !strings.EqualFold(strings.TrimSpace(*request.Extensions.InboundAPIShape), "anthropic") {
+		return false
+	}
+
+	// Copilot's Claude chat-completions stream carries valid incremental tool_calls,
+	// while the buffered non-streaming path can collapse into stop_reason=tool_use
+	// without an actual tool block. Preserve native streaming for Claude models.
+	model := a.RemapModel(request.Model)
+	return !strings.Contains(strings.ToLower(model), "claude")
 }
 
 func (a *CopilotAdapter) forceChatCompletions(request *cif.CanonicalRequest) bool {

--- a/internal/providers/copilot/copilot_test.go
+++ b/internal/providers/copilot/copilot_test.go
@@ -374,6 +374,67 @@ func TestCopilotAdapterExecuteStream_AnthropicRequestsBufferCompletedResponse(t 
 	}
 }
 
+func TestCopilotAdapterExecuteStream_AnthropicClaudeRequestsStayOnChatCompletionsStream(t *testing.T) {
+	var capturedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		if r.URL.Path != "/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		body := "data: {\"id\":\"chatcmpl_tool_stream\",\"model\":\"claude-haiku-4.5\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n" +
+			"data: {\"id\":\"chatcmpl_tool_stream\",\"model\":\"claude-haiku-4.5\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"call_id\":\"call_weather\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\\\"location\\\":\\\"Shanghai\\\"}\"}}]}}]}\n\n" +
+			"data: {\"id\":\"chatcmpl_tool_stream\",\"model\":\"claude-haiku-4.5\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n" +
+			"data: [DONE]\n\n"
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	provider := NewGitHubCopilotProvider("github-copilot-test", "")
+	provider.baseURL = server.URL
+	provider.token = "test-token"
+	adapter := provider.GetAdapter().(*CopilotAdapter)
+	inboundShape := "anthropic"
+
+	eventCh, err := adapter.ExecuteStream(context.Background(), &cif.CanonicalRequest{
+		Model: "claude-haiku-4.5",
+		Messages: []cif.CIFMessage{
+			cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "weather"}}},
+		},
+		Tools:  []cif.CIFTool{{Name: "get_weather"}},
+		Stream: true,
+		Extensions: &cif.Extensions{
+			InboundAPIShape: &inboundShape,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream returned error: %v", err)
+	}
+
+	resp, err := shared.CollectStream(eventCh)
+	if err != nil {
+		t.Fatalf("CollectStream returned error: %v", err)
+	}
+	if capturedPath != "/chat/completions" {
+		t.Fatalf("expected Anthropic Claude request to stay on /chat/completions stream, got %q", capturedPath)
+	}
+	if resp.StopReason != cif.StopReasonToolUse {
+		t.Fatalf("expected tool_use stop reason, got %v", resp.StopReason)
+	}
+	if len(resp.Content) != 1 {
+		t.Fatalf("expected one content part, got %#v", resp.Content)
+	}
+	toolCall, ok := resp.Content[0].(cif.CIFToolCallPart)
+	if !ok {
+		t.Fatalf("expected tool call, got %T", resp.Content[0])
+	}
+	if toolCall.ToolCallID != "call_weather" || toolCall.ToolArguments["location"] != "Shanghai" {
+		t.Fatalf("unexpected tool call payload: %#v", toolCall)
+	}
+}
+
 func TestCopilotAdapterExecuteStream_OpenAIShapeGPT5StreamsResponses(t *testing.T) {
 	var capturedPath string
 	var capturedPayload map[string]interface{}

--- a/internal/serialization/serialization_test.go
+++ b/internal/serialization/serialization_test.go
@@ -58,10 +58,14 @@ func TestSerializeToOpenAI_StopReasonMapping(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		content := []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "ok"}}
+		if c.reason == cif.StopReasonToolUse {
+			content = []cif.CIFContentPart{cif.CIFToolCallPart{Type: "tool_call", ToolCallID: "call_1", ToolName: "read", ToolArguments: map[string]interface{}{"file": "README.md"}}}
+		}
 		resp := &cif.CanonicalResponse{
 			ID:         "r1",
 			Model:      "gpt-4o",
-			Content:    []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "ok"}},
+			Content:    content,
 			StopReason: c.reason,
 		}
 		out, err := SerializeToOpenAI(resp)
@@ -210,10 +214,14 @@ func TestSerializeToAnthropic_StopReasonMapping(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		content := []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "ok"}}
+		if c.reason == cif.StopReasonToolUse {
+			content = []cif.CIFContentPart{cif.CIFToolCallPart{Type: "tool_call", ToolCallID: "call_1", ToolName: "read", ToolArguments: map[string]interface{}{"file": "README.md"}}}
+		}
 		resp := &cif.CanonicalResponse{
 			ID:         "m1",
 			Model:      "claude",
-			Content:    []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "ok"}},
+			Content:    content,
 			StopReason: c.reason,
 		}
 		out, err := SerializeToAnthropic(resp)
@@ -284,6 +292,50 @@ func TestSerializeToAnthropic_NormalizesCopilotToolUseID(t *testing.T) {
 	}
 	if out.Content[0].ID != "toolu_abc123" {
 		t.Fatalf("expected normalized tool use id, got %q", out.Content[0].ID)
+	}
+}
+
+func TestSerializeToAnthropic_DowngradesDanglingToolUseStopReason(t *testing.T) {
+	resp := &cif.CanonicalResponse{
+		ID:    "msg_dangling_tool_use",
+		Model: "claude-haiku-4.5",
+		Content: []cif.CIFContentPart{
+			cif.CIFTextPart{Type: "text", Text: "I'll inspect the repo first."},
+		},
+		StopReason: cif.StopReasonToolUse,
+	}
+
+	out, err := SerializeToAnthropic(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.StopReason == nil || *out.StopReason != "end_turn" {
+		t.Fatalf("expected dangling tool_use to downgrade to end_turn, got %#v", out.StopReason)
+	}
+	if len(out.Content) != 1 || out.Content[0].Type != "text" {
+		t.Fatalf("unexpected content payload: %#v", out.Content)
+	}
+}
+
+func TestSerializeToOpenAI_DowngradesDanglingToolUseFinishReason(t *testing.T) {
+	resp := &cif.CanonicalResponse{
+		ID:    "chatcmpl_dangling_tool_use",
+		Model: "claude-haiku-4.5",
+		Content: []cif.CIFContentPart{
+			cif.CIFTextPart{Type: "text", Text: "I'll inspect the repo first."},
+		},
+		StopReason: cif.StopReasonToolUse,
+	}
+
+	out, err := SerializeToOpenAI(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Choices) != 1 || out.Choices[0].FinishReason == nil || *out.Choices[0].FinishReason != "stop" {
+		t.Fatalf("expected dangling tool_use to downgrade to stop, got %#v", out.Choices)
+	}
+	if out.Choices[0].Message == nil || len(out.Choices[0].Message.ToolCalls) != 0 {
+		t.Fatalf("expected no tool calls in downgraded response, got %#v", out.Choices[0].Message)
 	}
 }
 

--- a/internal/serialization/to_anthropic.go
+++ b/internal/serialization/to_anthropic.go
@@ -70,6 +70,9 @@ func SerializeToAnthropicWithSuppression(response *cif.CanonicalResponse, suppre
 	}
 
 	stopReason := convertStopReasonToAnthropic(response.StopReason)
+	if !anthropicContentHasToolUse(content) && response.StopReason == cif.StopReasonToolUse {
+		stopReason = convertStopReasonToAnthropic(cif.StopReasonEndTurn)
+	}
 
 	anthropicResp := &AnthropicResponse{
 		ID:           response.ID,
@@ -347,6 +350,15 @@ func normalizeAnthropicToolUseID(id string) string {
 	default:
 		return "toolu_" + id
 	}
+}
+
+func anthropicContentHasToolUse(content []AnthropicContentBlock) bool {
+	for _, block := range content {
+		if block.Type == "tool_use" {
+			return true
+		}
+	}
+	return false
 }
 
 func FormatAnthropicSSEData(eventType string, data interface{}) (string, error) {

--- a/internal/serialization/to_openai.go
+++ b/internal/serialization/to_openai.go
@@ -93,6 +93,9 @@ func SerializeToOpenAI(response *cif.CanonicalResponse) (*OpenAIResponse, error)
 	}
 
 	finishReason := convertStopReasonToOpenAI(response.StopReason)
+	if len(toolCalls) == 0 && response.StopReason == cif.StopReasonToolUse {
+		finishReason = convertStopReasonToOpenAI(cif.StopReasonEndTurn)
+	}
 
 	choice := OpenAIChoice{
 		Index: 0,


### PR DESCRIPTION
Fixes Claude Code tool-call parsing failures on OmniLLM's Anthropic compatibility path.

What changed:
- Keep Copilot Claude Anthropic streaming on the native chat-completions stream path instead of buffering into a broken non-streaming shape.
- Downgrade dangling tool-use/tool-call stop reasons when no actual tool block exists.
- Add regression tests and a docs record.

Verification:
- go test ./internal/providers/copilot ./internal/serialization
- Live Claude Agent SDK checks against localhost:5000 for claude-haiku-4.5 and claude-sonnet-4.6 no longer hit the tool-call parse error.