### PR TITLE
feat: add metering breakdown by client and sortable table headers

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -513,6 +513,7 @@ export interface MeteringRecord {
   model_id: string
   model_used: string
   provider_id: string
+  client: string
   api_shape: string
   input_tokens: number
   output_tokens: number
@@ -536,6 +537,7 @@ export interface MeteringStats {
 export interface MeteringBreakdownItem {
   model_id?: string
   provider_id?: string
+  client?: string
   requests: number
   input_tokens: number
   output_tokens: number
@@ -588,6 +590,11 @@ export const getMeteringByModel = (params: MeteringQuery = {}) =>
 export const getMeteringByProvider = (params: MeteringQuery = {}) =>
   apiFetch<{ items: Array<MeteringBreakdownItem> | null }>(
     `/api/admin/metering/by-provider${buildQueryString(params)}`,
+  )
+
+export const getMeteringByClient = (params: MeteringQuery = {}) =>
+  apiFetch<{ items: Array<MeteringBreakdownItem> | null }>(
+    `/api/admin/metering/by-client${buildQueryString(params)}`,
   )
 
 export const getMeteringModels = (params: MeteringQuery = {}) =>

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -555,6 +555,7 @@ export interface MeteringLogsResponse {
 export interface MeteringQuery {
   model_id?: string
   provider_id?: string
+  client?: string
   api_shape?: string
   since?: string
   until?: string
@@ -605,6 +606,11 @@ export const getMeteringModels = (params: MeteringQuery = {}) =>
 export const getMeteringProviders = (params: MeteringQuery = {}) =>
   apiFetch<{ items: Array<string> | null }>(
     `/api/admin/metering/providers${buildQueryString(params)}`,
+  )
+
+export const getMeteringClients = (params: MeteringQuery = {}) =>
+  apiFetch<{ items: Array<string> | null }>(
+    `/api/admin/metering/clients${buildQueryString(params)}`,
   )
 
 // ─── Log level ────────────────────────────────────────────────────────────────

--- a/frontend/src/locales/en/metering.json
+++ b/frontend/src/locales/en/metering.json
@@ -24,6 +24,7 @@
     "all": "All",
     "allModels": "All models",
     "allProviders": "All providers",
+    "allClients": "All clients",
     "rowsPerPage": "Rows per page",
     "maxRows": "Max rows"
   },

--- a/frontend/src/locales/en/metering.json
+++ b/frontend/src/locales/en/metering.json
@@ -3,6 +3,7 @@
   "description": "Request-level usage data captured after CIF responses finalize, with token totals, latency, provider attribution, and raw request logs.",
   "byModel": "By model",
   "byProvider": "By provider",
+  "byClient": "By client",
   "requestLog": "Request log",
   "requestLogDescription": "Raw metering rows captured from OpenAI and Anthropic response paths.",
   "stats": {
@@ -29,6 +30,7 @@
   "table": {
     "model": "model",
     "provider": "provider",
+    "client": "client",
     "requests": "requests",
     "input": "input",
     "output": "output",

--- a/frontend/src/locales/zh/metering.json
+++ b/frontend/src/locales/zh/metering.json
@@ -24,6 +24,7 @@
     "all": "全部",
     "allModels": "全部模型",
     "allProviders": "全部提供者",
+    "allClients": "全部客户端",
     "rowsPerPage": "每页行数",
     "maxRows": "最大行数"
   },

--- a/frontend/src/locales/zh/metering.json
+++ b/frontend/src/locales/zh/metering.json
@@ -3,6 +3,7 @@
   "description": "CIF 响应完成后的请求级使用数据，包含令牌总数、延迟、提供者归属和原始请求日志。",
   "byModel": "按模型",
   "byProvider": "按提供者",
+  "byClient": "按客户端",
   "requestLog": "请求日志",
   "requestLogDescription": "从 OpenAI 和 Anthropic 响应路径捕获的原始计量行。",
   "stats": {
@@ -29,6 +30,7 @@
   "table": {
     "model": "模型",
     "provider": "提供者",
+    "client": "客户端",
     "requests": "请求数",
     "input": "输入",
     "output": "输出",

--- a/frontend/src/pages/MeteringPage.tsx
+++ b/frontend/src/pages/MeteringPage.tsx
@@ -2,9 +2,9 @@ import { useEffect, useMemo, useState, type CSSProperties } from "react"
 import { useTranslation } from "react-i18next"
 
 import {
-  getMeteringByClient,
   getMeteringByModel,
   getMeteringByProvider,
+  getMeteringClients,
   getMeteringLogs,
   getMeteringModels,
   getMeteringProviders,
@@ -16,6 +16,39 @@ import {
   type MeteringStats,
 } from "@/api"
 import { SearchableSelect } from "@/components/SearchableSelect"
+
+function sortItems<T>(
+  items: Array<T>,
+  sortKey: keyof T | null,
+  sortDirection: "asc" | "desc",
+) {
+  if (!sortKey) return [...items]
+
+  return [...items].sort((left, right) => {
+    const leftValue = left[sortKey]
+    const rightValue = right[sortKey]
+
+    if (typeof leftValue === "number" && typeof rightValue === "number") {
+      return sortDirection === "asc" ?
+          leftValue - rightValue
+        : rightValue - leftValue
+    }
+
+    if (typeof leftValue === "boolean" && typeof rightValue === "boolean") {
+      const leftNumber = Number(leftValue)
+      const rightNumber = Number(rightValue)
+      return sortDirection === "asc" ?
+          leftNumber - rightNumber
+        : rightNumber - leftNumber
+    }
+
+    const leftText = String(leftValue ?? "")
+    const rightText = String(rightValue ?? "")
+    return sortDirection === "asc" ?
+        leftText.localeCompare(rightText)
+      : rightText.localeCompare(leftText)
+  })
+}
 
 function formatNumber(value: number) {
   return new Intl.NumberFormat().format(value)
@@ -51,6 +84,7 @@ function Card({
         border: "1px solid var(--color-separator)",
         boxShadow: "var(--shadow-card)",
         overflow: "hidden",
+        minWidth: 0,
         ...style,
       }}
     >
@@ -124,13 +158,84 @@ function BreakdownTable({
   const { t } = useTranslation("metering")
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(5)
+  const [sortKey, setSortKey] = useState<
+    | "requests"
+    | "input_tokens"
+    | "output_tokens"
+    | "total_tokens"
+    | "avg_latency_ms"
+    | "model_id"
+    | "provider_id"
+    | "client"
+  >("total_tokens")
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc")
   const safeItems = items ?? []
-  const totalPages = Math.max(1, Math.ceil(safeItems.length / pageSize))
+
+  const sortedItems = useMemo(
+    () => sortItems(safeItems, sortKey, sortDirection),
+    [safeItems, sortDirection, sortKey],
+  )
+  const totalPages = Math.max(1, Math.ceil(sortedItems.length / pageSize))
 
   useEffect(() => {
     setPage(1)
-  }, [items, pageSize])
-  const pageItems = safeItems.slice((page - 1) * pageSize, page * pageSize)
+  }, [items, pageSize, sortDirection, sortKey])
+
+  const pageItems = sortedItems.slice((page - 1) * pageSize, page * pageSize)
+
+  const handleSort = (
+    nextKey:
+      | "requests"
+      | "input_tokens"
+      | "output_tokens"
+      | "total_tokens"
+      | "avg_latency_ms"
+      | "model_id"
+      | "provider_id"
+      | "client",
+  ) => {
+    if (sortKey === nextKey) {
+      setSortDirection((current) => (current === "asc" ? "desc" : "asc"))
+      return
+    }
+    setSortKey(nextKey)
+    let direction: "asc" | "desc" = "asc"
+    if (nextKey !== valueKey) {
+      direction = nextKey === "total_tokens" ? "desc" : "asc"
+    }
+    setSortDirection(direction)
+  }
+
+  const renderSortIndicator = (
+    key:
+      | "requests"
+      | "input_tokens"
+      | "output_tokens"
+      | "total_tokens"
+      | "avg_latency_ms"
+      | "model_id"
+      | "provider_id"
+      | "client",
+  ) => {
+    if (sortKey !== key) return null
+    return sortDirection === "asc" ? " ▲" : " ▼"
+  }
+
+  const groupedHeaders: Array<{
+    key:
+      | "requests"
+      | "input_tokens"
+      | "output_tokens"
+      | "total_tokens"
+      | "avg_latency_ms"
+    label: string
+  }> = [
+    { key: "requests", label: t("table.requests") },
+    { key: "input_tokens", label: t("table.input") },
+    { key: "output_tokens", label: t("table.output") },
+    { key: "total_tokens", label: t("table.total") },
+    { key: "avg_latency_ms", label: t("table.avgLatency") },
+  ]
 
   return (
     <Card>
@@ -145,7 +250,15 @@ function BreakdownTable({
           flexWrap: "wrap",
         }}
       >
-        <div>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 10,
+            minWidth: 220,
+            flex: "1 1 260px",
+          }}
+        >
           <h2
             style={{
               margin: 0,
@@ -157,7 +270,15 @@ function BreakdownTable({
             {title}
           </h2>
         </div>
-        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            flexWrap: "wrap",
+            justifyContent: "flex-end",
+          }}
+        >
           <label
             style={{
               display: "flex",
@@ -188,41 +309,45 @@ function BreakdownTable({
               fontFamily: "var(--font-mono)",
             }}
           >
-            {t("pagination.rows", { count: safeItems.length })}
+            {t("pagination.rows", { count: sortedItems.length })}
           </span>
         </div>
       </div>
       <div style={{ overflowX: "auto" }}>
-        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <table
+          style={{ width: "100%", minWidth: 720, borderCollapse: "collapse" }}
+        >
           <thead>
             <tr style={{ background: "rgba(255,255,255,0.02)" }}>
-              {[
-                keyLabel,
-                t("table.requests"),
-                t("table.input"),
-                t("table.output"),
-                t("table.total"),
-                t("table.avgLatency"),
-              ].map((label) => (
+              <th
+                onClick={() => handleSort(valueKey)}
+                style={{
+                  ...groupedHeaderCellStyle,
+                  minWidth: 180,
+                  cursor: "pointer",
+                }}
+              >
+                {keyLabel}
+                {renderSortIndicator(valueKey)}
+              </th>
+              {groupedHeaders.map((header) => (
                 <th
-                  key={label}
+                  key={header.key}
+                  onClick={() => handleSort(header.key)}
                   style={{
-                    textAlign: "left",
-                    padding: "10px 14px",
-                    fontSize: 11,
-                    textTransform: "uppercase",
-                    letterSpacing: "0.06em",
-                    color: "var(--color-text-tertiary)",
-                    borderBottom: "1px solid var(--color-separator)",
+                    ...groupedHeaderCellStyle,
+                    minWidth: 100,
+                    cursor: "pointer",
                   }}
                 >
-                  {label}
+                  {header.label}
+                  {renderSortIndicator(header.key)}
                 </th>
               ))}
             </tr>
           </thead>
           <tbody>
-            {safeItems.length === 0 && (
+            {sortedItems.length === 0 && (
               <tr>
                 <td
                   colSpan={6}
@@ -238,16 +363,7 @@ function BreakdownTable({
             )}
             {pageItems.map((item, index) => (
               <tr key={`${item[valueKey] ?? "unknown"}-${index}`}>
-                <td
-                  style={{
-                    padding: "12px 14px",
-                    borderBottom: "1px solid var(--color-separator)",
-                    color: "var(--color-text)",
-                    fontWeight: 600,
-                  }}
-                >
-                  {item[valueKey] ?? "—"}
-                </td>
+                <td style={groupedKeyCellStyle}>{item[valueKey] ?? "—"}</td>
                 <td style={cellStyle}>{formatNumber(item.requests)}</td>
                 <td style={cellStyle}>{formatNumber(item.input_tokens)}</td>
                 <td style={cellStyle}>{formatNumber(item.output_tokens)}</td>
@@ -294,6 +410,25 @@ function BreakdownTable({
   )
 }
 
+const groupedHeaderCellStyle: CSSProperties = {
+  textAlign: "left",
+  padding: "10px 14px",
+  fontSize: 11,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "var(--color-text-tertiary)",
+  borderBottom: "1px solid var(--color-separator)",
+  whiteSpace: "nowrap",
+}
+
+const groupedKeyCellStyle: CSSProperties = {
+  padding: "12px 14px",
+  borderBottom: "1px solid var(--color-separator)",
+  color: "var(--color-text)",
+  fontWeight: 600,
+  minWidth: 180,
+}
+
 const cellStyle: CSSProperties = {
   padding: "12px 14px",
   borderBottom: "1px solid var(--color-separator)",
@@ -319,6 +454,7 @@ export function MeteringPage({
   const [until, setUntil] = useState("")
   const [modelId, setModelId] = useState("")
   const [providerId, setProviderId] = useState("")
+  const [client, setClient] = useState("")
   const [apiShape, setAPIShape] = useState("")
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(50)
@@ -329,9 +465,14 @@ export function MeteringPage({
   const [logs, setLogs] = useState<MeteringLogsResponse | null>(null)
   const [byModel, setByModel] = useState<Array<MeteringBreakdownItem>>([])
   const [byProvider, setByProvider] = useState<Array<MeteringBreakdownItem>>([])
-  const [byClient, setByClient] = useState<Array<MeteringBreakdownItem>>([])
+  const [logSortKey, setLogSortKey] =
+    useState<keyof MeteringRecord>("created_at")
+  const [logSortDirection, setLogSortDirection] = useState<"asc" | "desc">(
+    "desc",
+  )
   const [modelOptions, setModelOptions] = useState<Array<string>>([])
   const [providerOptions, setProviderOptions] = useState<Array<string>>([])
+  const [clientOptions, setClientOptions] = useState<Array<string>>([])
 
   const query = useMemo<MeteringQuery>(
     () => ({
@@ -339,11 +480,22 @@ export function MeteringPage({
       until: until ? new Date(until).toISOString() : undefined,
       model_id: modelId || undefined,
       provider_id: providerId || undefined,
+      client: client || undefined,
       api_shape: apiShape || undefined,
       page,
       page_size: pageSize,
     }),
-    [apiShape, modelId, page, pageSize, providerId, reloadKey, since, until],
+    [
+      apiShape,
+      client,
+      modelId,
+      page,
+      pageSize,
+      providerId,
+      reloadKey,
+      since,
+      until,
+    ],
   )
 
   const modelOptionsQuery = useMemo<MeteringQuery>(
@@ -351,9 +503,10 @@ export function MeteringPage({
       since: since ? new Date(since).toISOString() : undefined,
       until: until ? new Date(until).toISOString() : undefined,
       provider_id: providerId || undefined,
+      client: client || undefined,
       api_shape: apiShape || undefined,
     }),
-    [apiShape, providerId, reloadKey, since, until],
+    [apiShape, client, providerId, reloadKey, since, until],
   )
 
   const providerOptionsQuery = useMemo<MeteringQuery>(
@@ -361,9 +514,21 @@ export function MeteringPage({
       since: since ? new Date(since).toISOString() : undefined,
       until: until ? new Date(until).toISOString() : undefined,
       model_id: modelId || undefined,
+      client: client || undefined,
       api_shape: apiShape || undefined,
     }),
-    [apiShape, modelId, reloadKey, since, until],
+    [apiShape, client, modelId, reloadKey, since, until],
+  )
+
+  const clientOptionsQuery = useMemo<MeteringQuery>(
+    () => ({
+      since: since ? new Date(since).toISOString() : undefined,
+      until: until ? new Date(until).toISOString() : undefined,
+      model_id: modelId || undefined,
+      provider_id: providerId || undefined,
+      api_shape: apiShape || undefined,
+    }),
+    [apiShape, modelId, providerId, reloadKey, since, until],
   )
 
   useEffect(() => {
@@ -375,9 +540,9 @@ export function MeteringPage({
       getMeteringLogs(query),
       getMeteringByModel(query),
       getMeteringByProvider(query),
-      getMeteringByClient(query),
       getMeteringModels(modelOptionsQuery),
       getMeteringProviders(providerOptionsQuery),
+      getMeteringClients(clientOptionsQuery),
     ])
       .then(
         ([
@@ -385,18 +550,18 @@ export function MeteringPage({
           nextLogs,
           nextByModel,
           nextByProvider,
-          nextByClient,
           nextModels,
           nextProviders,
+          nextClients,
         ]) => {
           if (cancelled) return
           setStats(nextStats)
           setLogs({ ...nextLogs, items: nextLogs.items ?? [] })
           setByModel(nextByModel.items ?? [])
           setByProvider(nextByProvider.items ?? [])
-          setByClient(nextByClient.items ?? [])
           setModelOptions(nextModels.items ?? [])
           setProviderOptions(nextProviders.items ?? [])
+          setClientOptions(nextClients.items ?? [])
         },
       )
       .catch((e: unknown) => {
@@ -414,11 +579,49 @@ export function MeteringPage({
     return () => {
       cancelled = true
     }
-  }, [modelOptionsQuery, providerOptionsQuery, query, showToast])
+  }, [
+    clientOptionsQuery,
+    modelOptionsQuery,
+    providerOptionsQuery,
+    query,
+    showToast,
+  ])
 
   const totalPages =
     logs ? Math.max(1, Math.ceil(logs.total / logs.page_size)) : 1
-  const logItems = (logs?.items ?? []).slice(0, maxRows || undefined)
+  const logSortOptions: Array<{ key: keyof MeteringRecord; label: string }> = [
+    { key: "created_at", label: t("table.time") },
+    { key: "model_id", label: t("table.model") },
+    { key: "provider_id", label: t("table.provider") },
+    { key: "client", label: t("table.client") },
+    { key: "api_shape", label: t("table.shape") },
+    { key: "input_tokens", label: t("table.input") },
+    { key: "output_tokens", label: t("table.output") },
+    { key: "total_tokens", label: t("table.total") },
+    { key: "latency_ms", label: t("table.latency") },
+    { key: "status_code", label: t("table.status") },
+    { key: "is_stream", label: t("table.stream") },
+  ]
+
+  const handleLogSort = (nextKey: keyof MeteringRecord) => {
+    if (logSortKey === nextKey) {
+      setLogSortDirection((current) => (current === "asc" ? "desc" : "asc"))
+      return
+    }
+    setLogSortKey(nextKey)
+    setLogSortDirection(nextKey === "created_at" ? "desc" : "asc")
+  }
+
+  const renderLogSortIndicator = (key: keyof MeteringRecord) => {
+    if (logSortKey !== key) return null
+    return logSortDirection === "asc" ? " ▲" : " ▼"
+  }
+
+  const sortedLogs = useMemo(
+    () => sortItems(logs?.items ?? [], logSortKey, logSortDirection),
+    [logSortDirection, logSortKey, logs?.items],
+  )
+  const logItems = sortedLogs.slice(0, maxRows || undefined)
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
@@ -524,6 +727,18 @@ export function MeteringPage({
             />
           </label>
           <label style={fieldStyle}>
+            <span style={labelStyle}>{t("table.client")}</span>
+            <SearchableSelect
+              options={clientOptions}
+              value={client}
+              onChange={(v) => {
+                setClient(v)
+                setPage(1)
+              }}
+              placeholder={t("filters.allClients")}
+            />
+          </label>
+          <label style={fieldStyle}>
             <span style={labelStyle}>{t("filters.apiShape")}</span>
             <select
               className="sys-select"
@@ -593,12 +808,6 @@ export function MeteringPage({
           items={byProvider}
           valueKey="provider_id"
         />
-        <BreakdownTable
-          title={t("byClient")}
-          keyLabel={t("table.client")}
-          items={byClient}
-          valueKey="client"
-        />
       </div>
 
       <Card>
@@ -633,7 +842,14 @@ export function MeteringPage({
               {t("requestLogDescription")}
             </p>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              flexWrap: "wrap",
+            }}
+          >
             <label
               style={{
                 display: "flex",
@@ -702,34 +918,45 @@ export function MeteringPage({
           </div>
         </div>
         <div style={{ overflowX: "auto" }}>
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <table
+            style={{
+              width: "100%",
+              minWidth: 1280,
+              borderCollapse: "collapse",
+            }}
+          >
             <thead>
               <tr style={{ background: "rgba(255,255,255,0.02)" }}>
-                {[
-                  t("table.time"),
-                  t("table.model"),
-                  t("table.provider"),
-                  t("table.shape"),
-                  t("table.input"),
-                  t("table.output"),
-                  t("table.total"),
-                  t("table.latency"),
-                  t("table.status"),
-                  t("table.stream"),
-                ].map((label) => (
+                {logSortOptions.map((option) => (
                   <th
-                    key={label}
+                    key={option.key}
+                    onClick={() => handleLogSort(option.key)}
                     style={{
-                      textAlign: "left",
-                      padding: "10px 14px",
-                      fontSize: 11,
-                      textTransform: "uppercase",
-                      letterSpacing: "0.06em",
-                      color: "var(--color-text-tertiary)",
-                      borderBottom: "1px solid var(--color-separator)",
+                      ...groupedHeaderCellStyle,
+                      minWidth: (() => {
+                        switch (option.key) {
+                          case "created_at": {
+                            return 170
+                          }
+                          case "model_id": {
+                            return 170
+                          }
+                          case "provider_id": {
+                            return 210
+                          }
+                          case "client": {
+                            return 160
+                          }
+                          default: {
+                            return 100
+                          }
+                        }
+                      })(),
+                      cursor: "pointer",
                     }}
                   >
-                    {label}
+                    {option.label}
+                    {renderLogSortIndicator(option.key)}
                   </th>
                 ))}
               </tr>
@@ -738,7 +965,7 @@ export function MeteringPage({
               {!loading && logItems.length === 0 && (
                 <tr>
                   <td
-                    colSpan={10}
+                    colSpan={11}
                     style={{
                       padding: "28px 16px",
                       textAlign: "center",
@@ -751,9 +978,18 @@ export function MeteringPage({
               )}
               {logItems.map((row: MeteringRecord) => (
                 <tr key={row.id}>
-                  <td style={cellStyle}>{formatDateTime(row.created_at)}</td>
-                  <td style={cellStyle}>{row.model_id}</td>
-                  <td style={cellStyle}>{row.provider_id}</td>
+                  <td style={{ ...cellStyle, minWidth: 170 }}>
+                    {formatDateTime(row.created_at)}
+                  </td>
+                  <td style={{ ...cellStyle, minWidth: 170 }}>
+                    {row.model_id}
+                  </td>
+                  <td style={{ ...cellStyle, minWidth: 210 }}>
+                    {row.provider_id}
+                  </td>
+                  <td style={{ ...cellStyle, minWidth: 160 }}>
+                    {row.client || "—"}
+                  </td>
                   <td style={cellStyle}>{row.api_shape}</td>
                   <td style={cellStyle}>{formatNumber(row.input_tokens)}</td>
                   <td style={cellStyle}>{formatNumber(row.output_tokens)}</td>

--- a/frontend/src/pages/MeteringPage.tsx
+++ b/frontend/src/pages/MeteringPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type CSSProperties } from "react"
 import { useTranslation } from "react-i18next"
 
 import {
+  getMeteringByClient,
   getMeteringByModel,
   getMeteringByProvider,
   getMeteringLogs,
@@ -118,7 +119,7 @@ function BreakdownTable({
   title: string
   keyLabel: string
   items: Array<MeteringBreakdownItem> | null | undefined
-  valueKey: "model_id" | "provider_id"
+  valueKey: "model_id" | "provider_id" | "client"
 }) {
   const { t } = useTranslation("metering")
   const [page, setPage] = useState(1)
@@ -328,6 +329,7 @@ export function MeteringPage({
   const [logs, setLogs] = useState<MeteringLogsResponse | null>(null)
   const [byModel, setByModel] = useState<Array<MeteringBreakdownItem>>([])
   const [byProvider, setByProvider] = useState<Array<MeteringBreakdownItem>>([])
+  const [byClient, setByClient] = useState<Array<MeteringBreakdownItem>>([])
   const [modelOptions, setModelOptions] = useState<Array<string>>([])
   const [providerOptions, setProviderOptions] = useState<Array<string>>([])
 
@@ -373,6 +375,7 @@ export function MeteringPage({
       getMeteringLogs(query),
       getMeteringByModel(query),
       getMeteringByProvider(query),
+      getMeteringByClient(query),
       getMeteringModels(modelOptionsQuery),
       getMeteringProviders(providerOptionsQuery),
     ])
@@ -382,6 +385,7 @@ export function MeteringPage({
           nextLogs,
           nextByModel,
           nextByProvider,
+          nextByClient,
           nextModels,
           nextProviders,
         ]) => {
@@ -390,6 +394,7 @@ export function MeteringPage({
           setLogs({ ...nextLogs, items: nextLogs.items ?? [] })
           setByModel(nextByModel.items ?? [])
           setByProvider(nextByProvider.items ?? [])
+          setByClient(nextByClient.items ?? [])
           setModelOptions(nextModels.items ?? [])
           setProviderOptions(nextProviders.items ?? [])
         },
@@ -587,6 +592,12 @@ export function MeteringPage({
           keyLabel={t("table.provider")}
           items={byProvider}
           valueKey="provider_id"
+        />
+        <BreakdownTable
+          title={t("byClient")}
+          keyLabel={t("table.client")}
+          items={byClient}
+          valueKey="client"
         />
       </div>
 

--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -188,6 +188,7 @@ func (db *Database) createTables() error {
 			model_id      TEXT    NOT NULL DEFAULT '',
 			model_used    TEXT    NOT NULL DEFAULT '',
 			provider_id   TEXT    NOT NULL DEFAULT '',
+			client        TEXT    NOT NULL DEFAULT 'unknown',
 			api_shape     TEXT    NOT NULL DEFAULT 'openai',
 			input_tokens  INTEGER NOT NULL DEFAULT 0,
 			output_tokens INTEGER NOT NULL DEFAULT 0,
@@ -304,6 +305,7 @@ var migrations = []migration{
 			model_id      TEXT    NOT NULL DEFAULT '',
 			model_used    TEXT    NOT NULL DEFAULT '',
 			provider_id   TEXT    NOT NULL DEFAULT '',
+			client        TEXT    NOT NULL DEFAULT 'unknown',
 			api_shape     TEXT    NOT NULL DEFAULT 'openai',
 			input_tokens  INTEGER NOT NULL DEFAULT 0,
 			output_tokens INTEGER NOT NULL DEFAULT 0,
@@ -317,6 +319,12 @@ var migrations = []migration{
 		`CREATE INDEX IF NOT EXISTS idx_request_logs_created_at          ON request_logs (created_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_request_logs_model_created_at    ON request_logs (model_id, created_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_request_logs_provider_created_at ON request_logs (provider_id, created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_logs_client_created_at   ON request_logs (client, created_at)`,
+	}},
+	// v8: add client dimension to request_logs for per-client metering breakdowns.
+	{8, []string{
+		`ALTER TABLE request_logs ADD COLUMN client TEXT NOT NULL DEFAULT 'unknown'`,
+		`CREATE INDEX IF NOT EXISTS idx_request_logs_client_created_at ON request_logs (client, created_at)`,
 	}},
 }
 

--- a/internal/database/store_metering.go
+++ b/internal/database/store_metering.go
@@ -26,6 +26,7 @@ func (db *Database) InsertMeteringRecord(r MeteringRecord) error {
 type MeteringFilter struct {
 	ModelID    string
 	ProviderID string
+	Client     string
 	APIShape   string
 	Since      time.Time
 	Until      time.Time
@@ -228,6 +229,10 @@ func meteringWhere(f MeteringFilter) (string, []any) {
 		clauses = append(clauses, "provider_id = ?")
 		args = append(args, f.ProviderID)
 	}
+	if f.Client != "" {
+		clauses = append(clauses, "client = ?")
+		args = append(args, f.Client)
+	}
 	if f.APIShape != "" {
 		clauses = append(clauses, "api_shape = ?")
 		args = append(args, f.APIShape)
@@ -297,6 +302,26 @@ func (db *Database) GetDistinctMeteringProviders(f MeteringFilter) ([]string, er
 			return nil, err
 		}
 		result = append(result, p)
+	}
+	return result, rows.Err()
+}
+
+// GetDistinctMeteringClients returns distinct clients from request_logs within the filter window.
+func (db *Database) GetDistinctMeteringClients(f MeteringFilter) ([]string, error) {
+	where, args := meteringWhere(f)
+	sql := `SELECT DISTINCT client FROM request_logs` + where + ` ORDER BY client`
+	rows, err := db.db.Query(sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("distinct clients: %w", err)
+	}
+	defer rows.Close()
+	var result []string
+	for rows.Next() {
+		var client string
+		if err := rows.Scan(&client); err != nil {
+			return nil, err
+		}
+		result = append(result, client)
 	}
 	return result, rows.Err()
 }

--- a/internal/database/store_metering.go
+++ b/internal/database/store_metering.go
@@ -10,11 +10,11 @@ import (
 func (db *Database) InsertMeteringRecord(r MeteringRecord) error {
 	_, err := db.db.Exec(
 		`INSERT INTO request_logs
-			(request_id, model_id, model_used, provider_id, api_shape,
-			 input_tokens, output_tokens, total_tokens,
-			 latency_ms, is_stream, status_code, error_message, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		r.RequestID, r.ModelID, r.ModelUsed, r.ProviderID, r.APIShape,
+				(request_id, model_id, model_used, provider_id, client, api_shape,
+				 input_tokens, output_tokens, total_tokens,
+				 latency_ms, is_stream, status_code, error_message, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.RequestID, r.ModelID, r.ModelUsed, r.ProviderID, r.Client, r.APIShape,
 		r.InputTokens, r.OutputTokens, r.TotalTokens,
 		r.LatencyMS, boolToInt(r.IsStream), r.StatusCode, r.ErrorMessage,
 		r.CreatedAt.UTC().Format(time.RFC3339),
@@ -43,7 +43,7 @@ func (db *Database) ListMeteringRecords(f MeteringFilter, limit, offset int) ([]
 	}
 
 	// rows
-	querySQL := `SELECT id, request_id, model_id, model_used, provider_id, api_shape,
+	querySQL := `SELECT id, request_id, model_id, model_used, provider_id, client, api_shape,
 		input_tokens, output_tokens, total_tokens, latency_ms, is_stream,
 		status_code, error_message, created_at
 		FROM request_logs` + where +
@@ -62,7 +62,7 @@ func (db *Database) ListMeteringRecords(f MeteringFilter, limit, offset int) ([]
 		var isStream int
 		var createdAt string
 		if err := rows.Scan(
-			&r.ID, &r.RequestID, &r.ModelID, &r.ModelUsed, &r.ProviderID, &r.APIShape,
+			&r.ID, &r.RequestID, &r.ModelID, &r.ModelUsed, &r.ProviderID, &r.Client, &r.APIShape,
 			&r.InputTokens, &r.OutputTokens, &r.TotalTokens, &r.LatencyMS, &isStream,
 			&r.StatusCode, &r.ErrorMessage, &createdAt,
 		); err != nil {
@@ -171,6 +171,43 @@ func (db *Database) GetMeteringByProvider(f MeteringFilter) ([]ProviderBreakdown
 	for rows.Next() {
 		var b ProviderBreakdown
 		if err := rows.Scan(&b.ProviderID, &b.Requests, &b.InputTokens, &b.OutputTokens, &b.TotalTokens, &b.AvgLatencyMS); err != nil {
+			return nil, err
+		}
+		result = append(result, b)
+	}
+	return result, rows.Err()
+}
+
+// ClientBreakdown holds per-client aggregate usage.
+type ClientBreakdown struct {
+	Client       string  `json:"client"`
+	Requests     int64   `json:"requests"`
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+	TotalTokens  int64   `json:"total_tokens"`
+	AvgLatencyMS float64 `json:"avg_latency_ms"`
+}
+
+// GetMeteringByClient returns per-client breakdown for the given filter window.
+func (db *Database) GetMeteringByClient(f MeteringFilter) ([]ClientBreakdown, error) {
+	where, args := meteringWhere(f)
+	sql := `SELECT client,
+		COUNT(*),
+		COALESCE(SUM(input_tokens),  0),
+		COALESCE(SUM(output_tokens), 0),
+		COALESCE(SUM(total_tokens),  0),
+		COALESCE(AVG(latency_ms),    0)
+		FROM request_logs` + where +
+		` GROUP BY client ORDER BY SUM(total_tokens) DESC`
+	rows, err := db.db.Query(sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("metering by-client: %w", err)
+	}
+	defer rows.Close()
+	var result []ClientBreakdown
+	for rows.Next() {
+		var b ClientBreakdown
+		if err := rows.Scan(&b.Client, &b.Requests, &b.InputTokens, &b.OutputTokens, &b.TotalTokens, &b.AvgLatencyMS); err != nil {
 			return nil, err
 		}
 		result = append(result, b)

--- a/internal/database/types.go
+++ b/internal/database/types.go
@@ -137,6 +137,7 @@ type MeteringRecord struct {
 	ModelID      string    `json:"model_id"`      // canonical model name as requested
 	ModelUsed    string    `json:"model_used"`    // actual model reported by provider
 	ProviderID   string    `json:"provider_id"`   // provider instance_id
+	Client       string    `json:"client"`
 	APIShape     string    `json:"api_shape"`     // "openai" | "anthropic"
 	InputTokens  int       `json:"input_tokens"`
 	OutputTokens int       `json:"output_tokens"`

--- a/internal/routes/admin_metering.go
+++ b/internal/routes/admin_metering.go
@@ -17,6 +17,7 @@ func SetupMeteringRoutes(router *gin.RouterGroup) {
 	router.GET("/metering/by-client", handleMeteringByClient)
 	router.GET("/metering/models", handleMeteringModels)
 	router.GET("/metering/providers", handleMeteringProviders)
+	router.GET("/metering/clients", handleMeteringClients)
 }
 
 // parseMeteringFilter reads common query params shared by all metering endpoints.
@@ -24,6 +25,7 @@ func parseMeteringFilter(c *gin.Context) database.MeteringFilter {
 	f := database.MeteringFilter{
 		ModelID:    c.Query("model_id"),
 		ProviderID: c.Query("provider_id"),
+		Client:     c.Query("client"),
 		APIShape:   c.Query("api_shape"),
 	}
 	if s := c.Query("since"); s != "" {
@@ -150,4 +152,18 @@ func handleMeteringProviders(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"items": providers})
+}
+
+// GET /api/admin/metering/clients?since=&until=
+func handleMeteringClients(c *gin.Context) {
+	f := parseMeteringFilter(c)
+
+	db := database.GetDatabase()
+	clients, err := db.GetDistinctMeteringClients(f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"items": clients})
 }

--- a/internal/routes/admin_metering.go
+++ b/internal/routes/admin_metering.go
@@ -14,6 +14,7 @@ func SetupMeteringRoutes(router *gin.RouterGroup) {
 	router.GET("/metering/stats", handleMeteringStats)
 	router.GET("/metering/by-model", handleMeteringByModel)
 	router.GET("/metering/by-provider", handleMeteringByProvider)
+	router.GET("/metering/by-client", handleMeteringByClient)
 	router.GET("/metering/models", handleMeteringModels)
 	router.GET("/metering/providers", handleMeteringProviders)
 }
@@ -101,6 +102,20 @@ func handleMeteringByProvider(c *gin.Context) {
 
 	db := database.GetDatabase()
 	breakdown, err := db.GetMeteringByProvider(f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"items": breakdown})
+}
+
+// GET /api/admin/metering/by-client?since=&until=
+func handleMeteringByClient(c *gin.Context) {
+	f := parseMeteringFilter(c)
+
+	db := database.GetDatabase()
+	breakdown, err := db.GetMeteringByClient(f)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/routes/chat.go
+++ b/internal/routes/chat.go
@@ -198,7 +198,7 @@ func handleNonStreamingResponse(c *gin.Context, adapter types.ProviderAdapter, c
 	}
 
 	logCompletedResponse("openai", requestID, originalModel, response.Model, providerID, false, response.StopReason, response.Usage, startTime)
-	recordUsage(requestID, originalModel, response.Model, providerID, "openai", response.Usage, time.Since(startTime).Milliseconds(), false, http.StatusOK, "")
+	recordUsage(requestID, originalModel, response.Model, providerID, normalizeMeteringClient(c.GetHeader("User-Agent")), "openai", response.Usage, time.Since(startTime).Milliseconds(), false, http.StatusOK, "")
 
 	c.JSON(http.StatusOK, openaiResp)
 	return nil
@@ -261,7 +261,7 @@ func handleStreamingResponse(c *gin.Context, adapter types.ProviderAdapter, cano
 					Int("output_tokens", outputTokens).
 					Int64("latency_ms", time.Since(startTime).Milliseconds()).
 					Msg("\x1b[32m<--\x1b[0m RESPONSE stream")
-				recordUsage(requestID, originalModel, modelUsed, providerID, "openai", endEvt.Usage, time.Since(startTime).Milliseconds(), true, http.StatusOK, "")
+				recordUsage(requestID, originalModel, modelUsed, providerID, normalizeMeteringClient(c.GetHeader("User-Agent")), "openai", endEvt.Usage, time.Since(startTime).Milliseconds(), true, http.StatusOK, "")
 				return false
 			}
 

--- a/internal/routes/messages.go
+++ b/internal/routes/messages.go
@@ -197,7 +197,7 @@ func handleAnthropicNonStreamingResponse(c *gin.Context, adapter types.ProviderA
 		Int("output_tokens", outputTokens).
 		Int64("latency_ms", time.Since(startTime).Milliseconds()).
 		Msg("\x1b[32m<--\x1b[0m RESPONSE")
-	recordUsage(requestID, originalModel, response.Model, providerID, "anthropic", response.Usage, time.Since(startTime).Milliseconds(), false, http.StatusOK, "")
+	recordUsage(requestID, originalModel, response.Model, providerID, normalizeMeteringClient(c.GetHeader("User-Agent")), "anthropic", response.Usage, time.Since(startTime).Milliseconds(), false, http.StatusOK, "")
 
 	c.JSON(http.StatusOK, anthropicResp)
 	return nil
@@ -287,7 +287,7 @@ func handleAnthropicStreamingResponse(c *gin.Context, adapter types.ProviderAdap
 					Int("output_tokens", outputTokens).
 					Int64("latency_ms", time.Since(startTime).Milliseconds()).
 					Msg("\x1b[32m<--\x1b[0m RESPONSE stream")
-				recordUsage(requestID, originalModel, modelUsed, providerID, "anthropic", endEvt.Usage, time.Since(startTime).Milliseconds(), true, http.StatusOK, "")
+				recordUsage(requestID, originalModel, modelUsed, providerID, normalizeMeteringClient(c.GetHeader("User-Agent")), "anthropic", endEvt.Usage, time.Since(startTime).Milliseconds(), true, http.StatusOK, "")
 				return false
 			}
 

--- a/internal/routes/metering.go
+++ b/internal/routes/metering.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"omnillm/internal/cif"
 	"omnillm/internal/database"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -12,11 +13,23 @@ import (
 // It is called from the four response handlers (streaming + non-streaming,
 // OpenAI + Anthropic shapes).  Errors are logged but never returned — metering
 // must never break the request path.
+func normalizeMeteringClient(userAgent string) string {
+	client := strings.TrimSpace(userAgent)
+	if client == "" {
+		return "unknown"
+	}
+	if parts := strings.Fields(client); len(parts) > 0 {
+		return parts[0]
+	}
+	return "unknown"
+}
+
 func recordUsage(
 	requestID string,
 	modelID string, // canonical model as the caller requested
 	modelUsed string, // actual model reported by the provider
 	providerID string,
+	client string,
 	apiShape string,
 	usage *cif.CIFUsage,
 	latencyMS int64,
@@ -36,6 +49,7 @@ func recordUsage(
 		ModelID:      modelID,
 		ModelUsed:    modelUsed,
 		ProviderID:   providerID,
+		Client:       client,
 		APIShape:     apiShape,
 		InputTokens:  inputTokens,
 		OutputTokens: outputTokens,


### PR DESCRIPTION
## Summary

- Add client tracking to metering: captures the first token of User-Agent as `client` field on each request
- Add "By client" breakdown table and client column to request log
- Add client as a top-level filter dropdown alongside model and provider
- Make all table column headers clickable for sorting (asc/desc toggle)
- Fix table width/overflow so all columns are visible via horizontal scroll

## Changes

**Backend:**
- Schema migration v8: adds `client` column to `request_logs` table
- `normalizeMeteringClient()` extracts first token from User-Agent header
- New API endpoints: `/api/admin/metering/by-client`, `/api/admin/metering/clients`
- Client filter support in `MeteringFilter`

**Frontend:**
- Client filter dropdown in metering filter bar
- Sortable column headers on grouped tables (By model, By provider) and request log
- `minWidth` fixes for horizontal scrolling on narrow viewports
- i18n keys for client-related labels (en + zh)

## Test plan

- [x] Verify metering page loads with client data from real requests
- [x] Verify client filter filters correctly
- [x] Verify sort toggles on all table headers
- [x] Verify horizontal scroll works on narrow viewports