### PR TITLE
fix: add metering for Responses API and expose responses shape in metering UI

### DIFF
--- a/frontend/src/locales/en/metering.json
+++ b/frontend/src/locales/en/metering.json
@@ -5,7 +5,7 @@
   "byProvider": "By provider",
   "byClient": "By client",
   "requestLog": "Request log",
-  "requestLogDescription": "Raw metering rows captured from OpenAI and Anthropic response paths.",
+  "requestLogDescription": "Raw metering rows captured from OpenAI, Responses API, and Anthropic response paths.",
   "stats": {
     "requests": "Requests",
     "requestsSubtext": "Completed requests in the selected window",

--- a/frontend/src/locales/zh/metering.json
+++ b/frontend/src/locales/zh/metering.json
@@ -5,7 +5,7 @@
   "byProvider": "按提供者",
   "byClient": "按客户端",
   "requestLog": "请求日志",
-  "requestLogDescription": "从 OpenAI 和 Anthropic 响应路径捕获的原始计量行。",
+  "requestLogDescription": "从 OpenAI、Responses API 和 Anthropic 响应路径捕获的原始计量行。",
   "stats": {
     "requests": "请求数",
     "requestsSubtext": "所选时间窗口内完成的请求",

--- a/frontend/src/pages/MeteringPage.tsx
+++ b/frontend/src/pages/MeteringPage.tsx
@@ -751,6 +751,7 @@ export function MeteringPage({
               <option value="">{t("filters.all")}</option>
               <option value="openai">openai</option>
               <option value="anthropic">anthropic</option>
+              <option value="responses">responses</option>
             </select>
           </label>
         </div>

--- a/internal/routes/responses.go
+++ b/internal/routes/responses.go
@@ -152,6 +152,7 @@ func handleResponsesNonStreamingResponse(c *gin.Context, adapter types.ProviderA
 	}
 
 	logCompletedResponse("responses", requestID, originalModel, response.Model, providerID, false, response.StopReason, response.Usage, startTime)
+	recordUsage(requestID, originalModel, response.Model, providerID, normalizeMeteringClient(c.GetHeader("User-Agent")), "responses", response.Usage, time.Since(startTime).Milliseconds(), false, http.StatusOK, "")
 
 	c.JSON(http.StatusOK, responsesResp)
 	return nil
@@ -229,6 +230,7 @@ func handleResponsesStreamingResponse(c *gin.Context, adapter types.ProviderAdap
 					Int("output_tokens", outputTokens).
 					Int64("latency_ms", time.Since(startTime).Milliseconds()).
 					Msg("\x1b[32m<--\x1b[0m RESPONSE stream")
+				recordUsage(requestID, originalModel, modelUsed, providerID, normalizeMeteringClient(c.GetHeader("User-Agent")), "responses", endEvt.Usage, time.Since(startTime).Milliseconds(), true, http.StatusOK, "")
 				return false
 			}
 


### PR DESCRIPTION
## Summary

- Add missing `recordUsage()` calls to the Responses API non-streaming and streaming completion paths so Codex/Copilot requests are metered
- Preserve the real inbound `api_shape` as `"responses"` in metering rows
- Add `responses` option to the metering page API shape filter
- Update metering page description text to reflect full coverage

## Changes

**Backend:**
- `internal/routes/responses.go` — `recordUsage()` now called after `logCompletedResponse()` in both `handleResponsesNonStreamingResponse()` and the `CIFStreamEnd` branch of `handleResponsesStreamingResponse()`
- Client normalization via `normalizeMeteringClient(c.GetHeader("User-Agent"))` matches existing chat/messages paths

**Frontend:**
- `frontend/src/pages/MeteringPage.tsx` — API shape filter dropdown now includes `responses`
- `frontend/src/locales/en/metering.json` / `zh/metering.json` — updated request log description to reflect Responses API coverage

## Test plan

- [x] Send a non-streaming `/responses` request and verify a metering row with `api_shape = responses`
- [x] Send a streaming `/responses` request and verify one metering row with `is_stream = true`
- [x] Reproduce a Codex/Copilot request (e.g. `gpt-5.x-codex`) and verify it appears in metering
- [x] Filter by `responses` on the metering page and confirm new rows are visible