### PR TITLE
feat: improve usage page date filters and CLI output formatting

### DIFF
--- a/frontend/src/locales/en/metering.json
+++ b/frontend/src/locales/en/metering.json
@@ -16,6 +16,12 @@
     "errorsSubtext": "Requests recorded with a status code ≥ 400"
   },
   "filters": {
+    "quickRange": "Quick range",
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "last7d": "Last 7 days",
+    "last30d": "Last 30 days",
+    "custom": "Custom",
     "since": "Since",
     "until": "Until",
     "model": "Model",

--- a/frontend/src/pages/MeteringPage.tsx
+++ b/frontend/src/pages/MeteringPage.tsx
@@ -17,6 +17,16 @@ import {
 } from "@/api"
 import { SearchableSelect } from "@/components/SearchableSelect"
 
+type DateRangePreset = "today" | "yesterday" | "last7d" | "last30d" | "custom"
+
+type StoredDateRange = {
+  preset: DateRangePreset
+  since: string
+  until: string
+}
+
+const METERING_DATE_RANGE_KEY = "olp-metering-date-range"
+
 function sortItems<T>(
   items: Array<T>,
   sortKey: keyof T | null,
@@ -66,7 +76,89 @@ function formatDateTime(value: string) {
 }
 
 function isoInputValue(date: Date) {
-  return date.toISOString().slice(0, 16)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  const hours = String(date.getHours()).padStart(2, "0")
+  const minutes = String(date.getMinutes()).padStart(2, "0")
+  return `${year}-${month}-${day}T${hours}:${minutes}`
+}
+
+function startOfToday() {
+  const value = new Date()
+  value.setHours(0, 0, 0, 0)
+  return value
+}
+
+function startOfYesterday() {
+  const value = startOfToday()
+  value.setDate(value.getDate() - 1)
+  return value
+}
+
+function getPresetRange(preset: Exclude<DateRangePreset, "custom">): {
+  since: string
+  until: string
+} {
+  switch (preset) {
+    case "today": {
+      return { since: isoInputValue(startOfToday()), until: "" }
+    }
+    case "yesterday": {
+      const since = startOfYesterday()
+      const until = startOfToday()
+      return { since: isoInputValue(since), until: isoInputValue(until) }
+    }
+    case "last7d": {
+      const since = startOfToday()
+      since.setDate(since.getDate() - 6)
+      return { since: isoInputValue(since), until: "" }
+    }
+    case "last30d": {
+      const since = startOfToday()
+      since.setDate(since.getDate() - 29)
+      return { since: isoInputValue(since), until: "" }
+    }
+    default: {
+      return { since: isoInputValue(startOfToday()), until: "" }
+    }
+  }
+}
+
+function loadStoredDateRange(): StoredDateRange {
+  const fallback = { preset: "today" as const, ...getPresetRange("today") }
+
+  try {
+    const raw = localStorage.getItem(METERING_DATE_RANGE_KEY)
+    if (!raw) return fallback
+
+    const parsed = JSON.parse(raw) as Partial<StoredDateRange>
+    if (
+      parsed.preset !== "today"
+      && parsed.preset !== "yesterday"
+      && parsed.preset !== "last7d"
+      && parsed.preset !== "last30d"
+      && parsed.preset !== "custom"
+    ) {
+      return fallback
+    }
+
+    return {
+      preset: parsed.preset,
+      since: typeof parsed.since === "string" ? parsed.since : fallback.since,
+      until: typeof parsed.until === "string" ? parsed.until : fallback.until,
+    }
+  } catch {
+    return fallback
+  }
+}
+
+function saveStoredDateRange(value: StoredDateRange) {
+  try {
+    localStorage.setItem(METERING_DATE_RANGE_KEY, JSON.stringify(value))
+  } catch {
+    // ignore
+  }
 }
 
 function Card({
@@ -490,15 +582,12 @@ export function MeteringPage({
   showToast: (msg: string, type?: "success" | "error") => void
 }) {
   const { t } = useTranslation("metering")
-  const now = useMemo(() => new Date(), [])
-  const defaultSince = useMemo(() => {
-    const value = new Date(now)
-    value.setHours(value.getHours() - 24)
-    return isoInputValue(value)
-  }, [now])
+  const initialDateRange = useMemo(loadStoredDateRange, [])
 
-  const [since, setSince] = useState(defaultSince)
-  const [until, setUntil] = useState("")
+  const [selectedRangePreset, setSelectedRangePreset] =
+    useState<DateRangePreset>(initialDateRange.preset)
+  const [since, setSince] = useState(initialDateRange.since)
+  const [until, setUntil] = useState(initialDateRange.until)
   const [modelId, setModelId] = useState("")
   const [providerId, setProviderId] = useState("")
   const [client, setClient] = useState("")
@@ -605,6 +694,30 @@ export function MeteringPage({
       stopAutoRefresh()
     }
   }
+
+  const applyDateRange = (
+    preset: DateRangePreset,
+    nextSince: string,
+    nextUntil: string,
+  ) => {
+    setSelectedRangePreset(preset)
+    setSince(nextSince)
+    setUntil(nextUntil)
+    setPage(1)
+  }
+
+  const applyPreset = (preset: Exclude<DateRangePreset, "custom">) => {
+    const range = getPresetRange(preset)
+    applyDateRange(preset, range.since, range.until)
+  }
+
+  useEffect(() => {
+    saveStoredDateRange({
+      preset: selectedRangePreset,
+      since,
+      until,
+    })
+  }, [selectedRangePreset, since, until])
 
   useEffect(() => {
     let cancelled = false
@@ -800,87 +913,142 @@ export function MeteringPage({
       <Card style={{ padding: 18, overflow: "visible" }}>
         <div
           style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
-            gap: 12,
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
           }}
         >
-          <label style={fieldStyle}>
-            <span style={labelStyle}>{t("filters.since")}</span>
-            <input
-              className="sys-input"
-              type="datetime-local"
-              value={since}
-              onChange={(e) => {
-                setSince(e.target.value)
-                setPage(1)
-              }}
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={labelStyle}>{t("filters.until")}</span>
-            <input
-              className="sys-input"
-              type="datetime-local"
-              value={until}
-              onChange={(e) => {
-                setUntil(e.target.value)
-                setPage(1)
-              }}
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={labelStyle}>{t("filters.model")}</span>
-            <SearchableSelect
-              options={modelOptions}
-              value={modelId}
-              onChange={(v) => {
-                setModelId(v)
-                setPage(1)
-              }}
-              placeholder={t("filters.allModels")}
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={labelStyle}>{t("filters.provider")}</span>
-            <SearchableSelect
-              options={providerOptions}
-              value={providerId}
-              onChange={(v) => {
-                setProviderId(v)
-                setPage(1)
-              }}
-              placeholder={t("filters.allProviders")}
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={labelStyle}>{t("table.client")}</span>
-            <SearchableSelect
-              options={clientOptions}
-              value={client}
-              onChange={(v) => {
-                setClient(v)
-                setPage(1)
-              }}
-              placeholder={t("filters.allClients")}
-            />
-          </label>
-          <label style={fieldStyle}>
-            <span style={labelStyle}>{t("filters.apiShape")}</span>
-            <select
-              className="sys-select"
-              value={apiShape}
-              onChange={(e) => {
-                setAPIShape(e.target.value)
-                setPage(1)
+          <div style={fieldStyle}>
+            <span style={labelStyle}>{t("filters.quickRange")}</span>
+            <div
+              style={{
+                display: "flex",
+                gap: 8,
+                flexWrap: "wrap",
               }}
             >
-              <option value="">{t("filters.all")}</option>
-              <option value="openai">openai</option>
-              <option value="anthropic">anthropic</option>
-              <option value="responses">responses</option>
-            </select>
-          </label>
+              {(["today", "yesterday", "last7d", "last30d"] as const).map(
+                (preset) => {
+                  const active = selectedRangePreset === preset
+                  return (
+                    <button
+                      key={preset}
+                      type="button"
+                      className="btn btn-ghost btn-sm"
+                      onClick={() => applyPreset(preset)}
+                      style={{
+                        borderColor:
+                          active ? "var(--color-primary)" : undefined,
+                        color: active ? "var(--color-text)" : undefined,
+                        background:
+                          active ?
+                            "color-mix(in srgb, var(--color-primary) 16%, transparent)"
+                          : undefined,
+                      }}
+                    >
+                      {t(`filters.${preset}`)}
+                    </button>
+                  )
+                },
+              )}
+              {selectedRangePreset === "custom" && (
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm"
+                  style={{
+                    borderColor: "var(--color-primary)",
+                    color: "var(--color-text)",
+                    background:
+                      "color-mix(in srgb, var(--color-primary) 16%, transparent)",
+                  }}
+                >
+                  {t("filters.custom")}
+                </button>
+              )}
+            </div>
+          </div>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+              gap: 12,
+            }}
+          >
+            <label style={fieldStyle}>
+              <span style={labelStyle}>{t("filters.since")}</span>
+              <input
+                className="sys-input"
+                type="datetime-local"
+                value={since}
+                onChange={(e) => {
+                  applyDateRange("custom", e.target.value, until)
+                }}
+              />
+            </label>
+            <label style={fieldStyle}>
+              <span style={labelStyle}>{t("filters.until")}</span>
+              <input
+                className="sys-input"
+                type="datetime-local"
+                value={until}
+                onChange={(e) => {
+                  applyDateRange("custom", since, e.target.value)
+                }}
+              />
+            </label>
+            <label style={fieldStyle}>
+              <span style={labelStyle}>{t("filters.model")}</span>
+              <SearchableSelect
+                options={modelOptions}
+                value={modelId}
+                onChange={(v) => {
+                  setModelId(v)
+                  setPage(1)
+                }}
+                placeholder={t("filters.allModels")}
+              />
+            </label>
+            <label style={fieldStyle}>
+              <span style={labelStyle}>{t("filters.provider")}</span>
+              <SearchableSelect
+                options={providerOptions}
+                value={providerId}
+                onChange={(v) => {
+                  setProviderId(v)
+                  setPage(1)
+                }}
+                placeholder={t("filters.allProviders")}
+              />
+            </label>
+            <label style={fieldStyle}>
+              <span style={labelStyle}>{t("table.client")}</span>
+              <SearchableSelect
+                options={clientOptions}
+                value={client}
+                onChange={(v) => {
+                  setClient(v)
+                  setPage(1)
+                }}
+                placeholder={t("filters.allClients")}
+              />
+            </label>
+            <label style={fieldStyle}>
+              <span style={labelStyle}>{t("filters.apiShape")}</span>
+              <select
+                className="sys-select"
+                value={apiShape}
+                onChange={(e) => {
+                  setAPIShape(e.target.value)
+                  setPage(1)
+                }}
+              >
+                <option value="">{t("filters.all")}</option>
+                <option value="openai">openai</option>
+                <option value="anthropic">anthropic</option>
+                <option value="responses">responses</option>
+              </select>
+            </label>
+          </div>
         </div>
       </Card>
 

--- a/internal/commands/chat.go
+++ b/internal/commands/chat.go
@@ -476,9 +476,9 @@ func handleChatSlashCommand(cmd *cobra.Command, c *Client, session *chatSessionS
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No models match %q\n", filter)
 			return replCommandResult{handled: true}, nil
 		}
-		table := NewTable("MODEL", "OWNER", "NAME")
+		table := NewTable("SELECTOR", "NAME")
 		for _, model := range filtered {
-			table.AddRow(model.ID, model.Owner, model.Name)
+			table.AddRow(model.Selector, model.Name)
 		}
 		if err := table.Render(cmd.OutOrStdout()); err != nil {
 			return replCommandResult{}, err
@@ -508,7 +508,7 @@ func printChatHelp(cmd *cobra.Command) {
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  /model             Show the current model")
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  /model <id>        Switch to a different model")
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  /models            Open the model selector in a terminal")
-	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  /models <filter>   List models matching a filter")
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  /models <filter>   List model selectors matching a filter")
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  /quit, /exit       Leave the chat shell")
 }
 
@@ -519,17 +519,25 @@ type chatMessage struct {
 }
 
 type chatModelInfo struct {
-	ID    string
-	Owner string
-	Name  string
+	ID       string
+	Owner    string
+	Name     string
+	Selector string
+}
+
+func chatModelSelector(model chatModelInfo) string {
+	if model.Owner == "" || model.Owner == "virtual" || strings.HasPrefix(model.ID, model.Owner+"/") {
+		return model.ID
+	}
+	return model.Owner + "/" + model.ID
 }
 
 func promptModelPicker(prompt string, models []chatModelInfo) (string, error) {
 	items := make([]string, 0, len(models))
 	for _, model := range models {
-		label := model.ID
+		label := model.Selector
 		if model.Name != "" && model.Name != model.ID {
-			label = fmt.Sprintf("%s — %s", model.ID, model.Name)
+			label = fmt.Sprintf("%s — %s", model.Selector, model.Name)
 		}
 		items = append(items, label)
 	}
@@ -540,7 +548,7 @@ func promptModelPicker(prompt string, models []chatModelInfo) (string, error) {
 	}
 	for i, item := range items {
 		if item == selected {
-			return models[i].ID, nil
+			return models[i].Selector, nil
 		}
 	}
 	return "", nil
@@ -554,7 +562,7 @@ func filterChatModels(models []chatModelInfo, filter string) []chatModelInfo {
 
 	filtered := make([]chatModelInfo, 0, len(models))
 	for _, model := range models {
-		if strings.Contains(strings.ToLower(model.ID), filter) || strings.Contains(strings.ToLower(model.Name), filter) || strings.Contains(strings.ToLower(model.Owner), filter) {
+		if strings.Contains(strings.ToLower(model.ID), filter) || strings.Contains(strings.ToLower(model.Name), filter) || strings.Contains(strings.ToLower(model.Owner), filter) || strings.Contains(strings.ToLower(model.Selector), filter) {
 			filtered = append(filtered, model)
 		}
 	}
@@ -666,7 +674,8 @@ func listChatModels(c *Client) ([]chatModelInfo, error) {
 		id, _ := entry["id"].(string)
 		owner, _ := entry["owned_by"].(string)
 		name, _ := entry["display_name"].(string)
-		models = append(models, chatModelInfo{ID: id, Owner: owner, Name: name})
+		selector := chatModelSelector(chatModelInfo{ID: id, Owner: owner, Name: name})
+		models = append(models, chatModelInfo{ID: id, Owner: owner, Name: name, Selector: selector})
 	}
 
 	sort.Slice(models, func(i, j int) bool {

--- a/internal/commands/chat_repl_test.go
+++ b/internal/commands/chat_repl_test.go
@@ -144,7 +144,7 @@ func TestHandleChatSlashCommandModelsFilterOutput(t *testing.T) {
 		t.Fatalf("expected handled result, got %+v", result)
 	}
 	text := out.String()
-	if !strings.Contains(text, "qwen3") || strings.Contains(text, "gpt-4") {
+	if !strings.Contains(text, "provider-b/qwen3") || strings.Contains(text, "provider-a/gpt-4") {
 		t.Fatalf("unexpected filtered output:\n%s", text)
 	}
 }

--- a/internal/commands/check-usage.go
+++ b/internal/commands/check-usage.go
@@ -41,6 +41,7 @@ func addUsageFlags(cmd *cobra.Command) {
 func runUsage(cmd *cobra.Command, args []string) error {
 	c := NewClient(cmd)
 	query := usageQuery(cmd)
+	out := cmd.OutOrStdout()
 
 	statsData, err := c.Get("/api/admin/metering/stats" + query)
 	if err != nil {
@@ -56,14 +57,31 @@ func runUsage(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("parse stats response: %w", err)
 	}
 
-	fmt.Println("Usage summary:")
-	fmt.Println(strings.Repeat("─", 40))
-	printUsageValue("Requests", stats["total_requests"])
-	printUsageValue("Input tokens", stats["total_input_tokens"])
-	printUsageValue("Output tokens", stats["total_output_tokens"])
-	printUsageValue("Total tokens", stats["total_tokens"])
-	printUsageValue("Average latency ms", stats["avg_latency_ms"])
-	printUsageValue("Errors", stats["error_count"])
+	if err := PrintSection(out, "Usage summary"); err != nil {
+		return err
+	}
+	if filters := activeUsageFilters(cmd); len(filters) > 0 {
+		filterTable := NewTable("FILTER", "VALUE")
+		for _, filter := range filters {
+			filterTable.AddRow(filter[0], filter[1])
+		}
+		if err := filterTable.Render(out); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
+	}
+	summary := NewTable("METRIC", "VALUE")
+	summary.AddRow("Requests", fmt.Sprint(stats["total_requests"]))
+	summary.AddRow("Input tokens", fmt.Sprint(stats["total_input_tokens"]))
+	summary.AddRow("Output tokens", fmt.Sprint(stats["total_output_tokens"]))
+	summary.AddRow("Total tokens", fmt.Sprint(stats["total_tokens"]))
+	summary.AddRow("Average latency ms", fmt.Sprint(stats["avg_latency_ms"]))
+	summary.AddRow("Errors", fmt.Sprint(stats["error_count"]))
+	if err := summary.Render(out); err != nil {
+		return err
+	}
 
 	breakdown, _ := cmd.Flags().GetString("breakdown")
 	path, err := usageBreakdownPath(breakdown)
@@ -87,17 +105,21 @@ func runUsage(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Println()
-	fmt.Printf("Usage by %s:\n", breakdown)
-	fmt.Println(strings.Repeat("─", 80))
+	if _, err := fmt.Fprintln(out); err != nil {
+		return err
+	}
+	if err := PrintSection(out, fmt.Sprintf("Usage by %s", usageBreakdownTitle(breakdown))); err != nil {
+		return err
+	}
+	table := usageBreakdownTable(breakdown)
 	for _, item := range items {
 		row, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		printUsageBreakdownRow(breakdown, row)
+		addUsageBreakdownRow(table, breakdown, row)
 	}
-	return nil
+	return table.Render(out)
 }
 
 func usageQuery(cmd *cobra.Command) string {
@@ -112,6 +134,40 @@ func usageQuery(cmd *cobra.Command) string {
 		return ""
 	}
 	return "?" + params.Encode()
+}
+
+func activeUsageFilters(cmd *cobra.Command) [][2]string {
+	filters := make([][2]string, 0, 6)
+	for _, entry := range []struct {
+		flag  string
+		label string
+	}{
+		{flag: "provider-id", label: "Provider"},
+		{flag: "model-id", label: "Model"},
+		{flag: "client", label: "Client"},
+		{flag: "api-shape", label: "API shape"},
+		{flag: "since", label: "Since"},
+		{flag: "until", label: "Until"},
+	} {
+		value, _ := cmd.Flags().GetString(entry.flag)
+		if value != "" {
+			filters = append(filters, [2]string{entry.label, value})
+		}
+	}
+	return filters
+}
+
+func usageBreakdownTitle(breakdown string) string {
+	switch breakdown {
+	case "providers":
+		return "provider"
+	case "models":
+		return "model"
+	case "clients":
+		return "client"
+	default:
+		return breakdown
+	}
 }
 
 func usageBreakdownPath(breakdown string) (string, error) {
@@ -129,11 +185,19 @@ func usageBreakdownPath(breakdown string) (string, error) {
 	}
 }
 
-func printUsageValue(label string, value any) {
-	fmt.Printf("  %-20s %v\n", label+":", value)
+func usageBreakdownTable(breakdown string) *Table {
+	labelHeader := map[string]string{
+		"provider":  "PROVIDER",
+		"providers": "PROVIDER",
+		"model":     "MODEL",
+		"models":    "MODEL",
+		"client":    "CLIENT",
+		"clients":   "CLIENT",
+	}[breakdown]
+	return NewTable(labelHeader, "REQUESTS", "TOKENS", "AVG LATENCY MS")
 }
 
-func printUsageBreakdownRow(breakdown string, row map[string]any) {
+func addUsageBreakdownRow(table *Table, breakdown string, row map[string]any) {
 	labelKey := map[string]string{
 		"provider":  "provider_id",
 		"providers": "provider_id",
@@ -146,6 +210,10 @@ func printUsageBreakdownRow(breakdown string, row map[string]any) {
 	if label == "" {
 		label = "(unknown)"
 	}
-	fmt.Printf("  %-36s requests=%v tokens=%v avg_latency_ms=%v\n",
-		padRight(label, 36), row["requests"], row["total_tokens"], row["avg_latency_ms"])
+	table.AddRow(
+		label,
+		fmt.Sprint(row["requests"]),
+		fmt.Sprint(row["total_tokens"]),
+		fmt.Sprint(row["avg_latency_ms"]),
+	)
 }

--- a/internal/commands/provider.go
+++ b/internal/commands/provider.go
@@ -223,23 +223,17 @@ func promptForGitHubCopilotAuth(cmd *cobra.Command) error {
 
 	if strings.TrimSpace(method) == "" {
 		const (
-			optBrowser    = "Browser login (auto-open)"
-			optDeviceCode = "Device code (manual copy-paste)"
-			optToken      = "Personal token"
+			optOAuth = "Browser login"
+			optToken = "Personal token"
 		)
-		selectedMethod, err := SelectFromOptions("Authenticate with GitHub Copilot using:", []string{optBrowser, optDeviceCode, optToken})
+		selectedMethod, err := SelectFromOptions("Authenticate with GitHub Copilot using:", []string{optOAuth, optToken})
 		if err != nil {
 			return err
 		}
 		switch selectedMethod {
 		case optToken:
 			method = "token"
-		case optDeviceCode:
-			method = "oauth"
-			if err := cmd.Flags().Set("device", "true"); err != nil {
-				return err
-			}
-		default: // optBrowser
+		default: // optOAuth
 			method = "oauth"
 		}
 		if err := cmd.Flags().Set("method", method); err != nil {

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -34,6 +33,7 @@ func runServerStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	out := cmd.OutOrStdout()
 	status, _ := resp["status"].(string)
 	uptime, _ := resp["uptime"].(string)
 	modelCount, _ := resp["modelCount"].(float64)
@@ -41,56 +41,102 @@ func runServerStatus(cmd *cobra.Command, args []string) error {
 	rateLimitSeconds := resp["rateLimitSeconds"]
 	rateLimitWait, _ := resp["rateLimitWait"].(bool)
 
-	activeProviders := []string{}
+	if err := PrintSection(out, "Server status"); err != nil {
+		return err
+	}
+	if err := PrintKeyValue(out, "Status", status); err != nil {
+		return err
+	}
+	if err := PrintKeyValue(out, "Uptime", uptime); err != nil {
+		return err
+	}
+	if err := PrintKeyValue(out, "Model count", fmt.Sprintf("%.0f", modelCount)); err != nil {
+		return err
+	}
+	if err := PrintKeyValue(out, "Manual approve", manualApprove); err != nil {
+		return err
+	}
+	if rateLimitSeconds != nil {
+		if err := PrintKeyValue(out, "Rate limit", fmt.Sprintf("%vs (wait=%v)", rateLimitSeconds, rateLimitWait)); err != nil {
+			return err
+		}
+	} else if err := PrintKeyValue(out, "Rate limit", "none"); err != nil {
+		return err
+	}
+
+	providerTable := NewTable("NAME", "ID")
+	providerCount := 0
 	if providers, ok := resp["activeProviders"].([]interface{}); ok {
 		for _, entry := range providers {
 			provider, _ := entry.(map[string]interface{})
 			name, _ := provider["name"].(string)
 			id, _ := provider["id"].(string)
-			if name != "" && id != "" {
-				activeProviders = append(activeProviders, fmt.Sprintf("%s (%s)", name, id))
+			if name == "" && id == "" {
+				continue
 			}
+			providerTable.AddRow(name, id)
+			providerCount++
 		}
-	}
-	activeProvider := "none"
-	if len(activeProviders) > 0 {
-		activeProvider = strings.Join(activeProviders, ", ")
 	} else if ap, ok := resp["activeProvider"].(map[string]interface{}); ok {
 		name, _ := ap["name"].(string)
 		id, _ := ap["id"].(string)
-		activeProvider = fmt.Sprintf("%s (%s)", name, id)
+		if name != "" || id != "" {
+			providerTable.AddRow(name, id)
+			providerCount = 1
+		}
 	}
-
-	fmt.Printf("Status:          %s\n", status)
-	fmt.Printf("Uptime:          %s\n", uptime)
-	fmt.Printf("Active provider: %s\n", activeProvider)
-	fmt.Printf("Model count:     %.0f\n", modelCount)
-	fmt.Printf("Manual approve:  %v\n", manualApprove)
-	if rateLimitSeconds != nil {
-		fmt.Printf("Rate limit:      %vs (wait=%v)\n", rateLimitSeconds, rateLimitWait)
-	} else {
-		fmt.Printf("Rate limit:      none\n")
+	if providerCount > 0 {
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
+		if err := PrintSection(out, "Active providers"); err != nil {
+			return err
+		}
+		if err := providerTable.Render(out); err != nil {
+			return err
+		}
+	} else if err := PrintKeyValue(out, "Active providers", "none"); err != nil {
+		return err
 	}
 
 	if services, ok := resp["services"].(map[string]interface{}); ok {
-		fmt.Println("\nServices:")
-		fmt.Printf("  API:      %v\n", services["api"])
-		fmt.Printf("  Database: %v\n", services["database"])
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
+		if err := PrintSection(out, "Services"); err != nil {
+			return err
+		}
+		serviceTable := NewTable("SERVICE", "STATUS")
+		serviceTable.AddRow("API", fmt.Sprint(services["api"]))
+		serviceTable.AddRow("Database", fmt.Sprint(services["database"]))
 		if providers, ok := services["providers"].(map[string]interface{}); ok {
-			fmt.Printf("  Providers: %v total, %v active\n",
-				providers["total"], providers["active"])
+			serviceTable.AddRow("Providers", fmt.Sprintf("%v total, %v active", providers["total"], providers["active"]))
+		}
+		if err := serviceTable.Render(out); err != nil {
+			return err
 		}
 	}
 
 	if authFlow, ok := resp["authFlow"].(map[string]interface{}); ok && authFlow != nil {
 		flowStatus, _ := authFlow["status"].(string)
 		providerID, _ := authFlow["providerId"].(string)
-		fmt.Printf("\nActive auth flow: %s (%s)\n", flowStatus, providerID)
-		if uc, ok := authFlow["userCode"].(string); ok {
-			fmt.Printf("  User code: %s\n", uc)
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
 		}
-		if url, ok := authFlow["instructionURL"].(string); ok {
-			fmt.Printf("  Visit:     %s\n", url)
+		if err := PrintSection(out, "Active auth flow"); err != nil {
+			return err
+		}
+		authTable := NewTable("FIELD", "VALUE")
+		authTable.AddRow("Status", flowStatus)
+		authTable.AddRow("Provider", providerID)
+		if uc, ok := authFlow["userCode"].(string); ok && uc != "" {
+			authTable.AddRow("User code", uc)
+		}
+		if url, ok := authFlow["instructionURL"].(string); ok && url != "" {
+			authTable.AddRow("Visit", url)
+		}
+		if err := authTable.Render(out); err != nil {
+			return err
 		}
 	}
 
@@ -118,25 +164,26 @@ var statusAuthCmd = &cobra.Command{
 
 		status, _ := resp["status"].(string)
 		if status == "idle" {
-			fmt.Println("No active authentication flow.")
-			return nil
+			return PrintEmpty(cmd.OutOrStdout(), "active authentication flow")
 		}
 
+		out := cmd.OutOrStdout()
 		providerID, _ := resp["providerId"].(string)
-		fmt.Printf("Provider:  %s\n", providerID)
-		fmt.Printf("Status:    %s\n", status)
-
+		if err := PrintSection(out, "Auth flow status"); err != nil {
+			return err
+		}
+		table := NewTable("FIELD", "VALUE")
+		table.AddRow("Provider", providerID)
+		table.AddRow("Status", status)
 		if uc, ok := resp["userCode"].(string); ok && uc != "" {
-			fmt.Printf("User code: %s\n", uc)
+			table.AddRow("User code", uc)
 		}
 		if url, ok := resp["instructionURL"].(string); ok && url != "" {
-			fmt.Printf("Visit:     %s\n", url)
+			table.AddRow("Visit", url)
 		}
 		if errMsg, ok := resp["error"].(string); ok && errMsg != "" {
-			fmt.Printf("Error:     %s\n", errMsg)
+			table.AddRow("Error", errMsg)
 		}
-
-		_ = strings.Repeat("", 0) // keep strings import
-		return nil
+		return table.Render(out)
 	},
 }


### PR DESCRIPTION
- Add quick date presets (Today, Yesterday, Last 7 days, Last 30 days) to usage page
- Persist selected date range across page refreshes via localStorage
- Default usage page to today's data instead of rolling 24-hour window
- Fix isoInputValue to use local timezone instead of UTC
- Simplify GitHub Copilot OAuth login prompt to single Browser login option
- Upgrade CLI status output to consistent sectioned table format
- Upgrade CLI usage output to consistent table format with active filter display
- Show full provider/model selectors in interactive chat /models command