### PR TITLE
feat: add dedicated ModelScope provider

### DIFF
--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -460,6 +460,52 @@ function AlibabaAuthForm({
   )
 }
 
+function ModelScopeAuthForm({
+  onSubmit,
+  onCancel,
+}: {
+  onSubmit: (body: Record<string, string>) => Promise<void>
+  onCancel: () => void
+}) {
+  const [apiKey, setApiKey] = useState("")
+  const submit = async () => {
+    if (!apiKey.trim()) return
+    await onSubmit({
+      method: "api-key",
+      apiKey: apiKey.trim(),
+    })
+  }
+  return (
+    <AuthFormWrapper title="Authenticate ModelScope">
+      <div
+        style={{
+          fontSize: 12,
+          color: "var(--color-text-tertiary)",
+          marginBottom: 12,
+        }}
+      >
+        Only API key authentication is supported for ModelScope.
+      </div>
+      <FormRow label="ModelScope API Key">
+        <SecretInput
+          className="sys-input"
+          placeholder="sk-…"
+          value={apiKey}
+          onChange={setApiKey}
+        />
+      </FormRow>
+      <div style={{ display: "flex", gap: 8 }}>
+        <button className="btn btn-primary btn-sm" onClick={submit}>
+          Submit
+        </button>
+        <button className="btn btn-ghost btn-sm" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </AuthFormWrapper>
+  )
+}
+
 function CopilotAuthForm({
   onSubmit,
   onCancel,
@@ -2998,6 +3044,12 @@ function ProviderCard({
               onCancel={() => setShowAuthForm(false)}
             />
           )}
+          {provider.type === "alibaba-modelscope" && (
+            <ModelScopeAuthForm
+              onSubmit={handleAuthSubmit}
+              onCancel={() => setShowAuthForm(false)}
+            />
+          )}
           {provider.type === "github-copilot" && (
             <CopilotAuthForm
               onSubmit={handleAuthSubmit}
@@ -3350,6 +3402,9 @@ function AddProviderFlow({
           {selectedType === "alibaba" && (
             <AddFlowAlibabaForm {...authFormProps} />
           )}
+          {selectedType === "alibaba-modelscope" && (
+            <AddFlowModelScopeForm {...authFormProps} />
+          )}
           {selectedType === "github-copilot" && (
             <AddFlowCopilotForm {...authFormProps} />
           )}
@@ -3586,6 +3641,74 @@ function AddFlowAlibabaForm({
       <AddFlowHint>
         Standard is the right default for `qwen3.6-plus`. Use Coding Plan only
         when you have a dedicated Coding Plan key and base URL.
+      </AddFlowHint>
+      <div style={{ display: "flex", gap: 8, paddingTop: 4 }}>
+        <button
+          className="btn btn-primary btn-sm"
+          onClick={submit}
+          disabled={submitting}
+        >
+          {submitting ?
+            <>
+              <Spin size={13} /> Connecting…
+            </>
+          : "Add Provider"}
+        </button>
+        <button
+          className="btn btn-ghost btn-sm"
+          onClick={onCancel}
+          disabled={submitting}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function AddFlowModelScopeForm({
+  onSubmit,
+  onCancel,
+  submitting,
+}: AddFlowFormProps) {
+  const [endpoint, setEndpoint] = useState("")
+  const [apiKey, setApiKey] = useState("")
+  const submit = async () => {
+    if (!apiKey.trim()) return
+    const body: Record<string, string> = {
+      method: "api-key",
+      apiKey: apiKey.trim(),
+    }
+    if (endpoint.trim()) {
+      body.endpoint = endpoint.trim()
+    }
+    await onSubmit(body)
+  }
+  return (
+    <div style={addFlowPanelStyle}>
+      <AddFlowHint>
+        Only API key authentication is supported for ModelScope.
+      </AddFlowHint>
+      <FormRow label="Base URL (optional)">
+        <input
+          type="text"
+          placeholder="https://api-inference.modelscope.cn/v1"
+          value={endpoint}
+          onChange={(e) => setEndpoint(e.target.value)}
+          style={addFlowTextInputStyle}
+        />
+      </FormRow>
+      <FormRow label="ModelScope API Key">
+        <SecretInput
+          placeholder="sk-…"
+          value={apiKey}
+          onChange={setApiKey}
+          style={addFlowTextInputStyle}
+        />
+      </FormRow>
+      <AddFlowHint>
+        ModelScope provides access to community models like DeepSeek, Qwen, and
+        more. Get your API key from modelscope.cn.
       </AddFlowHint>
       <div style={{ display: "flex", gap: 8, paddingTop: 4 }}>
         <button
@@ -4272,6 +4395,11 @@ const PROVIDER_TYPES = [
     id: "alibaba",
     name: "Alibaba DashScope",
     desc: "Qwen models via API key",
+  },
+  {
+    id: "alibaba-modelscope",
+    name: "Alibaba ModelScope",
+    desc: "ModelScope models (DeepSeek, Qwen, etc.) via API key",
   },
   {
     id: "azure-openai",

--- a/frontend/src/pages/providers/constants/providerRegistry.tsx
+++ b/frontend/src/pages/providers/constants/providerRegistry.tsx
@@ -4,6 +4,7 @@ export const PROVIDER_ACCENT: Record<string, string> = {
   "github-copilot": "#0a84ff",
   antigravity: "#30d158",
   alibaba: "#ff9f0a",
+  "alibaba-modelscope": "#ff6f0a",
   "azure-openai": "#0078d4",
   google: "#4285f4",
   kimi: "#e040fb",
@@ -34,6 +35,12 @@ export const PROVIDER_ICONS: Record<string, ReactNode> = {
   alibaba: (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
       <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
+    </svg>
+  ),
+  "alibaba-modelscope": (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
+      <circle cx="12" cy="12" r="2" />
     </svg>
   ),
   "azure-openai": (
@@ -92,6 +99,7 @@ export const TYPE_NAMES: Record<string, string> = {
   "github-copilot": "GitHub Copilot",
   antigravity: "Antigravity (Google)",
   alibaba: "Alibaba DashScope",
+  "alibaba-modelscope": "Alibaba ModelScope",
   "azure-openai": "Azure OpenAI",
   google: "Google Gemini",
   kimi: "Kimi (Moonshot)",
@@ -102,6 +110,7 @@ export const PROVIDER_TYPES = [
   "github-copilot",
   "antigravity",
   "alibaba",
+  "alibaba-modelscope",
   "azure-openai",
   "google",
   "kimi",

--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -345,6 +345,18 @@ var migrations = []migration{
 	{10, []string{
 		`ALTER TABLE access_tokens ADD COLUMN token_plaintext TEXT NOT NULL DEFAULT ''`,
 	}},
+	// v11: migrate existing Alibaba instances backed by ModelScope endpoints
+	// to the new "alibaba-modelscope" provider type.  Only rows whose
+	// provider_configs.config_data contains "modelscope.cn" are affected;
+	// DashScope instances remain unchanged.
+	{11, []string{
+		`UPDATE provider_instances SET provider_id = 'alibaba-modelscope'
+		 WHERE provider_id = 'alibaba'
+		 AND instance_id IN (
+		     SELECT pc.instance_id FROM provider_configs pc
+		     WHERE pc.config_data LIKE '%modelscope.cn%'
+		 )`,
+	}},
 }
 
 // applyMigrations runs any migrations that have not yet been applied.

--- a/internal/providers/modelscope/adapter.go
+++ b/internal/providers/modelscope/adapter.go
@@ -1,0 +1,63 @@
+package modelscope
+
+import (
+	"context"
+	"fmt"
+	"omnillm/internal/cif"
+	"omnillm/internal/providers/openaicompat"
+	"omnillm/internal/providers/shared"
+	"omnillm/internal/providers/types"
+)
+
+// Adapter implements types.ProviderAdapter for ModelScope.
+// Unlike the DashScope adapter, it does NOT inject enable_thinking into requests.
+type Adapter struct {
+	provider *Provider
+}
+
+func (a *Adapter) GetProvider() types.Provider { return a.provider }
+
+func (a *Adapter) RemapModel(model string) string { return model }
+
+func (a *Adapter) Execute(ctx context.Context, request *cif.CanonicalRequest) (*cif.CanonicalResponse, error) {
+	a.provider.ensureConfig()
+	cr, err := a.buildRequest(request, false)
+	if err != nil {
+		return nil, err
+	}
+	return openaicompat.Execute(ctx, chatURL(a.provider.baseURL), headers(a.provider.token), cr)
+}
+
+func (a *Adapter) ExecuteStream(ctx context.Context, request *cif.CanonicalRequest) (<-chan cif.CIFStreamEvent, error) {
+	a.provider.ensureConfig()
+	// ModelScope streaming can be unreliable for OmniLLM's bridged request shapes.
+	// Execute upstream non-streaming and let the route layer re-stream the
+	// completed CIF response to the client.
+	response, err := a.Execute(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	return shared.StreamResponse(response), nil
+}
+
+// buildRequest converts a CIF request into an openaicompat.ChatRequest.
+// Critically, this does NOT inject enable_thinking — ModelScope models do not
+// support it and return empty responses when it is present with tools.
+func (a *Adapter) buildRequest(request *cif.CanonicalRequest, stream bool) (*openaicompat.ChatRequest, error) {
+	model := a.RemapModel(request.Model)
+
+	if model == "" {
+		return nil, fmt.Errorf("modelscope: model is required")
+	}
+
+	defTemp := 0.55
+	defTopP := 1.0
+
+	cfg := openaicompat.Config{
+		DefaultTemperature:   &defTemp,
+		DefaultTopP:          &defTopP,
+		IncludeUsageInStream: stream,
+		// No Extras — no enable_thinking, no DashScope-specific parameters.
+	}
+	return openaicompat.BuildChatRequest(model, request, stream, cfg)
+}

--- a/internal/providers/modelscope/provider.go
+++ b/internal/providers/modelscope/provider.go
@@ -1,0 +1,295 @@
+// Package modelscope implements types.Provider for Alibaba ModelScope
+// (api-inference.modelscope.cn).  Unlike the DashScope provider, the adapter
+// does NOT inject enable_thinking — ModelScope's hosted models do not support
+// the parameter and return empty responses when it is present.
+package modelscope
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"omnillm/internal/database"
+	"omnillm/internal/providers/shared"
+	"omnillm/internal/providers/types"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+const UserAgent = "OmniLLM/1.0"
+
+// Default ModelScope inference endpoint.
+const BaseURL = "https://api-inference.modelscope.cn/v1"
+
+var httpClient = &http.Client{Timeout: 120 * time.Second}
+
+// TokenData is the persisted credential record for a ModelScope instance.
+type TokenData struct {
+	AuthType    string `json:"auth_type"`          // always "api-key"
+	AccessToken string `json:"access_token"`       // the ModelScope API key
+	BaseURL     string `json:"base_url,omitempty"` // optional explicit base URL
+}
+
+// Provider implements types.Provider for Alibaba ModelScope.
+type Provider struct {
+	instanceID string
+	name       string
+	token      string
+	baseURL    string
+	config     map[string]interface{}
+	configOnce sync.Once
+}
+
+// NewProvider creates a new ModelScope Provider.
+func NewProvider(instanceID, name string) *Provider {
+	return &Provider{
+		instanceID: instanceID,
+		name:       name,
+		baseURL:    BaseURL,
+	}
+}
+
+// ─── Identity ────────────────────────────────────────────────────────────────
+
+func (p *Provider) GetID() string         { return "alibaba-modelscope" }
+func (p *Provider) GetInstanceID() string { return p.instanceID }
+func (p *Provider) GetName() string       { return p.name }
+func (p *Provider) SetName(name string)   { p.name = name }
+
+// ─── Authentication ──────────────────────────────────────────────────────────
+
+func (p *Provider) SetupAuth(options *types.AuthOptions) error {
+	if options.APIKey == "" {
+		return fmt.Errorf("modelscope: API key is required")
+	}
+
+	p.token = options.APIKey
+
+	endpoint := strings.TrimSpace(options.Endpoint)
+	if endpoint != "" {
+		p.baseURL = ensureBaseURL(endpoint)
+	}
+
+	p.name = displayName(p.baseURL)
+
+	// Persist token.
+	tokenStore := database.NewTokenStore()
+	tokenData := map[string]interface{}{"access_token": options.APIKey}
+	if err := tokenStore.Save(p.instanceID, tokenData); err != nil {
+		return fmt.Errorf("modelscope: failed to save token: %w", err)
+	}
+
+	// Persist config.
+	cfg := map[string]interface{}{
+		"auth_type": "api-key",
+		"base_url":  p.baseURL,
+	}
+	p.config = cfg
+
+	configStore := database.NewProviderConfigStore()
+	if err := configStore.Save(p.instanceID, cfg); err != nil {
+		return fmt.Errorf("modelscope: failed to save config: %w", err)
+	}
+
+	log.Info().Str("provider", p.instanceID).Str("base_url", p.baseURL).
+		Msg("ModelScope authenticated via API key")
+
+	return nil
+}
+
+func (p *Provider) GetToken() string    { return p.token }
+func (p *Provider) RefreshToken() error { return nil }
+
+// ─── API Configuration ───────────────────────────────────────────────────────
+
+func (p *Provider) GetBaseURL() string {
+	p.ensureConfig()
+	return p.baseURL
+}
+
+func (p *Provider) GetHeaders(forVision bool) map[string]string {
+	p.ensureConfig()
+	return headers(p.token)
+}
+
+// ─── Models ──────────────────────────────────────────────────────────────────
+
+func (p *Provider) GetModels() (*types.ModelsResponse, error) {
+	p.ensureConfig()
+	return fetchModels(p.instanceID, p.token, p.baseURL)
+}
+
+// ─── Legacy stubs ────────────────────────────────────────────────────────────
+
+func (p *Provider) CreateChatCompletions(payload map[string]interface{}) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("modelscope: use the adapter for chat completions")
+}
+
+func (p *Provider) CreateEmbeddings(payload map[string]interface{}) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("modelscope: embeddings not implemented")
+}
+
+func (p *Provider) GetUsage() (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
+}
+
+// ─── Adapter ─────────────────────────────────────────────────────────────────
+
+func (p *Provider) GetAdapter() types.ProviderAdapter {
+	return &Adapter{provider: p}
+}
+
+// ─── Database loading ────────────────────────────────────────────────────────
+
+func (p *Provider) LoadFromDB() error {
+	// Load token.
+	tokenStore := database.NewTokenStore()
+	record, err := tokenStore.Get(p.instanceID)
+	if err != nil {
+		return fmt.Errorf("modelscope: failed to load token: %w", err)
+	}
+	if record != nil {
+		var td TokenData
+		if err := json.Unmarshal([]byte(record.TokenData), &td); err == nil {
+			if td.AccessToken != "" {
+				p.token = td.AccessToken
+			}
+		}
+	}
+
+	// Load config.
+	configStore := database.NewProviderConfigStore()
+	cfgRecord, err := configStore.Get(p.instanceID)
+	if err != nil {
+		log.Warn().Err(err).Str("provider", p.instanceID).Msg("modelscope: failed to load provider config")
+	} else if cfgRecord != nil {
+		var cfg map[string]interface{}
+		if jsonErr := json.Unmarshal([]byte(cfgRecord.ConfigData), &cfg); jsonErr != nil {
+			log.Warn().Err(jsonErr).Str("provider", p.instanceID).Msg("modelscope: failed to parse provider config")
+		} else {
+			p.config = cfg
+			if baseURL, ok := shared.FirstString(cfg, "base_url", "baseUrl"); ok && baseURL != "" {
+				p.baseURL = ensureBaseURL(baseURL)
+			}
+			// Migrate legacy access_token from config if token table was empty.
+			if p.token == "" {
+				if at, ok := shared.FirstString(cfg, "access_token"); ok && at != "" {
+					p.token = at
+				}
+			}
+		}
+	}
+
+	if p.name == "" {
+		p.name = displayName(p.baseURL)
+	}
+
+	// Mark configOnce as done so ensureConfig is a no-op.
+	p.configOnce.Do(func() {})
+	log.Debug().Str("provider", p.instanceID).Bool("has_token", p.token != "").Str("base_url", p.baseURL).Msg("ModelScope: loaded from DB")
+	return nil
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+func (p *Provider) ensureConfig() {
+	p.configOnce.Do(func() {
+		store := database.NewProviderConfigStore()
+		rec, err := store.Get(p.instanceID)
+		if err != nil || rec == nil {
+			return
+		}
+		var cfg map[string]interface{}
+		if err := json.Unmarshal([]byte(rec.ConfigData), &cfg); err != nil {
+			log.Warn().Err(err).Str("provider", p.instanceID).Msg("modelscope: failed to parse config")
+			return
+		}
+		p.config = cfg
+		if baseURL, ok := shared.FirstString(cfg, "base_url", "baseUrl"); ok && baseURL != "" {
+			p.baseURL = ensureBaseURL(baseURL)
+		}
+	})
+}
+
+func headers(token string) map[string]string {
+	return map[string]string{
+		"Authorization": "Bearer " + token,
+		"Content-Type":  "application/json",
+		"Accept":        "application/json",
+	}
+}
+
+func chatURL(baseURL string) string {
+	if baseURL == "" {
+		baseURL = BaseURL
+	}
+	return strings.TrimRight(baseURL, "/") + "/chat/completions"
+}
+
+func ensureBaseURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return BaseURL
+	}
+	if !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+		s = "https://" + s
+	}
+	s = strings.TrimRight(s, "/")
+	if !strings.HasSuffix(s, "/v1") {
+		s += "/v1"
+	}
+	return s
+}
+
+func displayName(baseURL string) string {
+	return "ModelScope"
+}
+
+func fetchModels(instanceID, token, baseURL string) (*types.ModelsResponse, error) {
+	if token == "" {
+		return nil, fmt.Errorf("modelscope: not authenticated")
+	}
+
+	url := strings.TrimRight(baseURL, "/") + "/models"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("modelscope: failed to create models request: %w", err)
+	}
+	for k, v := range headers(token) {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("modelscope: models request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("modelscope: models fetch failed (%d)", resp.StatusCode)
+	}
+
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("modelscope: failed to decode models response: %w", err)
+	}
+
+	models := make([]types.Model, 0, len(payload.Data))
+	for _, item := range payload.Data {
+		if item.ID == "" {
+			continue
+		}
+		models = append(models, types.Model{
+			ID:       item.ID,
+			Name:     item.ID,
+			Provider: instanceID,
+		})
+	}
+	return &types.ModelsResponse{Data: models, Object: "list"}, nil
+}

--- a/internal/providers/modelscope/provider_test.go
+++ b/internal/providers/modelscope/provider_test.go
@@ -1,0 +1,133 @@
+package modelscope
+
+import (
+	"omnillm/internal/cif"
+	"testing"
+)
+
+func TestGetID(t *testing.T) {
+	p := NewProvider("ms-test-1", "Test")
+	if got := p.GetID(); got != "alibaba-modelscope" {
+		t.Errorf("GetID() = %q, want %q", got, "alibaba-modelscope")
+	}
+}
+
+func TestGetInstanceID(t *testing.T) {
+	p := NewProvider("ms-test-1", "Test")
+	if got := p.GetInstanceID(); got != "ms-test-1" {
+		t.Errorf("GetInstanceID() = %q, want %q", got, "ms-test-1")
+	}
+}
+
+func TestDefaultBaseURL(t *testing.T) {
+	p := NewProvider("ms-test-1", "Test")
+	if got := p.baseURL; got != BaseURL {
+		t.Errorf("default baseURL = %q, want %q", got, BaseURL)
+	}
+}
+
+func TestEnsureBaseURL(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{"", BaseURL},
+		{"https://api-inference.modelscope.cn/v1", "https://api-inference.modelscope.cn/v1"},
+		{"https://api-inference.modelscope.cn/v1/", "https://api-inference.modelscope.cn/v1"},
+		{"api-inference.modelscope.cn", "https://api-inference.modelscope.cn/v1"},
+		{"http://localhost:8080", "http://localhost:8080/v1"},
+	}
+	for _, tc := range tests {
+		got := ensureBaseURL(tc.raw)
+		if got != tc.want {
+			t.Errorf("ensureBaseURL(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestChatURL(t *testing.T) {
+	got := chatURL(BaseURL)
+	want := "https://api-inference.modelscope.cn/v1/chat/completions"
+	if got != want {
+		t.Errorf("chatURL(%q) = %q, want %q", BaseURL, got, want)
+	}
+}
+
+func TestBuildRequest_NoEnableThinking(t *testing.T) {
+	p := NewProvider("ms-test-1", "Test")
+	a := &Adapter{provider: p}
+
+	// Build a request with no tools (the case where DashScope injects enable_thinking).
+	request := &cif.CanonicalRequest{
+		Model: "deepseek-ai/DeepSeek-V4-Flash",
+		Messages: []cif.CIFMessage{
+			cif.CIFUserMessage{
+				Role:    "user",
+				Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "hello"}},
+			},
+		},
+	}
+
+	cr, err := a.buildRequest(request, false)
+	if err != nil {
+		t.Fatalf("buildRequest() error: %v", err)
+	}
+
+	if cr.Extras != nil {
+		if _, ok := cr.Extras["enable_thinking"]; ok {
+			t.Fatal("buildRequest() should NOT set enable_thinking for ModelScope")
+		}
+	}
+}
+
+func TestBuildRequest_NoEnableThinkingWithTools(t *testing.T) {
+	p := NewProvider("ms-test-1", "Test")
+	a := &Adapter{provider: p}
+
+	desc := "Echo input"
+	request := &cif.CanonicalRequest{
+		Model: "deepseek-ai/DeepSeek-V4-Flash",
+		Messages: []cif.CIFMessage{
+			cif.CIFUserMessage{
+				Role:    "user",
+				Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "call echo"}},
+			},
+		},
+		Tools: []cif.CIFTool{
+			{
+				Name:             "echo",
+				Description:      &desc,
+				ParametersSchema: map[string]interface{}{"type": "object", "properties": map[string]interface{}{"text": map[string]interface{}{"type": "string"}}},
+			},
+		},
+	}
+
+	cr, err := a.buildRequest(request, false)
+	if err != nil {
+		t.Fatalf("buildRequest() error: %v", err)
+	}
+
+	if cr.Extras != nil {
+		if _, ok := cr.Extras["enable_thinking"]; ok {
+			t.Fatal("buildRequest() should NOT set enable_thinking for ModelScope even with tools")
+		}
+	}
+
+	if len(cr.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(cr.Tools))
+	}
+}
+
+func TestRemapModel_PassThrough(t *testing.T) {
+	a := &Adapter{provider: NewProvider("ms-test-1", "Test")}
+	tests := []string{
+		"deepseek-ai/DeepSeek-V4-Flash",
+		"Qwen/Qwen3-32B",
+		"ZhipuAI/GLM-5.1",
+	}
+	for _, model := range tests {
+		if got := a.RemapModel(model); got != model {
+			t.Errorf("RemapModel(%q) = %q, want pass-through", model, got)
+		}
+	}
+}

--- a/internal/providers/providermodels/providermodels.go
+++ b/internal/providers/providermodels/providermodels.go
@@ -46,6 +46,9 @@ var table = map[string]APIShape{
 	// DashScope speaks the OpenAI-compatible chat completions protocol.
 	"alibaba": ChatCompletions,
 
+	// ModelScope speaks the OpenAI-compatible chat completions protocol.
+	"alibaba-modelscope": ChatCompletions,
+
 	"kimi": ChatCompletions,
 
 	// Generic user-configured endpoints default to chat completions.

--- a/internal/providers/providermodels/providermodels_test.go
+++ b/internal/providers/providermodels/providermodels_test.go
@@ -30,6 +30,10 @@ func TestUpstreamAPI(t *testing.T) {
 		{"alibaba", "deepseek-v4-flash", providermodels.ChatCompletions},
 		{"alibaba", "qwq-32b", providermodels.ChatCompletions},
 
+		// ModelScope — always chat completions
+		{"alibaba-modelscope", "deepseek-ai/DeepSeek-V4-Flash", providermodels.ChatCompletions},
+		{"alibaba-modelscope", "Qwen/Qwen3-32B", providermodels.ChatCompletions},
+
 		// Kimi — always chat completions
 		{"kimi", "moonshot-v1-8k", providermodels.ChatCompletions},
 

--- a/internal/providers/types/types.go
+++ b/internal/providers/types/types.go
@@ -18,6 +18,7 @@ const (
 	ProviderGoogle           ProviderID = "google"
 	ProviderKimi             ProviderID = "kimi"
 	ProviderOpenAICompatible ProviderID = "openai-compatible"
+	ProviderModelScope      ProviderID = "alibaba-modelscope"
 )
 
 // AuthOptions is decoded from JSON request bodies.  Fields accept both

--- a/internal/routes/admin_providers.go
+++ b/internal/routes/admin_providers.go
@@ -14,6 +14,7 @@ import (
 	azurepkg "omnillm/internal/providers/azure"
 	codexpkg "omnillm/internal/providers/codex"
 	copilot "omnillm/internal/providers/copilot"
+	modelscopepkg "omnillm/internal/providers/modelscope"
 	openaicompatprovider "omnillm/internal/providers/openaicompatprovider"
 	generic "omnillm/internal/providers/generic"
 	"omnillm/internal/database"
@@ -124,7 +125,7 @@ func handleAddProviderInstance(c *gin.Context) {
 	switch providerType {
 	case "github-copilot":
 		provider = copilot.NewGitHubCopilotProvider(instanceID, "")
-	case "antigravity", "alibaba", "azure-openai", "google", "kimi":
+	case "antigravity", "alibaba", "alibaba-modelscope", "azure-openai", "google", "kimi":
 		provider = generic.NewGenericProvider(providerType, instanceID, "")
 	case "openai-compatible":
 		provider = openaicompatprovider.NewProvider(instanceID, "")
@@ -220,6 +221,50 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 		canonicalID := "alibaba-" + planSlug + "-" + region + "-" + suffix
 
 		prov := alibabapkg.NewProvider(canonicalID, "")
+		if err := prov.SetupAuth(&req); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"success": false,
+				"message": fmt.Sprintf("Authentication failed: %v", err),
+			})
+			return
+		}
+
+		if err := providerRegistry.Register(prov, true); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"success": false,
+				"message": fmt.Sprintf("Failed to register provider: %v", err),
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"success": true,
+			"provider": gin.H{
+				"id":         prov.GetInstanceID(),
+				"type":       prov.GetID(),
+				"name":       prov.GetName(),
+				"isActive":   false,
+				"authStatus": "authenticated",
+			},
+		})
+
+	// ——————————————————————————————————————————————————————————————
+	case "alibaba-modelscope":
+		if req.APIKey == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"success": false,
+				"message": "API key is required for ModelScope authentication",
+			})
+			return
+		}
+
+		suffix := req.APIKey
+		if len(suffix) > 6 {
+			suffix = suffix[len(suffix)-6:]
+		}
+		canonicalID := "modelscope-" + suffix
+
+		prov := modelscopepkg.NewProvider(canonicalID, "")
 		if err := prov.SetupAuth(&req); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"success": false,
@@ -811,6 +856,35 @@ func handleProviderAuth(c *gin.Context) {
 				"id":         aliProv.GetInstanceID(),
 				"type":       aliProv.GetID(),
 				"name":       aliProv.GetName(),
+				"authStatus": "authenticated",
+			},
+		})
+		return
+	}
+
+	// ModelScope: API-key only.
+	if msProv, ok := provider.(*modelscopepkg.Provider); ok {
+		if req.APIKey == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"success": false,
+				"message": "API key is required for ModelScope authentication",
+			})
+			return
+		}
+		if err := msProv.SetupAuth(&req); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false, "message": fmt.Sprintf("Authentication failed: %v", err)})
+			return
+		}
+		if err := providerRegistry.Register(msProv, true); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false, "message": fmt.Sprintf("Failed to update provider: %v", err)})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"success": true,
+			"provider": gin.H{
+				"id":         msProv.GetInstanceID(),
+				"type":       msProv.GetID(),
+				"name":       msProv.GetName(),
 				"authStatus": "authenticated",
 			},
 		})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,8 @@ import (
 
 	alibabapkg "omnillm/internal/providers/alibaba"
 
+	modelscopepkg "omnillm/internal/providers/modelscope"
+
 	openaicompatprovider "omnillm/internal/providers/openaicompatprovider"
 )
 
