### PR TITLE
feat: persist raw access token for admin reveal-after-refresh, show inline in prefix cell

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -998,6 +998,7 @@ export interface AccessToken {
   id: string
   name: string
   prefix: string
+  token_plaintext?: string
   created_at: string
   expires_at: string | null
   last_used_at: string | null

--- a/frontend/src/pages/AccessTokensPage.tsx
+++ b/frontend/src/pages/AccessTokensPage.tsx
@@ -33,17 +33,13 @@ export function AccessTokensPage({ showToast }: Props) {
   const [newTokenExpiry, setNewTokenExpiry] = useState("")
   const [creating, setCreating] = useState(false)
 
-  // Raw tokens kept in memory after creation (id → raw token).
-  // Cleared when the user navigates away or refreshes.
   const [newlyCreatedTokens, setNewlyCreatedTokens] = useState<
     Record<string, string>
   >({})
-  // Which token's inline reveal is currently open in the list.
   const [viewingTokenId, setViewingTokenId] = useState<string | null>(null)
   const [viewingTokenVisible, setViewingTokenVisible] = useState(false)
   const [copied, setCopied] = useState<string | null>(null)
 
-  // The just-created token banner (shown once after creation).
   const [justCreatedId, setJustCreatedId] = useState<string | null>(null)
   const [bannerTokenVisible, setBannerTokenVisible] = useState(false)
   const [bannerCopied, setBannerCopied] = useState(false)
@@ -52,6 +48,14 @@ export function AccessTokensPage({ showToast }: Props) {
     try {
       const data = await listAccessTokens()
       setTokens(data)
+      setNewlyCreatedTokens((prev) => {
+        const persisted = Object.fromEntries(
+          data
+            .filter((token) => token.token_plaintext)
+            .map((token) => [token.id, token.token_plaintext as string]),
+        )
+        return { ...persisted, ...prev }
+      })
     } catch {
       showToast("Failed to load tokens", "error")
     } finally {
@@ -74,7 +78,6 @@ export function AccessTokensPage({ showToast }: Props) {
         expiresAt = d.toISOString()
       }
       const res = await createAccessToken(newTokenName.trim(), expiresAt)
-      // Store raw token in memory, show banner.
       setNewlyCreatedTokens((prev) => ({ ...prev, [res.id]: res.token }))
       setJustCreatedId(res.id)
       setBannerTokenVisible(false)
@@ -157,7 +160,6 @@ export function AccessTokensPage({ showToast }: Props) {
     return formatDate(dateStr)
   }
 
-  // ── Just-created banner ────────────────────────────────────────────────────
   const justCreatedRaw =
     justCreatedId ? (newlyCreatedTokens[justCreatedId] ?? null) : null
 
@@ -211,7 +213,6 @@ export function AccessTokensPage({ showToast }: Props) {
     )
   }
 
-  // ── Token list ─────────────────────────────────────────────────────────────
   const renderTokenList = () => {
     if (loading) {
       return <div className="py-12 text-center text-zinc-500">Loading...</div>
@@ -256,94 +257,85 @@ export function AccessTokensPage({ showToast }: Props) {
             {tokens.map((token) => {
               const rawToken = newlyCreatedTokens[token.id]
               const isViewing = viewingTokenId === token.id
-              let tokenDisplay: string | null = null
+              const canReveal = Boolean(rawToken)
+              let tokenCellText = `${token.prefix}...`
               if (isViewing && rawToken) {
-                tokenDisplay =
+                tokenCellText =
                   viewingTokenVisible ? rawToken : (
                     "•".repeat(Math.max(rawToken.length, 24))
                   )
               }
+              const copyLabel = copied === token.id ? "✓" : null
 
               return (
-                <>
-                  <tr key={token.id} className="hover:bg-zinc-800/30">
-                    <td className="px-4 py-3 font-medium text-zinc-200">
-                      {token.name}
-                    </td>
-                    <td className="px-4 py-3">
-                      <code className="rounded bg-zinc-800 px-2 py-0.5 text-xs text-zinc-400">
-                        {token.prefix}...
+                <tr key={token.id} className="hover:bg-zinc-800/30">
+                  <td className="px-4 py-3 font-medium text-zinc-200">
+                    {token.name}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <code className="rounded bg-zinc-800 px-2 py-0.5 text-xs text-zinc-400 break-all">
+                        {tokenCellText}
                       </code>
-                    </td>
-                    <td className="px-4 py-3 text-zinc-400">
-                      {formatDate(token.created_at)}
-                    </td>
-                    <td className="px-4 py-3 text-zinc-400">
-                      {formatDate(token.last_used_at)}
-                    </td>
-                    <td className="px-4 py-3 text-zinc-400">
-                      {formatExpiry(token.expires_at)}
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-1">
-                        {rawToken && (
-                          <button
-                            type="button"
-                            onClick={() => toggleViewInList(token.id)}
-                            className="rounded p-1.5 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
-                            title={isViewing ? t("hideToken") : t("showToken")}
-                          >
-                            {isViewing ?
-                              <EyeOff size={14} />
-                            : <Eye size={14} />}
-                          </button>
-                        )}
+                      {isViewing && rawToken && (
                         <button
                           type="button"
-                          onClick={() => handleDelete(token)}
-                          className="rounded px-2 py-1 text-xs text-red-400 hover:bg-red-500/10"
+                          onClick={() => handleCopy(rawToken, token.id)}
+                          className="rounded p-1.5 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
+                          title={t("copyToken")}
                         >
-                          {t("delete")}
+                          {copyLabel ?
+                            <span className="text-xs text-green-400">
+                              {copyLabel}
+                            </span>
+                          : <Copy size={14} />}
                         </button>
-                      </div>
-                    </td>
-                  </tr>
-                  {isViewing && rawToken && (
-                    <tr key={`${token.id}-reveal`} className="bg-zinc-800/20">
-                      <td colSpan={6} className="px-4 py-3">
-                        <div className="flex items-center gap-2">
-                          <code className="flex-1 rounded bg-zinc-900 px-3 py-2 font-mono text-xs text-zinc-200 break-all">
-                            {tokenDisplay}
-                          </code>
-                          <button
-                            type="button"
-                            onClick={() => setViewingTokenVisible((v) => !v)}
-                            className="shrink-0 rounded bg-zinc-700 p-2 text-zinc-300 hover:bg-zinc-600"
-                            title={
-                              viewingTokenVisible ?
-                                t("hideToken")
-                              : t("showToken")
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-zinc-400">
+                    {formatDate(token.created_at)}
+                  </td>
+                  <td className="px-4 py-3 text-zinc-400">
+                    {formatDate(token.last_used_at)}
+                  </td>
+                  <td className="px-4 py-3 text-zinc-400">
+                    {formatExpiry(token.expires_at)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-1">
+                      {canReveal && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (isViewing) {
+                              setViewingTokenVisible((v) => !v)
+                            } else {
+                              toggleViewInList(token.id)
                             }
-                          >
-                            {viewingTokenVisible ?
-                              <EyeOff size={14} />
-                            : <Eye size={14} />}
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => handleCopy(rawToken, token.id)}
-                            className="shrink-0 rounded bg-zinc-700 p-2 text-zinc-300 hover:bg-zinc-600"
-                            title={t("copyToken")}
-                          >
-                            {copied === token.id ?
-                              <span className="text-xs text-green-400">✓</span>
-                            : <Copy size={14} />}
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  )}
-                </>
+                          }}
+                          className="rounded p-1.5 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
+                          title={
+                            isViewing && viewingTokenVisible ?
+                              t("hideToken")
+                            : t("showToken")
+                          }
+                        >
+                          {isViewing && viewingTokenVisible ?
+                            <EyeOff size={14} />
+                          : <Eye size={14} />}
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(token)}
+                        className="rounded px-2 py-1 text-xs text-red-400 hover:bg-red-500/10"
+                      >
+                        {t("delete")}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
               )
             })}
           </tbody>
@@ -354,7 +346,6 @@ export function AccessTokensPage({ showToast }: Props) {
 
   return (
     <div className="mx-auto max-w-4xl">
-      {/* Header */}
       <div className="mb-6 flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold text-zinc-100">{t("title")}</h1>
@@ -369,7 +360,6 @@ export function AccessTokensPage({ showToast }: Props) {
         </button>
       </div>
 
-      {/* Create form */}
       {showCreate && (
         <div className="mb-6 rounded-lg border border-zinc-700 bg-zinc-800/50 p-4">
           <h3 className="mb-3 text-sm font-medium text-zinc-200">
@@ -432,10 +422,7 @@ export function AccessTokensPage({ showToast }: Props) {
         </div>
       )}
 
-      {/* Just-created banner */}
       {renderBanner()}
-
-      {/* Token list */}
       {renderTokenList()}
     </div>
   )

--- a/frontend/src/pages/AccessTokensPage.tsx
+++ b/frontend/src/pages/AccessTokensPage.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { Eye, EyeOff } from "lucide-react"
+import { Copy, Eye, EyeOff, X } from "lucide-react"
 import { useState, useEffect, useCallback } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -31,10 +31,22 @@ export function AccessTokensPage({ showToast }: Props) {
   const [showCreate, setShowCreate] = useState(false)
   const [newTokenName, setNewTokenName] = useState("")
   const [newTokenExpiry, setNewTokenExpiry] = useState("")
-  const [createdToken, setCreatedToken] = useState<string | null>(null)
-  const [showCreatedToken, setShowCreatedToken] = useState(false)
-  const [copied, setCopied] = useState(false)
   const [creating, setCreating] = useState(false)
+
+  // Raw tokens kept in memory after creation (id → raw token).
+  // Cleared when the user navigates away or refreshes.
+  const [newlyCreatedTokens, setNewlyCreatedTokens] = useState<
+    Record<string, string>
+  >({})
+  // Which token's inline reveal is currently open in the list.
+  const [viewingTokenId, setViewingTokenId] = useState<string | null>(null)
+  const [viewingTokenVisible, setViewingTokenVisible] = useState(false)
+  const [copied, setCopied] = useState<string | null>(null)
+
+  // The just-created token banner (shown once after creation).
+  const [justCreatedId, setJustCreatedId] = useState<string | null>(null)
+  const [bannerTokenVisible, setBannerTokenVisible] = useState(false)
+  const [bannerCopied, setBannerCopied] = useState(false)
 
   const fetchTokens = useCallback(async () => {
     try {
@@ -62,9 +74,15 @@ export function AccessTokensPage({ showToast }: Props) {
         expiresAt = d.toISOString()
       }
       const res = await createAccessToken(newTokenName.trim(), expiresAt)
-      setCreatedToken(res.token)
-      setShowCreatedToken(false)
+      // Store raw token in memory, show banner.
+      setNewlyCreatedTokens((prev) => ({ ...prev, [res.id]: res.token }))
+      setJustCreatedId(res.id)
+      setBannerTokenVisible(false)
+      setBannerCopied(false)
       showToast(t("tokenCreatedSuccess"), "success")
+      setShowCreate(false)
+      setNewTokenName("")
+      setNewTokenExpiry("")
       fetchTokens()
     } catch {
       showToast("Failed to create token", "error")
@@ -82,6 +100,13 @@ export function AccessTokensPage({ showToast }: Props) {
     if (!ok) return
     try {
       await deleteAccessToken(token.id)
+      setNewlyCreatedTokens((prev) =>
+        Object.fromEntries(
+          Object.entries(prev).filter(([k]) => k !== token.id),
+        ),
+      )
+      if (viewingTokenId === token.id) setViewingTokenId(null)
+      if (justCreatedId === token.id) setJustCreatedId(null)
       showToast(t("tokenDeleted"), "success")
       fetchTokens()
     } catch {
@@ -89,10 +114,31 @@ export function AccessTokensPage({ showToast }: Props) {
     }
   }
 
-  const handleCopy = async (text: string) => {
+  const handleCopy = async (text: string, key: string) => {
     await navigator.clipboard.writeText(text)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    setCopied(key)
+    setTimeout(() => setCopied(null), 2000)
+  }
+
+  const handleBannerCopy = async (text: string) => {
+    await navigator.clipboard.writeText(text)
+    setBannerCopied(true)
+    setTimeout(() => setBannerCopied(false), 2000)
+  }
+
+  const dismissBanner = () => {
+    setJustCreatedId(null)
+    setBannerTokenVisible(false)
+  }
+
+  const toggleViewInList = (id: string) => {
+    if (viewingTokenId === id) {
+      setViewingTokenId(null)
+      setViewingTokenVisible(false)
+    } else {
+      setViewingTokenId(id)
+      setViewingTokenVisible(false)
+    }
   }
 
   const formatDate = (dateStr: string | null) => {
@@ -111,83 +157,77 @@ export function AccessTokensPage({ showToast }: Props) {
     return formatDate(dateStr)
   }
 
-  let createdTokenDisplay = ""
-  if (createdToken) {
-    createdTokenDisplay =
-      showCreatedToken ? createdToken : (
-        "•".repeat(Math.max(createdToken.length, 24))
+  // ── Just-created banner ────────────────────────────────────────────────────
+  const justCreatedRaw =
+    justCreatedId ? (newlyCreatedTokens[justCreatedId] ?? null) : null
+
+  const renderBanner = () => {
+    if (!justCreatedId || !justCreatedRaw) return null
+    const display =
+      bannerTokenVisible ? justCreatedRaw : (
+        "•".repeat(Math.max(justCreatedRaw.length, 24))
       )
-  }
-
-  const tokenVisibilityLabel =
-    showCreatedToken ? t("hideToken") : t("showToken")
-  const tokenVisibilityIcon =
-    showCreatedToken ? <EyeOff size={16} /> : <Eye size={16} />
-
-  // Created token reveal dialog
-  if (createdToken) {
     return (
-      <div className="mx-auto max-w-2xl p-6">
-        <div className="rounded-lg border border-green-500/30 bg-green-500/10 p-6">
-          <h2 className="mb-2 text-lg font-semibold text-green-400">
+      <div className="mb-6 rounded-lg border border-green-500/30 bg-green-500/10 p-4">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-sm font-semibold text-green-400">
             {t("tokenCreated")}
-          </h2>
-          <p className="mb-4 text-sm text-zinc-400">
-            {t("tokenCreatedDescription")}
-          </p>
-          <div className="mb-4 flex items-center gap-2">
-            <code className="flex-1 rounded bg-zinc-800 px-3 py-2 font-mono text-sm text-zinc-200 break-all">
-              {createdTokenDisplay}
-            </code>
-            <button
-              type="button"
-              onClick={() => setShowCreatedToken((value) => !value)}
-              className="shrink-0 rounded bg-zinc-700 px-3 py-2 text-sm text-zinc-200 hover:bg-zinc-600"
-              aria-label={tokenVisibilityLabel}
-              title={tokenVisibilityLabel}
-            >
-              {tokenVisibilityIcon}
-            </button>
-            <button
-              type="button"
-              onClick={() => handleCopy(createdToken)}
-              className="shrink-0 rounded bg-zinc-700 px-3 py-2 text-sm text-zinc-200 hover:bg-zinc-600"
-            >
-              {copied ? t("copied") : t("copyToken")}
-            </button>
-          </div>
+          </span>
           <button
             type="button"
-            onClick={() => {
-              setCreatedToken(null)
-              setShowCreatedToken(false)
-              setShowCreate(false)
-              setNewTokenName("")
-              setNewTokenExpiry("")
-            }}
-            className="rounded bg-zinc-700 px-4 py-2 text-sm text-zinc-200 hover:bg-zinc-600"
+            onClick={dismissBanner}
+            className="rounded p-1 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
+            aria-label="Dismiss"
           >
-            {t("done")}
+            <X size={14} />
+          </button>
+        </div>
+        <p className="mb-3 text-xs text-zinc-400">
+          {t("tokenCreatedDescription")}
+        </p>
+        <div className="flex items-center gap-2">
+          <code className="flex-1 rounded bg-zinc-800 px-3 py-2 font-mono text-xs text-zinc-200 break-all">
+            {display}
+          </code>
+          <button
+            type="button"
+            onClick={() => setBannerTokenVisible((v) => !v)}
+            className="shrink-0 rounded bg-zinc-700 p-2 text-zinc-300 hover:bg-zinc-600"
+            title={bannerTokenVisible ? t("hideToken") : t("showToken")}
+          >
+            {bannerTokenVisible ?
+              <EyeOff size={14} />
+            : <Eye size={14} />}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleBannerCopy(justCreatedRaw)}
+            className="shrink-0 rounded bg-zinc-700 px-3 py-2 text-xs text-zinc-300 hover:bg-zinc-600"
+          >
+            {bannerCopied ? t("copied") : t("copyToken")}
           </button>
         </div>
       </div>
     )
   }
 
-  let tokenListContent: React.ReactNode
-  if (loading) {
-    tokenListContent = (
-      <div className="py-12 text-center text-zinc-500">Loading...</div>
-    )
-  } else if (tokens.length === 0) {
-    tokenListContent = (
-      <div className="rounded-lg border border-zinc-700 bg-zinc-800/30 py-12 text-center">
-        <p className="text-zinc-400">{t("noTokens")}</p>
-        <p className="mt-1 text-sm text-zinc-500">{t("noTokensDescription")}</p>
-      </div>
-    )
-  } else {
-    tokenListContent = (
+  // ── Token list ─────────────────────────────────────────────────────────────
+  const renderTokenList = () => {
+    if (loading) {
+      return <div className="py-12 text-center text-zinc-500">Loading...</div>
+    }
+    if (tokens.length === 0) {
+      return (
+        <div className="rounded-lg border border-zinc-700 bg-zinc-800/30 py-12 text-center">
+          <p className="text-zinc-400">{t("noTokens")}</p>
+          <p className="mt-1 text-sm text-zinc-500">
+            {t("noTokensDescription")}
+          </p>
+        </div>
+      )
+    }
+
+    return (
       <div className="overflow-x-auto rounded-lg border border-zinc-700">
         <table className="w-full text-left text-sm">
           <thead className="border-b border-zinc-700 bg-zinc-800/50">
@@ -213,36 +253,99 @@ export function AccessTokensPage({ showToast }: Props) {
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-700/50">
-            {tokens.map((token) => (
-              <tr key={token.id} className="hover:bg-zinc-800/30">
-                <td className="px-4 py-3 font-medium text-zinc-200">
-                  {token.name}
-                </td>
-                <td className="px-4 py-3">
-                  <code className="rounded bg-zinc-800 px-2 py-0.5 text-xs text-zinc-400">
-                    {token.prefix}...
-                  </code>
-                </td>
-                <td className="px-4 py-3 text-zinc-400">
-                  {formatDate(token.created_at)}
-                </td>
-                <td className="px-4 py-3 text-zinc-400">
-                  {formatDate(token.last_used_at)}
-                </td>
-                <td className="px-4 py-3 text-zinc-400">
-                  {formatExpiry(token.expires_at)}
-                </td>
-                <td className="px-4 py-3">
-                  <button
-                    type="button"
-                    onClick={() => handleDelete(token)}
-                    className="rounded px-2 py-1 text-xs text-red-400 hover:bg-red-500/10"
-                  >
-                    {t("delete")}
-                  </button>
-                </td>
-              </tr>
-            ))}
+            {tokens.map((token) => {
+              const rawToken = newlyCreatedTokens[token.id]
+              const isViewing = viewingTokenId === token.id
+              let tokenDisplay: string | null = null
+              if (isViewing && rawToken) {
+                tokenDisplay =
+                  viewingTokenVisible ? rawToken : (
+                    "•".repeat(Math.max(rawToken.length, 24))
+                  )
+              }
+
+              return (
+                <>
+                  <tr key={token.id} className="hover:bg-zinc-800/30">
+                    <td className="px-4 py-3 font-medium text-zinc-200">
+                      {token.name}
+                    </td>
+                    <td className="px-4 py-3">
+                      <code className="rounded bg-zinc-800 px-2 py-0.5 text-xs text-zinc-400">
+                        {token.prefix}...
+                      </code>
+                    </td>
+                    <td className="px-4 py-3 text-zinc-400">
+                      {formatDate(token.created_at)}
+                    </td>
+                    <td className="px-4 py-3 text-zinc-400">
+                      {formatDate(token.last_used_at)}
+                    </td>
+                    <td className="px-4 py-3 text-zinc-400">
+                      {formatExpiry(token.expires_at)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-1">
+                        {rawToken && (
+                          <button
+                            type="button"
+                            onClick={() => toggleViewInList(token.id)}
+                            className="rounded p-1.5 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
+                            title={isViewing ? t("hideToken") : t("showToken")}
+                          >
+                            {isViewing ?
+                              <EyeOff size={14} />
+                            : <Eye size={14} />}
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(token)}
+                          className="rounded px-2 py-1 text-xs text-red-400 hover:bg-red-500/10"
+                        >
+                          {t("delete")}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                  {isViewing && rawToken && (
+                    <tr key={`${token.id}-reveal`} className="bg-zinc-800/20">
+                      <td colSpan={6} className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <code className="flex-1 rounded bg-zinc-900 px-3 py-2 font-mono text-xs text-zinc-200 break-all">
+                            {tokenDisplay}
+                          </code>
+                          <button
+                            type="button"
+                            onClick={() => setViewingTokenVisible((v) => !v)}
+                            className="shrink-0 rounded bg-zinc-700 p-2 text-zinc-300 hover:bg-zinc-600"
+                            title={
+                              viewingTokenVisible ?
+                                t("hideToken")
+                              : t("showToken")
+                            }
+                          >
+                            {viewingTokenVisible ?
+                              <EyeOff size={14} />
+                            : <Eye size={14} />}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleCopy(rawToken, token.id)}
+                            className="shrink-0 rounded bg-zinc-700 p-2 text-zinc-300 hover:bg-zinc-600"
+                            title={t("copyToken")}
+                          >
+                            {copied === token.id ?
+                              <span className="text-xs text-green-400">✓</span>
+                            : <Copy size={14} />}
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </>
+              )
+            })}
           </tbody>
         </table>
       </div>
@@ -281,6 +384,9 @@ export function AccessTokensPage({ showToast }: Props) {
                 type="text"
                 value={newTokenName}
                 onChange={(e) => setNewTokenName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleCreate()
+                }}
                 placeholder={t("tokenNamePlaceholder")}
                 className="w-full rounded border border-zinc-600 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-500 focus:border-blue-500 focus:outline-none"
               />
@@ -326,8 +432,11 @@ export function AccessTokensPage({ showToast }: Props) {
         </div>
       )}
 
+      {/* Just-created banner */}
+      {renderBanner()}
+
       {/* Token list */}
-      {tokenListContent}
+      {renderTokenList()}
     </div>
   )
 }

--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -341,6 +341,10 @@ var migrations = []migration{
 		`CREATE INDEX IF NOT EXISTS idx_access_tokens_token_hash ON access_tokens (token_hash)`,
 		`CREATE INDEX IF NOT EXISTS idx_access_tokens_enabled ON access_tokens (enabled)`,
 	}},
+	// v10: persist raw token for admin reveal-after-refresh behavior.
+	{10, []string{
+		`ALTER TABLE access_tokens ADD COLUMN token_plaintext TEXT NOT NULL DEFAULT ''`,
+	}},
 }
 
 // applyMigrations runs any migrations that have not yet been applied.

--- a/internal/database/store_access_tokens.go
+++ b/internal/database/store_access_tokens.go
@@ -14,10 +14,10 @@ func NewAccessTokenStore() *AccessTokenStore {
 	return &AccessTokenStore{db: GetDatabase()}
 }
 
-// List returns all access tokens (without the hash).
+// List returns all access tokens.
 func (s *AccessTokenStore) List() ([]AccessTokenRecord, error) {
 	rows, err := s.db.db.Query(`
-		SELECT id, name, token_hash, prefix, created_at, expires_at, last_used_at, enabled
+		SELECT id, name, token_hash, token_plaintext, prefix, created_at, expires_at, last_used_at, enabled
 		FROM access_tokens ORDER BY created_at DESC
 	`)
 	if err != nil {
@@ -37,18 +37,18 @@ func (s *AccessTokenStore) List() ([]AccessTokenRecord, error) {
 }
 
 // Create inserts a new access token record.
-func (s *AccessTokenStore) Create(id, name, tokenHash, prefix string, expiresAt *time.Time) error {
+func (s *AccessTokenStore) Create(id, name, tokenHash, tokenPlaintext, prefix string, expiresAt *time.Time) error {
 	_, err := s.db.db.Exec(`
-		INSERT INTO access_tokens (id, name, token_hash, prefix, expires_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, id, name, tokenHash, prefix, expiresAt)
+		INSERT INTO access_tokens (id, name, token_hash, token_plaintext, prefix, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, id, name, tokenHash, tokenPlaintext, prefix, expiresAt)
 	return err
 }
 
 // Get retrieves a single access token by ID.
 func (s *AccessTokenStore) Get(id string) (*AccessTokenRecord, error) {
 	row := s.db.db.QueryRow(`
-		SELECT id, name, token_hash, prefix, created_at, expires_at, last_used_at, enabled
+		SELECT id, name, token_hash, token_plaintext, prefix, created_at, expires_at, last_used_at, enabled
 		FROM access_tokens WHERE id = ?
 	`, id)
 
@@ -57,7 +57,7 @@ func (s *AccessTokenStore) Get(id string) (*AccessTokenRecord, error) {
 	var expiresAtStr, lastUsedAtStr sql.NullString
 	var enabled int
 
-	err := row.Scan(&rec.ID, &rec.Name, &rec.TokenHash, &prefixStr,
+	err := row.Scan(&rec.ID, &rec.Name, &rec.TokenHash, &rec.TokenPlaintext, &prefixStr,
 		&createdAtStr, &expiresAtStr, &lastUsedAtStr, &enabled)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -90,7 +90,7 @@ func (s *AccessTokenStore) Delete(id string) error {
 // Returns nil if not found, disabled, or expired.
 func (s *AccessTokenStore) ValidateByHash(tokenHash string) (*AccessTokenRecord, error) {
 	row := s.db.db.QueryRow(`
-		SELECT id, name, token_hash, prefix, created_at, expires_at, last_used_at, enabled
+		SELECT id, name, token_hash, token_plaintext, prefix, created_at, expires_at, last_used_at, enabled
 		FROM access_tokens WHERE token_hash = ? AND enabled = 1
 	`, tokenHash)
 
@@ -99,7 +99,7 @@ func (s *AccessTokenStore) ValidateByHash(tokenHash string) (*AccessTokenRecord,
 	var expiresAtStr, lastUsedAtStr sql.NullString
 	var enabled int
 
-	err := row.Scan(&rec.ID, &rec.Name, &rec.TokenHash, &prefixStr,
+	err := row.Scan(&rec.ID, &rec.Name, &rec.TokenHash, &rec.TokenPlaintext, &prefixStr,
 		&createdAtStr, &expiresAtStr, &lastUsedAtStr, &enabled)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -114,7 +114,7 @@ func (s *AccessTokenStore) ValidateByHash(tokenHash string) (*AccessTokenRecord,
 	if expiresAtStr.Valid {
 		t := parseTime(expiresAtStr.String)
 		if t.Before(time.Now()) {
-			return nil, nil // expired
+			return nil, nil
 		}
 		rec.ExpiresAt = &t
 	}
@@ -123,7 +123,6 @@ func (s *AccessTokenStore) ValidateByHash(tokenHash string) (*AccessTokenRecord,
 		rec.LastUsedAt = &t
 	}
 
-	// Update last_used_at asynchronously
 	go func() {
 		_, _ = s.db.db.Exec(`UPDATE access_tokens SET last_used_at = datetime('now') WHERE id = ?`, rec.ID)
 	}()
@@ -138,7 +137,7 @@ func scanAccessToken(rows *sql.Rows) (AccessTokenRecord, error) {
 	var expiresAtStr, lastUsedAtStr sql.NullString
 	var enabled int
 
-	err := rows.Scan(&rec.ID, &rec.Name, &rec.TokenHash, &prefixStr,
+	err := rows.Scan(&rec.ID, &rec.Name, &rec.TokenHash, &rec.TokenPlaintext, &prefixStr,
 		&createdAtStr, &expiresAtStr, &lastUsedAtStr, &enabled)
 	if err != nil {
 		return rec, err

--- a/internal/database/types.go
+++ b/internal/database/types.go
@@ -132,14 +132,15 @@ type VirtualModelUpstreamRecord struct {
 
 // AccessTokenRecord holds a generated access token for authenticating with the proxy.
 type AccessTokenRecord struct {
-	ID         string     `json:"id"`
-	Name       string     `json:"name"`
-	TokenHash  string     `json:"-"`               // SHA-256 hash, never exposed via JSON
-	Prefix     string     `json:"prefix"`           // first 8 chars for display
-	CreatedAt  time.Time  `json:"created_at"`
-	ExpiresAt  *time.Time `json:"expires_at"`       // nil means no expiry
-	LastUsedAt *time.Time `json:"last_used_at"`
-	Enabled    bool       `json:"enabled"`
+	ID             string     `json:"id"`
+	Name           string     `json:"name"`
+	TokenHash      string     `json:"-"`               // SHA-256 hash, never exposed via JSON
+	TokenPlaintext string     `json:"token_plaintext,omitempty"`
+	Prefix         string     `json:"prefix"`           // first 8 chars for display
+	CreatedAt      time.Time  `json:"created_at"`
+	ExpiresAt      *time.Time `json:"expires_at"`       // nil means no expiry
+	LastUsedAt     *time.Time `json:"last_used_at"`
+	Enabled        bool       `json:"enabled"`
 }
 
 // MeteringRecord holds per-request usage data recorded after each API call.

--- a/internal/routes/admin_access_tokens.go
+++ b/internal/routes/admin_access_tokens.go
@@ -72,7 +72,7 @@ func handleCreateAccessToken(c *gin.Context) {
 	}
 
 	store := database.NewAccessTokenStore()
-	if err := store.Create(id, req.Name, tokenHash, prefix, expiresAt); err != nil {
+	if err := store.Create(id, req.Name, tokenHash, rawToken, prefix, expiresAt); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}


### PR DESCRIPTION
## Summary
- Store the raw access token in the database alongside the existing hash so the admin UI can show it again after a page refresh.
- Return `token_plaintext` in the admin list API so the eye button and reveal persist across page reloads.
- Replace the separate reveal-row pattern with inline reveal inside the existing token/prefix cell.

## Changes
- **Migration v10**: adds `token_plaintext TEXT` column to `access_tokens`
- **Store**: `Create()` now accepts and persists the raw token; all queries include the new column
- **Types**: `AccessTokenRecord.TokenPlaintext` with `json:"token_plaintext,omitempty"`
- **API**: `AccessToken` interface extended with `token_plaintext?: string`
- **UI**: token cell swaps between masked text and full token in-place; copy button appears inline when revealed

## Test plan
- [ ] Create a token → refresh → eye icon still present
- [ ] Click eye → token revealed inline in the same cell (not a separate row)
- [ ] Toggle eye → token hidden again
- [ ] Delete → token removed from list and memory
- [ ] Auth still works using the hash path (unchanged)