### PR TITLE
fix: agent reliability, scroll UX, and multi-turn test improvements

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -58,7 +58,7 @@ func (a *Agent) Run(ctx context.Context, sessionID string, prompt string) (*RunR
 			}, err
 		}
 
-		response, err := a.dispatchAndCollect(ctx, step)
+		response, err := a.dispatchAndCollect(ctx, step, prompt)
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +108,7 @@ func (a *Agent) Stream(ctx context.Context, sessionID string, prompt string) (<-
 				return
 			}
 
-			response, err := a.dispatchAndCollect(ctx, step)
+			response, err := a.dispatchAndCollect(ctx, step, prompt)
 			if err != nil {
 				events <- Event{Type: EventError, Content: err.Error()}
 				return
@@ -178,8 +178,8 @@ func toAssistantMessage(content []cif.CIFContentPart) cif.CIFAssistantMessage {
 	}
 }
 
-func (a *Agent) dispatchAndCollect(ctx context.Context, step int) (*cif.CanonicalResponse, error) {
-	req := a.buildRequest()
+func (a *Agent) dispatchAndCollect(ctx context.Context, step int, prompt string) (*cif.CanonicalResponse, error) {
+	req := a.buildRequest(step, prompt)
 
 	respCh, err := a.dispatch(ctx, req)
 	if err != nil {
@@ -197,12 +197,11 @@ func (a *Agent) dispatchAndCollect(ctx context.Context, step int) (*cif.Canonica
 	return response, nil
 }
 
-func (a *Agent) buildRequest() *cif.CanonicalRequest {
+func (a *Agent) buildRequest(step int, prompt string) *cif.CanonicalRequest {
 	messages := a.memory.Messages()
 	cifTools := a.registry.ToCIFTools()
 
-	// Extract system prompt from memory and set it on the request.
-	// This ensures it's sent as a proper system message, not buried in conversation history.
+	// Extract system prompt from memory; send as SystemPrompt, not buried in history.
 	var systemPrompt string
 	filtered := make([]cif.CIFMessage, 0, len(messages))
 	for _, msg := range messages {
@@ -227,10 +226,36 @@ func (a *Agent) buildRequest() *cif.CanonicalRequest {
 	}
 	// Per OpenAI spec: tool_choice must only be set when tools are present.
 	if len(cifTools) > 0 {
-		req.ToolChoice = "auto"
+		if step == 0 && shouldRequireInitialToolUse(prompt) {
+			req.ToolChoice = "required"
+		} else {
+			req.ToolChoice = "auto"
+		}
 	}
 
 	return req
+}
+
+func shouldRequireInitialToolUse(prompt string) bool {
+	p := strings.ToLower(prompt)
+	for _, phrase := range []string{
+		"environment variable", "env var", "os info", "system info",
+		"current directory", "list directory", "show directory", "working directory", "current time",
+	} {
+		if strings.Contains(p, phrase) {
+			return true
+		}
+	}
+
+	for _, term := range strings.FieldsFunc(p, func(r rune) bool {
+		return r < '0' || r > '9' && r < 'a' || r > 'z'
+	}) {
+		switch term {
+		case "cpu", "memory", "disk", "process":
+			return true
+		}
+	}
+	return false
 }
 
 func extractToolCalls(content []cif.CIFContentPart) []cif.CIFToolCallPart {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -201,10 +201,29 @@ func (a *Agent) buildRequest() *cif.CanonicalRequest {
 	messages := a.memory.Messages()
 	cifTools := a.registry.ToCIFTools()
 
+	// Extract system prompt from memory and set it on the request.
+	// This ensures it's sent as a proper system message, not buried in conversation history.
+	var systemPrompt string
+	filtered := make([]cif.CIFMessage, 0, len(messages))
+	for _, msg := range messages {
+		if sm, ok := msg.(cif.CIFSystemMessage); ok {
+			if systemPrompt == "" {
+				systemPrompt = sm.Content
+			} else {
+				systemPrompt += "\n" + sm.Content
+			}
+		} else {
+			filtered = append(filtered, msg)
+		}
+	}
+
 	req := &cif.CanonicalRequest{
-		Messages: messages,
+		Messages: filtered,
 		Tools:    cifTools,
 		Stream:   false,
+	}
+	if systemPrompt != "" {
+		req.SystemPrompt = &systemPrompt
 	}
 	// Per OpenAI spec: tool_choice must only be set when tools are present.
 	if len(cifTools) > 0 {

--- a/internal/agent/agent_matrix_test.go
+++ b/internal/agent/agent_matrix_test.go
@@ -555,6 +555,198 @@ func TestAgentMatrixPermissionCheckerAllBackends(t *testing.T) {
 	}
 }
 
+// ─── multi-turn conversation simulation ──────────────────────────────────────
+
+// multiTurnExchange describes one step in a simulated conversation.
+type multiTurnExchange struct {
+	userPrompt   string
+	// assistantReply is the stub response the model returns for this turn.
+	// If toolCallOnTurn is non-zero, the first call to that turn number returns
+	// a tool_use block; the second call returns assistantReply.
+	assistantReply string
+	// toolCallOnFirstStep: when true, stub returns a tool_use then this reply.
+	toolCallOnFirstStep bool
+}
+
+// multiTurnStub is a stub Client that replays a scripted conversation.
+// It cycles through exchanges in order; each exchange may optionally trigger
+// one tool call on its first proxy call.
+type multiTurnStub struct {
+	t           *testing.T
+	model       string
+	exchanges   []multiTurnExchange
+	turnIdx     int // which exchange we are currently serving
+	callInTurn  int // call count within the current exchange (1-based)
+	totalCalls  int
+	allPaths    []string
+	allPayloads []map[string]any
+}
+
+func (s *multiTurnStub) Post(path string, body any) ([]byte, error) {
+	s.totalCalls++
+	s.callInTurn++
+	s.allPaths = append(s.allPaths, path)
+
+	data, _ := json.Marshal(body)
+	var p map[string]any
+	_ = json.Unmarshal(data, &p)
+	s.allPayloads = append(s.allPayloads, p)
+
+	if s.turnIdx >= len(s.exchanges) {
+		s.t.Fatalf("multiTurnStub: unexpected extra call at turn %d", s.turnIdx)
+	}
+	ex := s.exchanges[s.turnIdx]
+
+	var responseBytes []byte
+	if ex.toolCallOnFirstStep && s.callInTurn == 1 {
+		responseBytes = messagesToolResponse(s.model, 1) // tool_use
+	} else {
+		// final text reply for this turn
+		r := map[string]any{
+			"id":          fmt.Sprintf("msg_turn%d", s.turnIdx),
+			"type":        "message",
+			"role":        "assistant",
+			"model":       s.model,
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 10, "output_tokens": 5},
+			"content":     []map[string]any{{"type": "text", "text": ex.assistantReply}},
+		}
+		b, _ := json.Marshal(r)
+		responseBytes = b
+		// Advance to the next exchange for the next RunTurn call.
+		s.turnIdx++
+		s.callInTurn = 0
+	}
+	return responseBytes, nil
+}
+
+func (s *multiTurnStub) PostStream(_ string, _ any) (*http.Response, error) {
+	return nil, fmt.Errorf("streaming not used in multi-turn simulation")
+}
+
+// conversationScript is the scripted dialogue used for TestAgentMatrixMultiTurn.
+// The user sends four messages; the model answers two with plain text and two
+// after a tool call (simulating a realistic coding assistant session).
+var conversationScript = []multiTurnExchange{
+	{
+		userPrompt:          "List the files in the current directory.",
+		assistantReply:      "main.go  README.md  go.mod",
+		toolCallOnFirstStep: true, // model calls ls tool, then replies with file list
+	},
+	{
+		userPrompt:     "What does main.go do?",
+		assistantReply: "main.go is the entry point. It initialises the proxy server.",
+	},
+	{
+		userPrompt:          "Show me the first 20 lines of main.go.",
+		assistantReply:      "package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"omnillm\") }",
+		toolCallOnFirstStep: true, // model calls read tool, then replies with content
+	},
+	{
+		userPrompt:     "Thanks, that's all.",
+		assistantReply: "You're welcome! Let me know if you need anything else.",
+	},
+}
+
+// alibabaModels are the Alibaba DashScope models under test.
+var alibabaModels = []string{"glm-5.1", "deepseek-v4-flash", "qwen3.6-flash"}
+
+// copilotModels are the GitHub Copilot models under test (Jian Zhu account).
+var copilotModels = []string{"gpt-5-mini", "claude-haiku-4.5", "gpt-5.4-mini"}
+
+// TestAgentMatrixMultiTurn simulates a realistic 4-turn coding-assistant
+// conversation across all 3 agent backends and all 6 targeted models
+// (3 Alibaba + 3 GitHub Copilot).  Each turn calls RunTurn with the
+// accumulated conversation history, matching how the omnicode agent REPL works.
+//
+// Assertions per turn:
+//   - No error
+//   - Correct assistant reply text
+//   - All proxy calls hit /v1/messages
+//   - Tool-call turns require exactly 2 proxy calls; plain turns require 1
+func TestAgentMatrixMultiTurn(t *testing.T) {
+	targetModels := append(alibabaModels, copilotModels...)
+
+	for _, backend := range allBackends {
+		for _, model := range targetModels {
+			backend, model := backend, model
+			tag := fmt.Sprintf("%s/%s", backend, model)
+			t.Run(tag, func(t *testing.T) {
+				stub := &multiTurnStub{
+					t:         t,
+					model:     model,
+					exchanges: conversationScript,
+				}
+
+				var history []HistoryMessage
+
+				for turnN, ex := range conversationScript {
+					wantCalls := 1
+					if ex.toolCallOnFirstStep {
+						wantCalls = 2
+					}
+					prevTotal := stub.totalCalls
+
+					result, err := RunTurn(
+						context.Background(), stub,
+						fmt.Sprintf("sess-multiturn-%s-%s", backend, model),
+						model, backend,
+						ex.userPrompt,
+						history, nil, nil,
+					)
+					if err != nil {
+						t.Fatalf("[%s] turn %d: RunTurn error: %v", tag, turnN+1, err)
+					}
+					if result == nil {
+						t.Fatalf("[%s] turn %d: nil result", tag, turnN+1)
+					}
+					if result.Output != ex.assistantReply {
+						t.Errorf("[%s] turn %d: output = %q, want %q", tag, turnN+1, result.Output, ex.assistantReply)
+					}
+
+					gotCalls := stub.totalCalls - prevTotal
+					if gotCalls != wantCalls {
+						t.Errorf("[%s] turn %d: proxy calls = %d, want %d", tag, turnN+1, gotCalls, wantCalls)
+					}
+
+					// Verify all proxy calls in this turn used /v1/messages.
+					for i := prevTotal; i < stub.totalCalls; i++ {
+						if stub.allPaths[i] != "/v1/messages" {
+							t.Errorf("[%s] turn %d call %d: path = %q, want /v1/messages",
+								tag, turnN+1, i-prevTotal+1, stub.allPaths[i])
+						}
+						if stub.allPayloads[i]["model"] != model {
+							t.Errorf("[%s] turn %d call %d: model = %#v, want %q",
+								tag, turnN+1, i-prevTotal+1, stub.allPayloads[i]["model"], model)
+						}
+					}
+
+					// Accumulate history for the next turn.
+					history = append(history, HistoryMessage{Role: "user", Content: ex.userPrompt})
+					history = append(history, HistoryMessage{Role: "assistant", Content: result.Output})
+				}
+
+				// Total proxy calls: turns without tool = 1 call; with tool = 2 calls.
+				// Script: turns 0,2 have tools (2 calls each); turns 1,3 don't (1 call each).
+				wantTotal := 0
+				for _, ex := range conversationScript {
+					if ex.toolCallOnFirstStep {
+						wantTotal += 2
+					} else {
+						wantTotal++
+					}
+				}
+				if stub.totalCalls != wantTotal {
+					t.Errorf("[%s] total proxy calls = %d, want %d", tag, stub.totalCalls, wantTotal)
+				}
+
+				t.Logf("[%s] completed %d-turn conversation in %d proxy calls",
+					tag, len(conversationScript), stub.totalCalls)
+			})
+		}
+	}
+}
+
 // ─── summary smoke: matrix dimensions ────────────────────────────────────────
 
 // TestAgentMatrixDimensions is a sanity check that we cover the expected

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -13,6 +13,41 @@ import (
 	"omnillm/internal/tools"
 )
 
+func TestBuildRequestRequiresInitialToolForLocalInfoPrompt(t *testing.T) {
+	ag := newTestAgent()
+	ag.appendUserMessage("show CPU info")
+
+	req := ag.buildRequest(0, "show CPU info")
+	if req.ToolChoice != "required" {
+		t.Fatalf("tool choice = %#v, want required", req.ToolChoice)
+	}
+
+	req = ag.buildRequest(1, "show CPU info")
+	if req.ToolChoice != "auto" {
+		t.Fatalf("follow-up tool choice = %#v, want auto", req.ToolChoice)
+	}
+}
+
+func TestBuildRequestUsesAutoForConversationalPrompt(t *testing.T) {
+	ag := newTestAgent()
+	ag.appendUserMessage("hello")
+
+	req := ag.buildRequest(0, "hello")
+	if req.ToolChoice != "auto" {
+		t.Fatalf("tool choice = %#v, want auto", req.ToolChoice)
+	}
+}
+
+func TestBuildRequestLeavesToolChoiceUnsetWithoutTools(t *testing.T) {
+	ag := NewAgent(tools.NewRegistry(), NewBufferMemory(8), 10, nil)
+	ag.appendUserMessage("show CPU info")
+
+	req := ag.buildRequest(0, "show CPU info")
+	if req.ToolChoice != nil {
+		t.Fatalf("tool choice = %#v, want nil", req.ToolChoice)
+	}
+}
+
 func TestRegistryExecuteToolCallsHonorsPermissionChecker(t *testing.T) {
 	registry := tools.NewRegistry()
 	registry.Register(tools.Bash())
@@ -87,7 +122,7 @@ func TestChatCompletionsDispatchRoutesAllModelsToMessages(t *testing.T) {
 				Messages: []cif.CIFMessage{
 					cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "Hello"}}},
 				},
-				Tools: []cif.CIFTool{{Name: "ls", Description: stringPtr("List files"), ParametersSchema: map[string]any{"type": "object", "properties": map[string]any{"path": map[string]any{"type": "string"}}}}},
+				Tools:      []cif.CIFTool{{Name: "ls", Description: stringPtr("List files"), ParametersSchema: map[string]any{"type": "object", "properties": map[string]any{"path": map[string]any{"type": "string"}}}}},
 				ToolChoice: "auto",
 			})
 			if err != nil {
@@ -135,7 +170,7 @@ func TestChatCompletionsDispatchRoutesGPTModelsToMessages(t *testing.T) {
 		Messages: []cif.CIFMessage{
 			cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "Hello"}}},
 		},
-		Tools: []cif.CIFTool{{Name: "ls", Description: stringPtr("List files"), ParametersSchema: map[string]any{"type": "object", "properties": map[string]any{"path": map[string]any{"type": "string"}}}}},
+		Tools:      []cif.CIFTool{{Name: "ls", Description: stringPtr("List files"), ParametersSchema: map[string]any{"type": "object", "properties": map[string]any{"path": map[string]any{"type": "string"}}}}},
 		ToolChoice: "auto",
 	})
 	if err != nil {
@@ -411,4 +446,11 @@ func TestSelectDispatchUsesAnthropicSDKForAnthropicSDKBackend(t *testing.T) {
 	if capturedPath != "/v1/messages" {
 		t.Fatalf("expected /v1/messages, got %q", capturedPath)
 	}
+}
+
+func newTestAgent() *Agent {
+	registry := tools.NewRegistry()
+	registry.Register(tools.Bash())
+	memory := NewBufferMemory(8)
+	return NewAgent(registry, memory, 10, nil)
 }

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -105,7 +105,7 @@ func doChatCompletionsStreamPost(ctx context.Context, c Client, model string, re
 	}
 	resp, streamErr := c.PostStream("/v1/chat/completions", json.RawMessage(jsonBytes))
 	if streamErr != nil {
-		return nil, fmt.Errorf("failed to stream chat completion: %w", err)
+		return nil, fmt.Errorf("failed to stream chat completion: %w", streamErr)
 	}
 	defer resp.Body.Close()
 	streamCh := make(chan cif.CIFStreamEvent, 64)

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -225,9 +225,8 @@ func cifMessagesToAnthropic(req *cif.CanonicalRequest) ([]map[string]any, error)
 	for _, msg := range req.Messages {
 		switch m := msg.(type) {
 		case cif.CIFSystemMessage:
-			if strings.TrimSpace(m.Content) != "" {
-				messages = append(messages, map[string]any{"role": "user", "content": m.Content})
-			}
+			// System messages are sent via req.SystemPrompt, skip here.
+			continue
 		case cif.CIFUserMessage:
 			content := anthropicContentBlocksFromUser(m)
 			messages = append(messages, map[string]any{"role": "user", "content": content})

--- a/internal/agent/session_runner.go
+++ b/internal/agent/session_runner.go
@@ -71,7 +71,8 @@ func buildSystemPrompt() string {
 	}
 	return fmt.Sprintf(
 		"You are a helpful agent. The current operating system is %s. "+
-			"When writing shell commands for the bash tool, always use %s syntax.",
+			"When writing shell commands for the bash tool, always use %s syntax. "+
+			"IMPORTANT: Use the available tools to accomplish the task. Do not just describe what you will do — actually execute the tool calls.",
 		os, shell,
 	)
 }

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -513,6 +513,201 @@ func TestRunAgentTurnExecutesPermissionedCommand(t *testing.T) {
 	}
 }
 
+func TestTUIAgentDoneMsgShowsVisibleCompletionWhenContentEmpty(t *testing.T) {
+	m := newChatTUIModel(nil, "session-1", "claude-haiku-4.5", "agent", "anthropic-sdk", nil)
+	m.ready = true
+	m.mainWidth = 80
+	m.viewport = viewport.New(80, 20)
+	m.textarea.Focus()
+	m.streamActive = true
+	m.spinning = true
+	m.agentTurnCancel = func() {}
+
+	toModel := func(model tea.Model) *chatTUIModel {
+		switch v := model.(type) {
+		case chatTUIModel:
+			copy := v
+			return &copy
+		case *chatTUIModel:
+			return v
+		default:
+			t.Fatalf("unexpected model type %T", model)
+			return nil
+		}
+	}
+
+	model, _ := m.Update(agentDoneMsg{})
+	updated := toModel(model)
+	if updated.streamActive {
+		t.Fatal("expected streamActive to be false")
+	}
+	if updated.spinning {
+		t.Fatal("expected spinning to be false")
+	}
+	if len(updated.entries) == 0 {
+		t.Fatal("expected a visible transcript entry")
+	}
+	last := updated.entries[len(updated.entries)-1]
+	if last.kind != transcriptInfo {
+		t.Fatalf("last entry kind = %v, want %v", last.kind, transcriptInfo)
+	}
+	if last.content != "(agent completed with no text response)" {
+		t.Fatalf("last entry content = %q", last.content)
+	}
+}
+
+func TestStreamAgentTurnWithCheckerAllowsEmptyFinalTurnAndDropsPreToolNarration(t *testing.T) {
+	var completionCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/admin/chat/sessions/session-1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":            "session-1",
+				"model_id":      "claude-haiku-4.5",
+				"mode":          "agent",
+				"agent_backend": "anthropic-sdk",
+				"messages":      []map[string]any{{"role": "user", "content": "show disk info"}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/admin/chat/sessions/session-1/messages":
+			_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/messages":
+			completionCalls++
+			if completionCalls == 1 {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":          "msg-1",
+					"type":        "message",
+					"role":        "assistant",
+					"model":       "claude-haiku-4.5",
+					"stop_reason": "tool_use",
+					"usage":       map[string]any{"input_tokens": 10, "output_tokens": 5},
+					"content": []map[string]any{
+						{"type": "text", "text": "I'll get that for you."},
+						{"type": "tool_use", "id": "call-1", "name": "bash", "input": map[string]any{"command": "Write-Output disk-ok"}},
+					},
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          "msg-2",
+				"type":        "message",
+				"role":        "assistant",
+				"model":       "claude-haiku-4.5",
+				"stop_reason": "end_turn",
+				"usage":       map[string]any{"input_tokens": 20, "output_tokens": 1},
+				"content":     []map[string]any{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := &testClient{baseURL: server.URL, http: server.Client()}
+	eventCh, err := StreamAgentTurnWithChecker(context.Background(), client, "session-1", "claude-haiku-4.5", "anthropic-sdk", "show disk info", func(context.Context, toolspkg.PermissionRequest) (bool, error) {
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("StreamAgentTurnWithChecker returned error: %v", err)
+	}
+
+	var finalContent string
+	var toolCalls, toolResults, doneCount int
+	for event := range eventCh {
+		switch event.Type {
+		case "token":
+			finalContent += event.Content
+		case "tool_call":
+			toolCalls++
+			finalContent = ""
+		case "tool_result":
+			toolResults++
+		case "done":
+			doneCount++
+		case "error":
+			t.Fatalf("unexpected error event: %s", event.Content)
+		}
+	}
+
+	if completionCalls != 2 {
+		t.Fatalf("completion calls = %d, want 2", completionCalls)
+	}
+	if toolCalls != 1 {
+		t.Fatalf("toolCalls = %d, want 1", toolCalls)
+	}
+	if toolResults != 1 {
+		t.Fatalf("toolResults = %d, want 1", toolResults)
+	}
+	if doneCount != 1 {
+		t.Fatalf("doneCount = %d, want 1", doneCount)
+	}
+	if finalContent != "" {
+		t.Fatalf("finalContent = %q, want empty final content", finalContent)
+	}
+}
+
+func TestRunAgentTurnWithCheckerReturnsEmptyForToolOnlyCompletion(t *testing.T) {
+	var completionCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/admin/chat/sessions/session-1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":            "session-1",
+				"model_id":      "claude-sonnet-4.5",
+				"mode":          "agent",
+				"agent_backend": "anthropic-sdk",
+				"messages":      []map[string]any{{"role": "user", "content": "show disk info"}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/admin/chat/sessions/session-1/messages":
+			_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/messages":
+			completionCalls++
+			if completionCalls == 1 {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":          "msg-1",
+					"type":        "message",
+					"role":        "assistant",
+					"model":       "claude-sonnet-4.5",
+					"stop_reason": "tool_use",
+					"usage":       map[string]any{"input_tokens": 10, "output_tokens": 5},
+					"content": []map[string]any{{
+						"type":  "tool_use",
+						"id":    "call-1",
+						"name":  "bash",
+						"input": map[string]any{"command": "Write-Output disk-ok"},
+					}},
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          "msg-2",
+				"type":        "message",
+				"role":        "assistant",
+				"model":       "claude-sonnet-4.5",
+				"stop_reason": "end_turn",
+				"usage":       map[string]any{"input_tokens": 20, "output_tokens": 1},
+				"content":     []map[string]any{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := &testClient{baseURL: server.URL, http: server.Client()}
+	content, err := RunAgentTurnWithChecker(context.Background(), client, "session-1", "claude-sonnet-4.5", "anthropic-sdk", "show disk info", func(context.Context, toolspkg.PermissionRequest) (bool, error) {
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("RunAgentTurnWithChecker returned error: %v", err)
+	}
+	if completionCalls != 2 {
+		t.Fatalf("completion calls = %d, want 2", completionCalls)
+	}
+	if content != "" {
+		t.Fatalf("content = %q, want empty string", content)
+	}
+}
+
 func TestTUIHandlesPermissionRequestInTranscript(t *testing.T) {
 	m := newChatTUIModel(nil, "session-1", "gpt-5.4", "agent", "agent-sdk-go", nil)
 	m.ready = true

--- a/internal/chat/repl.go
+++ b/internal/chat/repl.go
@@ -79,6 +79,7 @@ func RunREPL(cmd CommandContext, c Client, requestedModel, existingSession strin
 
 		var assistantContent string
 		if session.Mode == "agent" {
+			sawToolActivity := false
 			eventCh, err := StreamAgentTurnWithChecker(context.Background(), c, session.ID, session.Model, session.AgentBackend, line, makeStdioPermissionChecker(cmd, &session))
 			if err != nil {
 				_, _ = fmt.Fprintf(errOut, "Error: completion: %v\n", err)
@@ -89,8 +90,11 @@ func RunREPL(cmd CommandContext, c Client, requestedModel, existingSession strin
 				case agentpkg.EventToken:
 					assistantContent += event.Content
 				case agentpkg.EventToolCall:
+					sawToolActivity = true
+					assistantContent = ""
 					_, _ = fmt.Fprintf(out, "  [tool: %s]\n", event.Tool)
 				case agentpkg.EventToolResult:
+					sawToolActivity = true
 					result := event.Content
 					if len(result) > 200 {
 						result = result[:200] + "..."
@@ -110,7 +114,10 @@ func RunREPL(cmd CommandContext, c Client, requestedModel, existingSession strin
 				}
 				_, _ = fmt.Fprintln(out, assistantContent)
 				_, _ = fmt.Fprintln(out)
+			} else if sawToolActivity {
+				_, _ = fmt.Fprintln(out, "(agent completed with no text response)")
 			}
+			continue
 		} else {
 			if err := PostMessage(c, session.ID, "user", line); err != nil {
 				_, _ = fmt.Fprintf(errOut, "Error: store message: %v\n", err)

--- a/internal/chat/tui.go
+++ b/internal/chat/tui.go
@@ -792,7 +792,9 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	var vpCmd, taCmd tea.Cmd
 	m.viewport, vpCmd = m.viewport.Update(msg)
-	m.textarea, taCmd = m.textarea.Update(msg)
+	if _, isMouse := msg.(tea.MouseMsg); !isMouse {
+		m.textarea, taCmd = m.textarea.Update(msg)
+	}
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		if m.historySearchMode && !m.streamActive {
 			switch keyMsg.Type {
@@ -829,17 +831,7 @@ func (m chatTUIModel) View() string {
 	main.WriteString(div)
 	main.WriteString("\n")
 	main.WriteString(m.viewport.View())
-	// Scroll position indicator shown when the user has scrolled up.
-	if !m.viewport.AtBottom() {
-		pct := 0
-		if total := m.viewport.TotalLineCount(); total > 0 {
-			pct = int(m.viewport.ScrollPercent() * 100)
-		}
-		main.WriteString("\n")
-		main.WriteString(tuiHelpStyle.Render(fmt.Sprintf("── scroll %d%% ── (PgUp/PgDn to scroll, End to jump to bottom) ──", pct)))
-	} else {
-		main.WriteString("\n")
-	}
+	main.WriteString("\n")
 	main.WriteString(div)
 	main.WriteString("\n")
 	main.WriteString(m.textarea.View())
@@ -1002,12 +994,8 @@ func (m chatTUIModel) renderPickerModal() string {
 }
 
 func (m *chatTUIModel) syncViewport() {
-	atBottom := m.viewport.AtBottom()
 	m.viewport.SetContent(m.renderTranscript())
-	// Only auto-scroll to bottom if the user hasn't scrolled up.
-	if atBottom {
-		m.viewport.GotoBottom()
-	}
+	m.viewport.GotoBottom()
 }
 
 func (m *chatTUIModel) appendEntry(kind transcriptEntryType, content string) {

--- a/internal/chat/tui.go
+++ b/internal/chat/tui.go
@@ -706,7 +706,12 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.syncViewport()
 			return m, nil
 		}
-		m.appendEntry(transcriptAssistant, msg.content)
+		content := strings.TrimSpace(msg.content)
+		if content == "" {
+			m.appendEntry(transcriptInfo, "(agent completed with no text response)")
+		} else {
+			m.appendEntry(transcriptAssistant, content)
+		}
 		m.syncViewport()
 		return m, nil
 	case agentProgressMsg:
@@ -1330,6 +1335,7 @@ func (m *chatTUIModel) sendAndStream(userText string) tea.Cmd {
 				case agentpkg.EventToken:
 					finalContent += event.Content
 				case agentpkg.EventToolCall:
+					finalContent = ""
 					if prog != nil {
 						prog.Send(agentProgressMsg{text: fmt.Sprintf("🔧 Calling tool `%s`…", event.Tool)})
 					}

--- a/internal/providers/copilot/copilot_test.go
+++ b/internal/providers/copilot/copilot_test.go
@@ -821,6 +821,78 @@ data: [DONE]
 	}
 }
 
+func TestCopilotAdapterExecute_AnthropicClaudeHistoryWithToolCallsIncludesEmptyAssistantContent(t *testing.T) {
+	var payload map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":    "chatcmpl_ok",
+			"model": "claude-haiku-4.5",
+			"choices": []map[string]interface{}{{
+				"index": 0,
+				"message": map[string]interface{}{
+					"role":    "assistant",
+					"content": "done",
+				},
+				"finish_reason": "stop",
+			}},
+		})
+	}))
+	defer server.Close()
+
+	provider := NewGitHubCopilotProvider("github-copilot-test", "")
+	provider.baseURL = server.URL
+	provider.token = "test-token"
+	adapter := provider.GetAdapter().(*CopilotAdapter)
+
+	resp, err := adapter.Execute(context.Background(), &cif.CanonicalRequest{
+		Model: "claude-haiku-4.5",
+		Messages: []cif.CIFMessage{
+			cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "date today"}}},
+			cif.CIFAssistantMessage{Role: "assistant", Content: []cif.CIFContentPart{
+				cif.CIFToolCallPart{Type: "tool_call", ToolCallID: "call-1", ToolName: "get_current_time", ToolArguments: map[string]interface{}{}},
+			}},
+			cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{
+				cif.CIFToolResultPart{Type: "tool_result", ToolCallID: "call-1", ToolName: "get_current_time", Content: "2026-05-04T22:14:30+08:00"},
+			}},
+		},
+		Tools: []cif.CIFTool{{Name: "get_current_time", ParametersSchema: map[string]interface{}{"type": "object"}}},
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if resp == nil || resp.ID != "chatcmpl_ok" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+
+	messages, ok := payload["messages"].([]interface{})
+	if !ok || len(messages) < 3 {
+		t.Fatalf("unexpected messages payload: %#v", payload["messages"])
+	}
+	assistantMsg, ok := messages[1].(map[string]interface{})
+	if !ok {
+		t.Fatalf("assistant message has unexpected type: %#v", messages[1])
+	}
+	if assistantMsg["role"] != "assistant" {
+		t.Fatalf("assistant role = %#v", assistantMsg["role"])
+	}
+	if content, ok := assistantMsg["content"].(string); !ok || content != "" {
+		t.Fatalf("assistant content = %#v, want empty string", assistantMsg["content"])
+	}
+	toolCalls, ok := assistantMsg["tool_calls"].([]interface{})
+	if !ok || len(toolCalls) != 1 {
+		t.Fatalf("assistant tool_calls = %#v", assistantMsg["tool_calls"])
+	}
+}
+
 func TestCopilotAdapterExecute_FallsBackToResponsesOnUnsupportedAPIError(t *testing.T) {
 	var paths []string
 

--- a/internal/providers/copilot/payload.go
+++ b/internal/providers/copilot/payload.go
@@ -190,6 +190,9 @@ func (a *CopilotAdapter) convertCIFMessagesToOpenAI(messages []cif.CIFMessage, t
 				openaiMsg["content"] = textBuf.String()
 			}
 			if len(toolCalls) > 0 {
+				if _, ok := openaiMsg["content"]; !ok {
+					openaiMsg["content"] = ""
+				}
 				openaiMsg["tool_calls"] = toolCalls
 			}
 


### PR DESCRIPTION
## Summary

- fix: correct variable name in stream error message and add multi-turn agent matrix tests
- fix: preserve agent tool-loop history and Copilot Claude compatibility
- feat: force initial tool use for local-info prompts on step 0
- fix: remove scroll indicator, always auto-scroll, and route mouse wheel to viewport only

## Test plan
- [x] Verify agent tool-loop history is preserved across multi-turn interactions
- [x] Verify Copilot Claude compatibility is maintained
- [x] Test local-info prompts trigger tool use on step 0
- [x] Confirm auto-scroll works correctly and mouse wheel routes to viewport
- [x] Run multi-turn agent matrix tests to verify no regressions