@@ -288,6 +290,12 @@ func registerDefaultProviders(reg *registry.ProviderRegistry, options StartOptio
 				provider = p
 			case "alibaba":
 				p := alibabapkg.NewProvider(inst.InstanceID, inst.Name)
+				if err := p.LoadFromDB(); err != nil {
+					log.Warn().Err(err).Str("instance", inst.InstanceID).Msg("Failed to load provider token")
+				}
+				provider = p
+			case "alibaba-modelscope":
+				p := modelscopepkg.NewProvider(inst.InstanceID, inst.Name)
 				if err := p.LoadFromDB(); err != nil {
 					log.Warn().Err(err).Str("instance", inst.InstanceID).Msg("Failed to load provider token")
 				}


### PR DESCRIPTION
## Summary

Adds a dedicated `alibaba-modelscope` provider type for ModelScope inference endpoints (`api-inference.modelscope.cn`), split from the existing `alibaba` DashScope provider.

## Problem

ModelScope endpoints configured under the `alibaba` provider break tool-use because:
- The Alibaba adapter injects `enable_thinking: true` for reasoning models — ModelScope doesn'"'"'t support this
- ModelScope uses org/repo model IDs (`deepseek-ai/DeepSeek-V4-Flash`) vs DashScope'"'"'s flat IDs
- Existing entries had no way to distinguish which upstream they targeted

## Changes

### Backend
- **New package**: `internal/providers/modelscope/` — dedicated `Provider` and `Adapter` that do **not** inject `enable_thinking`
- **Dispatch points**: Added `alibaba-modelscope` to `types.go`, `server.go`, `admin_providers.go`, `providermodels.go`
- **Migration v11**: Auto-migrates existing DB entries whose config contains `modelscope.cn` from `alibaba` → `alibaba-modelscope`
- **8 unit tests** covering provider identity, URL normalization, adapter request building (no enable_thinking), and model pass-through

### Frontend
- Added `alibaba-modelscope` to provider registry (color, icon, display name, type list)
- Created `AddFlowModelScopeForm` (API key + optional endpoint) and `ModelScopeAuthForm` (re-auth)
- Wired conditionals in `ProvidersPage.tsx`

## Testing
- `go build ./...` — clean
- `bun run typecheck` — clean
- All 10 unit tests pass
- Migration verified live: existing modelscope01/modelscope02 entries migrated correctly
- Non-streaming Anthropic tool-use verified working through the new provider

Closes #71