### PR TITLE
fix: handle Qwen3.5-Plus tool calling quirks on DashScope

### DIFF
--- a/internal/chat/repl.go
+++ b/internal/chat/repl.go
@@ -54,6 +54,11 @@ func RunREPL(cmd CommandContext, c Client, requestedModel, existingSession strin
 			continue
 		}
 
+		if strings.HasPrefix(line, "?") && strings.TrimSpace(line) == "?" {
+			printHelp(cmd.OutOrStdout())
+			continue
+		}
+
 		if strings.HasPrefix(line, "/") {
 			result, err := handleSlashCommand(cmd, c, &session, line)
 			if err != nil {
@@ -78,12 +83,29 @@ func RunREPL(cmd CommandContext, c Client, requestedModel, existingSession strin
 			}
 		}
 
+		if strings.HasPrefix(line, "!") {
+			command, _ := strings.CutPrefix(line, "!")
+			command = strings.TrimSpace(command)
+			if command == "" {
+				continue
+			}
+			result := toolspkg.RunShellCommand(context.Background(), command, 0)
+			if result.IsError {
+				_, _ = fmt.Fprintf(errOut, "%s\n", result.Output)
+			} else {
+				_, _ = fmt.Fprintln(out, result.Output)
+			}
+			continue
+		}
+
 		_, _ = fmt.Fprintln(out, ChatHeader("Assistant", session.IsTTY))
 
 		var assistantContent string
 		if session.Mode == "agent" {
 			sawToolActivity := false
-			eventCh, err := StreamAgentTurnWithChecker(context.Background(), c, session.ID, session.Model, session.AgentBackend, session.APIShape, line, makeStdioPermissionChecker(cmd, &session), 25)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			eventCh, err := StreamAgentTurnWithChecker(ctx, c, session.ID, session.Model, session.AgentBackend, session.APIShape, line, makeStdioPermissionChecker(cmd, &session), 25)
 			if err != nil {
 				_, _ = fmt.Fprintf(errOut, "Error: completion: %v\n", err)
 				continue
@@ -268,7 +290,7 @@ func handleSlashCommand(cmd CommandContext, c Client, session *SessionState, lin
 	case "/clear", "/cls":
 		clearScreen(cmd.OutOrStdout())
 		return replCommandResult{handled: true}, nil
-	case "/help":
+	case "/help", "?":
 		printHelp(cmd.OutOrStdout())
 		return replCommandResult{handled: true}, nil
 	case "/mode":

--- a/internal/chat/tui.go
+++ b/internal/chat/tui.go
@@ -381,6 +381,7 @@ type chatTUIModel struct {
 	entries            []transcriptEntry
 	streamActive       bool
 	streamBuf          string
+	queuedPrompt       string
 	picker             *modelPickerState
 	sessionPicker      *sessionPickerState
 	pendingPermission  *pendingPermissionState
@@ -621,6 +622,21 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.exitHistorySearch()
 				return m, nil
 			}
+			if m.streamActive {
+				m.streamActive = false
+				m.spinning = false
+				m.streamBuf = ""
+				if m.pendingPermission != nil {
+					select {
+					case m.pendingPermission.respCh <- false:
+					default:
+					}
+					m.pendingPermission = nil
+				}
+				m.textarea.Placeholder = m.normalPlaceholder
+				m.appendEntry(transcriptInfo, "(cancelled)")
+				m.syncViewport()
+			}
 			if m.agentTurnCancel != nil {
 				m.agentTurnCancel()
 				m.agentTurnCancel = nil
@@ -665,12 +681,28 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.cyclePromptHistory(1)
 			return m, nil
+		case tea.KeyCtrlJ:
+			if m.textarea.Focused() && !m.streamActive {
+				m.textarea.InsertString("\n")
+				return m, nil
+			}
 		case tea.KeyEnter:
 			if m.historySearchMode {
 				m.exitHistorySearch()
 				return m, nil
 			}
 			if !m.textarea.Focused() || m.streamActive && m.pendingPermission == nil {
+				if m.streamActive && m.pendingPermission == nil {
+					text := strings.TrimSpace(m.textarea.Value())
+					if text == "" {
+						break
+					}
+					m.queuedPrompt = text
+					m.textarea.Reset()
+					m.appendEntry(transcriptInfo, fmt.Sprintf("(queued: %s)", truncateString(text, 60)))
+					m.syncViewport()
+					return m, nil
+				}
 				break
 			}
 			text := strings.TrimSpace(m.textarea.Value())
@@ -684,8 +716,23 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.textarea.Reset()
 			m.resetHistoryNavigation()
 			m.exitHistorySearch()
+			if strings.HasPrefix(text, "?") && strings.TrimSpace(text) == "?" {
+				return m.handleSlash(text)
+			}
 			if strings.HasPrefix(text, "/") {
 				return m.handleSlash(text)
+			}
+			if strings.HasPrefix(text, "!") {
+				command, _ := strings.CutPrefix(text, "!")
+				command = strings.TrimSpace(command)
+				if command == "" {
+					return m, nil
+				}
+				m.appendEntry(transcriptUser, text)
+				result := toolspkg.RunShellCommand(context.Background(), command, 0)
+				m.appendEntry(transcriptAssistant, result.Output)
+				m.syncViewport()
+				return m, nil
 			}
 			m.appendEntry(transcriptUser, text)
 			m.syncViewport()
@@ -724,12 +771,22 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.syncViewport()
 		save := content
-		return m, func() tea.Msg {
+		cmds := []tea.Cmd{func() tea.Msg {
 			if err := PostMessage(m.client, m.sessionID, "assistant", save); err != nil {
 				return appendLineMsg("Warning: failed to save response: " + err.Error())
 			}
 			return appendLineMsg("")
+		}}
+		if m.queuedPrompt != "" {
+			queued := m.queuedPrompt
+			m.queuedPrompt = ""
+			m.appendEntry(transcriptUser, queued)
+			m.streamActive = true
+			m.spinning = true
+			m.streamBuf = ""
+			cmds = append(cmds, m.spinner.Tick, m.sendAndStream(queued))
 		}
+		return m, tea.Batch(cmds...)
 	case agentDoneMsg:
 		m.streamActive = false
 		m.spinning = false
@@ -748,6 +805,15 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.appendEntry(transcriptAssistant, content)
 		}
 		m.syncViewport()
+		if m.queuedPrompt != "" {
+			queued := m.queuedPrompt
+			m.queuedPrompt = ""
+			m.appendEntry(transcriptUser, queued)
+			m.streamActive = true
+			m.spinning = true
+			m.streamBuf = ""
+			return m, tea.Batch(m.spinner.Tick, m.sendAndStream(queued))
+		}
 		return m, nil
 	case agentProgressMsg:
 		m.appendEntry(transcriptInfo, msg.text)
@@ -891,7 +957,7 @@ func (m chatTUIModel) View() string {
 		main.WriteString(status)
 	}
 	main.WriteString("\n")
-	main.WriteString(tuiHelpStyle.Render("Ctrl+C: quit  ↑↓: history  PgUp/PgDn: scroll  Ctrl+R: search  Shift+Tab: autopilot  /help: commands  /apishape: API shape"))
+	main.WriteString(tuiHelpStyle.Render("Ctrl+C: quit  Ctrl+J: newline  ↑↓: history  PgUp/PgDn: scroll  Ctrl+R: search  Shift+Tab: autopilot  /help: commands  /apishape: API shape"))
 
 	base := main.String()
 	if m.sidebarWidth > 0 {
@@ -1559,8 +1625,8 @@ func (m chatTUIModel) handleSlash(text string) (tea.Model, tea.Cmd) {
 		m.entries = nil
 		m.syncViewport()
 		return m, nil
-	case "/help":
-		add(m.renderMD("**Commands:**\n\n- `/help` — show this help\n- `/new [title]` — start a new session\n- `/sessions` — browse and resume a previous session\n- `/session` — show current session info\n- `/mode` — show current mode\n- `/mode <chat|agent>` — switch mode\n- `/apishape` — show agent API request shape\n- `/apishape <anthropic|openai|responses>` — switch agent API request shape\n- `/permissions` — toggle autopilot (auto-approve tool calls)\n- `/model` — show current model\n- `/model <id>` — switch model\n- `/agent` — show current backend and supported backends\n- `/agent <backend>` — switch agent backend (agent-sdk-go, google-adk, anthropic-sdk)\n- `/max-turns [1-100]` — show or set max agent turns (default 25)`r`n- `/models` — open model picker\n- `/clear` or `/cls` — clear the screen\n- `/quit` or `/exit` — quit\n\n**Keyboard shortcuts:**\n\n- `Shift+Tab` — toggle autopilot (auto-approve tool calls)\n- The right-hand panel always shows permission and session status\n"))
+	case "/help", "?":
+		add(m.renderMD("**Commands:**\n\n- `/help` or `?` — show this help\n- `/new [title]` — start a new session\n- `/sessions` — browse and resume a previous session\n- `/session` — show current session info\n- `/mode` — show current mode\n- `/mode <chat|agent>` — switch mode\n- `/apishape` — show agent API request shape\n- `/apishape <anthropic|openai|responses>` — switch agent API request shape\n- `/permissions` — toggle autopilot (auto-approve tool calls)\n- `/model` — show current model\n- `/model <id>` — switch model\n- `/agent` — show current backend and supported backends\n- `/agent <backend>` — switch agent backend (agent-sdk-go, google-adk, anthropic-sdk)\n- `/max-turns [1-100]` — show or set max agent turns (default 25)\n- `/models` — open model picker\n- `/clear` or `/cls` — clear the screen\n- `/quit` or `/exit` — quit\n\n**Keyboard shortcuts:**\n\n- `Shift+Tab` — toggle autopilot (auto-approve tool calls)\n- `Esc` — cancel current running job\n- The right-hand panel always shows permission and session status\n"))
 		return m, nil
 	case "/session":
 		add(m.renderMD(fmt.Sprintf("**Session:** `%s`\n**Mode:** `%s`\n**API Shape:** `%s`\n**Model:** `%s`", m.sessionID, m.mode, formatAPIShape(m.apiShape), m.model)))

--- a/internal/providerdispatch/attempts.go
+++ b/internal/providerdispatch/attempts.go
@@ -1,0 +1,46 @@
+package providerdispatch
+
+import (
+	"fmt"
+	"omnillm/internal/cif"
+	"omnillm/internal/lib/modelrouting"
+)
+
+type CandidateHandler func(candidate *Candidate, providerID string) error
+
+type AttemptErrorHandler func(attempt Attempt, err error)
+
+type AttemptEmptyHandler func(attempt Attempt)
+
+func (e *Executor) TryAttempts(attempts []Attempt, request *cif.CanonicalRequest, cache *modelrouting.ModelCache, resolve ResolveFunc, onEmpty AttemptEmptyHandler, onError AttemptErrorHandler, handle CandidateHandler) error {
+	var lastErr error
+
+	for _, attempt := range attempts {
+		prepared, err := e.PrepareCandidates(attempt, request, cache, resolve)
+		if err != nil {
+			if onError != nil {
+				onError(attempt, err)
+			}
+			return err
+		}
+
+		if len(prepared) == 0 {
+			lastErr = fmt.Errorf("model '%s' not found or no providers available", attempt.RequestedModel)
+			if onEmpty != nil {
+				onEmpty(attempt)
+			}
+			continue
+		}
+
+		for _, preparedCandidate := range prepared {
+			candidate := preparedCandidate.Candidate
+			providerID := preparedCandidate.ProviderID
+			lastErr = handle(candidate, providerID)
+			if lastErr == nil {
+				return nil
+			}
+		}
+	}
+
+	return lastErr
+}

--- a/internal/providerdispatch/executor.go
+++ b/internal/providerdispatch/executor.go
@@ -1,0 +1,117 @@
+package providerdispatch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"omnillm/internal/cif"
+	"omnillm/internal/providers/shared"
+	"omnillm/internal/providers/types"
+)
+
+type upstreamAPIReporter interface {
+	UpstreamAPI(request *cif.CanonicalRequest, model string) string
+}
+
+type Candidate struct {
+	Provider       types.Provider
+	Adapter        types.ProviderAdapter
+	Request        *cif.CanonicalRequest
+	CanonicalModel string
+	UpstreamModel  string
+	UpstreamAPI    string
+}
+
+type PrepareFunc func(provider types.Provider, request *cif.CanonicalRequest)
+type FallbackFunc func(request *cif.CanonicalRequest) bool
+
+type Executor struct {
+	PrepareRequest       PrepareFunc
+	DefaultUpstreamAPI   func(providerID, model string) string
+}
+
+func NewExecutor(prepare PrepareFunc, defaultUpstreamAPI func(providerID, model string) string) *Executor {
+	return &Executor{
+		PrepareRequest:     prepare,
+		DefaultUpstreamAPI: defaultUpstreamAPI,
+	}
+}
+
+func (e *Executor) BuildCandidate(provider types.Provider, request *cif.CanonicalRequest) (*Candidate, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("provider is nil")
+	}
+	adapter := provider.GetAdapter()
+	if adapter == nil {
+		return nil, fmt.Errorf("provider %q has no adapter", provider.GetInstanceID())
+	}
+
+	providerRequest := *request
+	if e.PrepareRequest != nil {
+		e.PrepareRequest(provider, &providerRequest)
+	}
+
+	canonicalModel := providerRequest.Model
+	upstreamModel := adapter.RemapModel(providerRequest.Model)
+	providerRequest.Model = upstreamModel
+
+	return &Candidate{
+		Provider:       provider,
+		Adapter:        adapter,
+		Request:        &providerRequest,
+		CanonicalModel: canonicalModel,
+		UpstreamModel:  upstreamModel,
+		UpstreamAPI:    e.detectUpstreamAPI(provider.GetID(), adapter, &providerRequest, upstreamModel),
+	}, nil
+}
+
+func (e *Executor) Execute(ctx context.Context, candidate *Candidate) (*cif.CanonicalResponse, error) {
+	response, err := candidate.Adapter.Execute(ctx, candidate.Request)
+	if err != nil {
+		return nil, fmt.Errorf("adapter execute failed: %w", err)
+	}
+	return response, nil
+}
+
+func (e *Executor) ExecuteStream(ctx context.Context, candidate *Candidate) (<-chan cif.CIFStreamEvent, error) {
+	eventCh, err := candidate.Adapter.ExecuteStream(ctx, candidate.Request)
+	if err != nil {
+		return nil, err
+	}
+	return eventCh, nil
+}
+
+func (e *Executor) detectUpstreamAPI(providerID string, adapter types.ProviderAdapter, request *cif.CanonicalRequest, model string) string {
+	if reporter, ok := adapter.(upstreamAPIReporter); ok {
+		return reporter.UpstreamAPI(request, model)
+	}
+	if e.DefaultUpstreamAPI != nil {
+		return e.DefaultUpstreamAPI(providerID, model)
+	}
+	return "chat.completions"
+}
+
+func DefaultUpstreamAPI(providerID, model string) string {
+	if providerID == "azure-openai" && strings.Contains(strings.ToLower(model), "gpt-5.4") {
+		return "responses"
+	}
+	return "chat.completions"
+}
+
+func ApplyGitHubCopilotSingleUpstreamMode(provider types.Provider, request *cif.CanonicalRequest) {
+	if provider == nil || request == nil || provider.GetID() != string(types.ProviderGitHubCopilot) {
+		return
+	}
+
+	if request.Extensions == nil {
+		request.Extensions = &cif.Extensions{}
+	}
+
+	trueValue := true
+	if !shared.IsGPT5Family(request.Model) {
+		request.Extensions.ForceChatCompletions = &trueValue
+	}
+	request.Extensions.DisableAuthRetry = &trueValue
+	request.Extensions.DisableStreamingFallback = &trueValue
+}

--- a/internal/providerdispatch/prepare.go
+++ b/internal/providerdispatch/prepare.go
@@ -1,0 +1,57 @@
+package providerdispatch
+
+import (
+	"fmt"
+	"omnillm/internal/cif"
+	"omnillm/internal/lib/modelrouting"
+)
+
+type Attempt struct {
+	RequestedModel  string
+	NormalizedModel string
+	ProviderID      string
+}
+
+type ResolveFunc func(requestedModel, normalizedModel, providerID string, cache *modelrouting.ModelCache) (*modelrouting.ResolvedModelRoute, error)
+
+type PreparedCandidate struct {
+	Candidate  *Candidate
+	ProviderID string
+}
+
+func (e *Executor) PrepareCandidates(attempt Attempt, request *cif.CanonicalRequest, cache *modelrouting.ModelCache, resolve ResolveFunc) ([]PreparedCandidate, error) {
+	if request == nil {
+		return nil, fmt.Errorf("request is nil")
+	}
+	if resolve == nil {
+		return nil, fmt.Errorf("resolve function is nil")
+	}
+
+	modelRoute, err := resolve(attempt.RequestedModel, attempt.NormalizedModel, attempt.ProviderID, cache)
+	if err != nil {
+		return nil, err
+	}
+	if len(modelRoute.CandidateProviders) == 0 {
+		return nil, nil
+	}
+
+	attemptRequest := *request
+	attemptRequest.Model = attempt.RequestedModel
+	if attempt.ProviderID == "" && attempt.NormalizedModel != attemptRequest.Model {
+		attemptRequest.Model = attempt.NormalizedModel
+	}
+
+	prepared := make([]PreparedCandidate, 0, len(modelRoute.CandidateProviders))
+	for _, provider := range modelRoute.CandidateProviders {
+		candidate, err := e.BuildCandidate(provider, &attemptRequest)
+		if err != nil {
+			continue
+		}
+		prepared = append(prepared, PreparedCandidate{
+			Candidate:  candidate,
+			ProviderID: provider.GetInstanceID(),
+		})
+	}
+
+	return prepared, nil
+}

--- a/internal/providers/alibaba/adapter_models.go
+++ b/internal/providers/alibaba/adapter_models.go
@@ -83,10 +83,11 @@ func (a *Adapter) buildRequest(request *cif.CanonicalRequest, stream bool) (*ope
 		delete(extras, "enable_thinking")
 	}
 
-	// Non-reasoning third-party models (e.g. GLM) on DashScope require
-	// enable_thinking to be explicitly set to false when tools are present;
-	// omitting the flag causes a 400 "Required body invalid" error.
-	if !IsReasoningModel(model) && len(request.Tools) > 0 {
+	// Non-reasoning Qwen models require enable_thinking to be explicitly set
+	// to false when tools are present; omitting the flag causes a 400 error.
+	// Third-party models (GLM, Qwen3.5-Plus) do not support enable_thinking
+	// at all — skip it for those.
+	if !IsReasoningModel(model) && !isNonReasoningToolModel(model) && len(request.Tools) > 0 {
 		extras["enable_thinking"] = false
 	}
 
@@ -106,10 +107,20 @@ func (a *Adapter) buildRequest(request *cif.CanonicalRequest, stream bool) (*ope
 	if isQwenReasoningModel(model) && len(request.Tools) > 0 {
 		chatReq.ToolChoice = nil
 	}
+	// Non-reasoning third-party models (e.g. GLM, Qwen3.5-Plus) on DashScope
+	// reject tool_choice entirely when tools are present.
+	if isNonReasoningToolModel(model) && len(request.Tools) > 0 {
+		chatReq.ToolChoice = nil
+	}
 	// Non-reasoning models (e.g. GLM) do not support reasoning_content in
 	// request messages. Strip it to avoid 400 errors.
 	if !IsReasoningModel(model) {
 		stripReasoningContent(chatReq.Messages)
+	}
+	// Non-reasoning third-party models require explicit empty content for
+	// tool-only assistant messages; omitting content (nil) causes a 400 error.
+	if isNonReasoningToolModel(model) && len(request.Tools) > 0 {
+		ensureToolAssistantContent(chatReq.Messages)
 	}
 	return chatReq, nil
 }
@@ -117,6 +128,14 @@ func (a *Adapter) buildRequest(request *cif.CanonicalRequest, stream bool) (*ope
 func stripReasoningContent(messages []openaicompat.Message) {
 	for i := range messages {
 		messages[i].ReasoningContent = ""
+	}
+}
+
+func ensureToolAssistantContent(messages []openaicompat.Message) {
+	for i := range messages {
+		if messages[i].Role == "assistant" && messages[i].Content == nil && len(messages[i].ToolCalls) > 0 {
+			messages[i].Content = ""
+		}
 	}
 }
 

--- a/internal/providers/alibaba/adapter_models.go
+++ b/internal/providers/alibaba/adapter_models.go
@@ -62,12 +62,32 @@ func (a *Adapter) buildRequest(request *cif.CanonicalRequest, stream bool) (*ope
 	defTopP := 1.0
 
 	extras := map[string]any{}
-	if IsReasoningModel(model) && len(request.Tools) == 0 {
-		extras["enable_thinking"] = true
+	if IsReasoningModel(model) {
+		if len(request.Tools) == 0 {
+			extras["enable_thinking"] = true
+		} else {
+			// DashScope reasoning models require explicit opt-out when
+			// tools are present; omitting the flag causes a 400 error.
+			extras["enable_thinking"] = false
+		}
 	}
-	if isDeepSeekV4Model(model) && len(request.Tools) > 0 {
+	if isDeepSeekV4ModelID(model) && len(request.Tools) > 0 {
 		delete(extras, "enable_thinking")
 		extras["thinking"] = map[string]any{"type": "disabled"}
+	}
+
+	// Qwen reasoning models reject tool_choice="required" or object-style
+	// tool_choice when thinking mode is active. Strip tool_choice entirely
+	// so the upstream defaults to "auto".
+	if isQwenReasoningModel(model) && len(request.Tools) > 0 {
+		delete(extras, "enable_thinking")
+	}
+
+	// Non-reasoning third-party models (e.g. GLM) on DashScope require
+	// enable_thinking to be explicitly set to false when tools are present;
+	// omitting the flag causes a 400 "Required body invalid" error.
+	if !IsReasoningModel(model) && len(request.Tools) > 0 {
+		extras["enable_thinking"] = false
 	}
 
 	cfg := openaicompat.Config{
@@ -80,15 +100,24 @@ func (a *Adapter) buildRequest(request *cif.CanonicalRequest, stream bool) (*ope
 	if err != nil {
 		return nil, err
 	}
-	if isDeepSeekV4Model(model) && len(request.Tools) > 0 {
+	if isDeepSeekV4ModelID(model) && len(request.Tools) > 0 {
 		chatReq.ToolChoice = nil
+	}
+	if isQwenReasoningModel(model) && len(request.Tools) > 0 {
+		chatReq.ToolChoice = nil
+	}
+	// Non-reasoning models (e.g. GLM) do not support reasoning_content in
+	// request messages. Strip it to avoid 400 errors.
+	if !IsReasoningModel(model) {
+		stripReasoningContent(chatReq.Messages)
 	}
 	return chatReq, nil
 }
 
-func isDeepSeekV4Model(modelID string) bool {
-	lower := strings.ToLower(strings.TrimSpace(modelID))
-	return strings.Contains(lower, "deepseek-v4")
+func stripReasoningContent(messages []openaicompat.Message) {
+	for i := range messages {
+		messages[i].ReasoningContent = ""
+	}
 }
 
 // ErrHardcodedFallback is returned alongside a hardcoded model list when the

--- a/internal/providers/alibaba/provider.go
+++ b/internal/providers/alibaba/provider.go
@@ -29,6 +29,7 @@ var Models = []types.Model{
 	{ID: "qwen3-235b-a22b-instruct", Name: "Qwen3-235B-A22B Instruct", MaxTokens: 131072, Provider: "alibaba"},
 	{ID: "qwen-plus", Name: "Qwen Plus", MaxTokens: 131072, Provider: "alibaba"},
 	{ID: "qwen-turbo", Name: "Qwen Turbo", MaxTokens: 1000000, Provider: "alibaba"},
+	{ID: "glm-5.1", Name: "GLM 5.1", MaxTokens: 131072, Provider: "alibaba"},
 	// DeepSeek models available via DashScope — used as metadata enrichment when
 	// FetchModelsFromAPI returns them from the live /models endpoint.
 	{ID: "deepseek-v3", Name: "DeepSeek V3", MaxTokens: 65536, Provider: "alibaba"},
@@ -36,6 +37,38 @@ var Models = []types.Model{
 	{ID: "deepseek-r1", Name: "DeepSeek R1", MaxTokens: 65536, Provider: "alibaba"},
 	{ID: "deepseek-r1-0528", Name: "DeepSeek R1 0528", MaxTokens: 65536, Provider: "alibaba"},
 }
+
+var reasoningModelIDs = map[string]struct{}{
+	"qwen3.6-plus":               {},
+	"qwen3-coder-next":           {},
+	"qwen3-coder-plus":           {},
+	"qwen3-coder-flash":          {},
+	"qwen3-max":                  {},
+	"qwen3-max-preview":          {},
+	"qwen3-32b":                  {},
+	"qwen3-235b-a22b-instruct":   {},
+	"qwen-plus":                  {},
+	"deepseek-r1":                {},
+	"deepseek-r1-0528":           {},
+	"deepseek-v4-flash":          {},
+}
+
+var qwenReasoningModelIDs = map[string]struct{}{
+	"qwen3.6-plus":             {},
+	"qwen3-coder-next":         {},
+	"qwen3-coder-plus":         {},
+	"qwen3-coder-flash":        {},
+	"qwen3-max":                {},
+	"qwen3-max-preview":        {},
+	"qwen3-32b":                {},
+	"qwen3-235b-a22b-instruct": {},
+	"qwen-plus":                {},
+}
+
+var deepSeekV4ModelIDs = map[string]struct{}{
+	"deepseek-v4-flash": {},
+}
+
 
 // Provider implements types.Provider for Alibaba DashScope.
 type Provider struct {
@@ -367,23 +400,27 @@ func IsChatCompletionsModel(modelID string) bool {
 }
 
 // IsReasoningModel returns true for models that support extended thinking /
-// chain-of-thought via the enable_thinking parameter. This covers Qwen3 and
-// DeepSeek families.
+// chain-of-thought via the enable_thinking parameter.
 func IsReasoningModel(modelID string) bool {
-	lower := strings.ToLower(modelID)
-	return strings.Contains(lower, "qwen3") ||
-		strings.Contains(lower, "qwq") ||
-		strings.Contains(lower, "qwen-plus") ||
-		strings.Contains(lower, "qwen3.5") ||
-		strings.Contains(lower, "qwen3.6") ||
-		strings.Contains(lower, "deepseek-r1") ||
-		strings.Contains(lower, "deepseek-v4")
+	_, ok := reasoningModelIDs[strings.ToLower(RemapModel(modelID))]
+	return ok
+}
+
+func isQwenReasoningModel(modelID string) bool {
+	_, ok := qwenReasoningModelIDs[strings.ToLower(RemapModel(modelID))]
+	return ok
+}
+
+func isDeepSeekV4ModelID(modelID string) bool {
+	_, ok := deepSeekV4ModelIDs[strings.ToLower(RemapModel(modelID))]
+	return ok
 }
 
 // ModelMetadata returns hardcoded metadata for a known model ID.
 func ModelMetadata(modelID string) (types.Model, bool) {
+	remapped := strings.ToLower(RemapModel(modelID))
 	for _, m := range Models {
-		if m.ID == modelID {
+		if m.ID == remapped {
 			return m, true
 		}
 	}

--- a/internal/providers/alibaba/provider.go
+++ b/internal/providers/alibaba/provider.go
@@ -19,6 +19,7 @@ const AlibabaAPIModeOpenAICompatible = "openai-compatible"
 
 var Models = []types.Model{
 	{ID: "qwen3.6-plus", Name: "Qwen3.6 Plus", MaxTokens: 131072, Provider: "alibaba"},
+	{ID: "qwen3.5-plus", Name: "Qwen3.5 Plus", MaxTokens: 131072, Provider: "alibaba"},
 	{ID: "qwen3.5-omni-flash", Name: "Qwen3.5 Omni Flash", MaxTokens: 131072, Provider: "alibaba"},
 	{ID: "qwen3-coder-next", Name: "Qwen3 Coder Next", MaxTokens: 131072, Provider: "alibaba"},
 	{ID: "qwen3-coder-plus", Name: "Qwen3 Coder Plus", MaxTokens: 131072, Provider: "alibaba"},
@@ -67,6 +68,15 @@ var qwenReasoningModelIDs = map[string]struct{}{
 
 var deepSeekV4ModelIDs = map[string]struct{}{
 	"deepseek-v4-flash": {},
+}
+
+// nonReasoningToolModelIDs are models that are NOT reasoning models but require
+// special tool handling when tools are present on DashScope. These are typically
+// third-party models (GLM, Qwen3.5-Plus) that reject tool_choice and require
+// explicit empty content for tool-only assistant messages.
+var nonReasoningToolModelIDs = map[string]struct{}{
+	"qwen3.5-plus": {},
+	"glm-5.1":      {},
 }
 
 
@@ -413,6 +423,11 @@ func isQwenReasoningModel(modelID string) bool {
 
 func isDeepSeekV4ModelID(modelID string) bool {
 	_, ok := deepSeekV4ModelIDs[strings.ToLower(RemapModel(modelID))]
+	return ok
+}
+
+func isNonReasoningToolModel(modelID string) bool {
+	_, ok := nonReasoningToolModelIDs[strings.ToLower(RemapModel(modelID))]
 	return ok
 }
 

--- a/internal/providers/alibaba/provider_test.go
+++ b/internal/providers/alibaba/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"omnillm/internal/cif"
 	"omnillm/internal/database"
+	"omnillm/internal/providers/openaicompat"
 	"omnillm/internal/providers/types"
 	"os"
 	"strings"
@@ -376,7 +377,7 @@ func TestAlibabaBuildRequestDeepSeekV4ToolsDisablesThinkingAndOmitsToolChoice(t 
 	}
 }
 
-func TestAlibabaBuildRequestGLMToolsDisablesThinkingAndStripsReasoningContent(t *testing.T) {
+func TestAlibabaBuildRequestGLMToolsOmitsToolChoiceAndSetsEmptyContent(t *testing.T) {
 	p := NewProvider("alibaba-test-glm", "Alibaba Test")
 	adapter := &Adapter{provider: p}
 
@@ -416,11 +417,11 @@ func TestAlibabaBuildRequestGLMToolsDisablesThinkingAndStripsReasoningContent(t 
 	if chatReq.Model != "glm-5.1" {
 		t.Fatalf("model = %q, want glm-5.1", chatReq.Model)
 	}
-	if chatReq.ToolChoice != "auto" {
-		t.Fatalf("expected GLM upstream tool_choice to remain auto, got %#v", chatReq.ToolChoice)
+	if chatReq.ToolChoice != nil {
+		t.Fatalf("expected GLM upstream tool_choice to be omitted, got %#v", chatReq.ToolChoice)
 	}
-	if val, ok := chatReq.Extras["enable_thinking"]; !ok || val != false {
-		t.Fatalf("expected enable_thinking=false for GLM tools, got %#v", chatReq.Extras)
+	if _, exists := chatReq.Extras["enable_thinking"]; exists {
+		t.Fatalf("enable_thinking must not be sent for GLM tools, got %#v", chatReq.Extras)
 	}
 	if len(chatReq.Messages) == 0 {
 		t.Fatalf("expected messages to be present")
@@ -428,8 +429,154 @@ func TestAlibabaBuildRequestGLMToolsDisablesThinkingAndStripsReasoningContent(t 
 	if chatReq.Messages[0].ReasoningContent != "" {
 		t.Fatalf("expected reasoning_content to be stripped for GLM, got %q", chatReq.Messages[0].ReasoningContent)
 	}
-	if chatReq.Messages[0].Content != nil {
-		t.Fatalf("expected tool-only assistant content to be omitted, got %#v", chatReq.Messages[0].Content)
+	content, ok := chatReq.Messages[0].Content.(string)
+	if !ok {
+		t.Fatalf("expected assistant tool-only content to be empty string, got %#v (type %T)", chatReq.Messages[0].Content, chatReq.Messages[0].Content)
+	}
+	if content != "" {
+		t.Fatalf("expected assistant tool-only content to be empty string, got %q", content)
+	}
+}
+
+// ─── Qwen3.5-Plus tools ─────────────────────────────────────────────────────
+
+func TestAlibabaBuildRequestQwen35PlusToolsHandling(t *testing.T) {
+	p := NewProvider("alibaba-test-qwen35", "Alibaba Test")
+	adapter := &Adapter{provider: p}
+
+	for _, model := range []string{"qwen3.5-plus", "alibaba-sk-ab2c5/qwen3.5-plus"} {
+		t.Run(model, func(t *testing.T) {
+			req := &cif.CanonicalRequest{
+				Model: model,
+				Messages: []cif.CIFMessage{
+					cif.CIFAssistantMessage{
+						Role: "assistant",
+						Content: []cif.CIFContentPart{
+							cif.CIFThinkingPart{Type: "thinking", Thinking: "hidden reasoning"},
+							cif.CIFToolCallPart{
+								Type:          "tool_call",
+								ToolCallID:    "call_ls",
+								ToolName:      "ls",
+								ToolArguments: map[string]interface{}{"path": "."},
+							},
+						},
+					},
+					cif.CIFUserMessage{
+						Role: "user",
+						Content: []cif.CIFContentPart{
+							cif.CIFTextPart{Type: "text", Text: "List files"},
+						},
+					},
+				},
+				Tools: []cif.CIFTool{{
+					Name:             "ls",
+					ParametersSchema: map[string]interface{}{"type": "object", "properties": map[string]interface{}{}},
+				}},
+				ToolChoice: "auto",
+			}
+
+			chatReq, err := adapter.buildRequest(req, false)
+			if err != nil {
+				t.Fatalf("buildRequest returned error: %v", err)
+			}
+			if chatReq.Model != "qwen3.5-plus" {
+				t.Fatalf("model = %q, want qwen3.5-plus", chatReq.Model)
+			}
+			if chatReq.ToolChoice != nil {
+				t.Fatalf("expected qwen3.5-plus upstream tool_choice to be omitted, got %#v", chatReq.ToolChoice)
+			}
+			if _, exists := chatReq.Extras["enable_thinking"]; exists {
+				t.Fatalf("enable_thinking must not be sent for non-reasoning tool models, got %#v", chatReq.Extras)
+			}
+			if chatReq.Messages[0].ReasoningContent != "" {
+				t.Fatalf("expected reasoning_content to be stripped for qwen3.5-plus, got %q", chatReq.Messages[0].ReasoningContent)
+			}
+			content, ok := chatReq.Messages[0].Content.(string)
+			if !ok {
+				t.Fatalf("expected tool-only assistant content to be empty string, got %#v", chatReq.Messages[0].Content)
+			}
+			if content != "" {
+				t.Fatalf("expected tool-only assistant content to be empty string, got %q", content)
+			}
+		})
+	}
+}
+
+// ─── Non-reasoning model without tools ───────────────────────────────────────
+
+func TestAlibabaBuildRequestNonReasoningModelWithoutToolsStillWorks(t *testing.T) {
+	p := NewProvider("alibaba-test-glm", "Alibaba Test")
+	adapter := &Adapter{provider: p}
+
+	req := &cif.CanonicalRequest{
+		Model: "glm-5.1",
+		Messages: []cif.CIFMessage{
+			cif.CIFUserMessage{
+				Role: "user",
+				Content: []cif.CIFContentPart{
+					cif.CIFTextPart{Type: "text", Text: "Hello"},
+				},
+			},
+		},
+	}
+
+	chatReq, err := adapter.buildRequest(req, false)
+	if err != nil {
+		t.Fatalf("buildRequest returned error: %v", err)
+	}
+	if _, exists := chatReq.Extras["enable_thinking"]; exists {
+		t.Fatalf("enable_thinking must not be set when no tools, got %#v", chatReq.Extras)
+	}
+	if chatReq.ToolChoice != nil {
+		t.Fatalf("tool_choice must be nil when not provided, got %#v", chatReq.ToolChoice)
+	}
+	if chatReq.Messages[0].Content != "Hello" {
+		t.Fatalf("content = %#v, want Hello", chatReq.Messages[0].Content)
+	}
+}
+
+// ─── isNonReasoningToolModel ─────────────────────────────────────────────────
+
+func TestIsNonReasoningToolModel(t *testing.T) {
+	cases := []struct {
+		modelID string
+		want    bool
+	}{
+		{"qwen3.5-plus", true},
+		{"glm-5.1", true},
+		{"QWEN3.5-PLUS", true},
+		{"alibaba-sk-ab2c5/qwen3.5-plus", true},
+		{"qwen3-max", false},
+		{"qwen-turbo", false},
+		{"deepseek-v4-flash", false},
+		{"gpt-4o", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := isNonReasoningToolModel(tc.modelID)
+		if got != tc.want {
+			t.Errorf("isNonReasoningToolModel(%q) = %v, want %v", tc.modelID, got, tc.want)
+		}
+	}
+}
+
+// ─── ensureToolAssistantContent ──────────────────────────────────────────────
+
+func TestEnsureToolAssistantContent(t *testing.T) {
+	messages := []openaicompat.Message{
+		{Role: "assistant", ToolCalls: []openaicompat.ToolCall{{ID: "call_1"}}},
+		{Role: "assistant", Content: "Hello"},
+		{Role: "user", Content: "Hi"},
+	}
+	ensureToolAssistantContent(messages)
+	if messages[0].Content != "" {
+		t.Fatalf("expected empty string content for tool-only assistant, got %#v", messages[0].Content)
+	}
+	if messages[1].Content != "Hello" {
+		t.Fatalf("expected 'Hello' unchanged, got %#v", messages[1].Content)
+	}
+	if messages[2].Content != "Hi" {
+		t.Fatalf("expected 'Hi' unchanged, got %#v", messages[2].Content)
 	}
 }
 

--- a/internal/providers/alibaba/provider_test.go
+++ b/internal/providers/alibaba/provider_test.go
@@ -309,13 +309,13 @@ func TestIsReasoningModel(t *testing.T) {
 		{"qwen3-max", true},
 		{"qwen3-coder-plus", true},
 		{"qwen3-235b-a22b-instruct", true},
-		{"qwq-32b", true},
 		{"qwen-plus", true},
-		{"qwen3.5-plus", true},
 		{"qwen3.6-plus", true},
 		{"deepseek-r1", true},
+		{"deepseek-r1-0528", true},
 		{"deepseek-v4-flash", true},
 		{"QWEN3-MAX", true},
+		{"glm-5.1", false},
 		{"qwen2-5-72b-instruct", false},
 		{"qwen-turbo", false},
 		{"gpt-4o", false},
@@ -373,6 +373,63 @@ func TestAlibabaBuildRequestDeepSeekV4ToolsDisablesThinkingAndOmitsToolChoice(t 
 				t.Fatalf("expected thinking.type=disabled, got %#v", thinking)
 			}
 		})
+	}
+}
+
+func TestAlibabaBuildRequestGLMToolsDisablesThinkingAndStripsReasoningContent(t *testing.T) {
+	p := NewProvider("alibaba-test-glm", "Alibaba Test")
+	adapter := &Adapter{provider: p}
+
+	req := &cif.CanonicalRequest{
+		Model: "alibaba-sk-ab2c5/glm-5.1",
+		Messages: []cif.CIFMessage{
+			cif.CIFAssistantMessage{
+				Role: "assistant",
+				Content: []cif.CIFContentPart{
+					cif.CIFThinkingPart{Type: "thinking", Thinking: "hidden reasoning"},
+					cif.CIFToolCallPart{
+						Type:          "tool_call",
+						ToolCallID:    "call_ls",
+						ToolName:      "ls",
+						ToolArguments: map[string]interface{}{"path": "."},
+					},
+				},
+			},
+			cif.CIFUserMessage{
+				Role: "user",
+				Content: []cif.CIFContentPart{
+					cif.CIFTextPart{Type: "text", Text: "List files"},
+				},
+			},
+		},
+		Tools: []cif.CIFTool{{
+			Name:             "ls",
+			ParametersSchema: map[string]interface{}{"type": "object", "properties": map[string]interface{}{}},
+		}},
+		ToolChoice: "auto",
+	}
+
+	chatReq, err := adapter.buildRequest(req, false)
+	if err != nil {
+		t.Fatalf("buildRequest returned error: %v", err)
+	}
+	if chatReq.Model != "glm-5.1" {
+		t.Fatalf("model = %q, want glm-5.1", chatReq.Model)
+	}
+	if chatReq.ToolChoice != "auto" {
+		t.Fatalf("expected GLM upstream tool_choice to remain auto, got %#v", chatReq.ToolChoice)
+	}
+	if val, ok := chatReq.Extras["enable_thinking"]; !ok || val != false {
+		t.Fatalf("expected enable_thinking=false for GLM tools, got %#v", chatReq.Extras)
+	}
+	if len(chatReq.Messages) == 0 {
+		t.Fatalf("expected messages to be present")
+	}
+	if chatReq.Messages[0].ReasoningContent != "" {
+		t.Fatalf("expected reasoning_content to be stripped for GLM, got %q", chatReq.Messages[0].ReasoningContent)
+	}
+	if chatReq.Messages[0].Content != nil {
+		t.Fatalf("expected tool-only assistant content to be omitted, got %#v", chatReq.Messages[0].Content)
 	}
 }
 

--- a/internal/providers/copilot/adapter.go
+++ b/internal/providers/copilot/adapter.go
@@ -310,7 +310,21 @@ func (a *CopilotAdapter) responsesURL() string {
 }
 
 func (a *CopilotAdapter) buildResponsesPayload(request *cif.CanonicalRequest, stream bool) map[string]interface{} {
-	return openaicompat.BuildResponsesPayload(a.RemapModel(request.Model), request, stream, openaicompat.ResponsesConfig{})
+	payload := openaicompat.BuildResponsesPayload(a.RemapModel(request.Model), request, stream, openaicompat.ResponsesConfig{})
+	model := a.RemapModel(request.Model)
+	if shared.IsReasoningModel(model) {
+		delete(payload, "temperature")
+		delete(payload, "top_p")
+	}
+	if request != nil && request.MaxTokens != nil && *request.MaxTokens > 0 {
+		if copilotModelUsesMaxCompletionTokens(model) {
+			delete(payload, "max_output_tokens")
+			payload["max_completion_tokens"] = *request.MaxTokens
+		} else if *request.MaxTokens < 16 {
+			payload["max_output_tokens"] = 16
+		}
+	}
+	return payload
 }
 
 func (a *CopilotAdapter) executeResponses(ctx context.Context, request *cif.CanonicalRequest) (*cif.CanonicalResponse, error) {

--- a/internal/providers/copilot/copilot_test.go
+++ b/internal/providers/copilot/copilot_test.go
@@ -157,6 +157,37 @@ func TestCopilotAdapterExecute_StripsThinkingPartsFromPayload(t *testing.T) {
 	}
 }
 
+func TestCopilotBuildResponsesPayloadOwnsReasoningSamplingAndTokenFields(t *testing.T) {
+	provider := NewGitHubCopilotProvider("github-copilot-test", "")
+	adapter := provider.GetAdapter().(*CopilotAdapter)
+	temperature := 0.7
+	topP := 0.8
+	maxTokens := 8
+
+	payload := adapter.buildResponsesPayload(&cif.CanonicalRequest{
+		Model:       "gpt-5-mini",
+		Temperature: &temperature,
+		TopP:        &topP,
+		MaxTokens:   &maxTokens,
+		Messages: []cif.CIFMessage{
+			cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "ping"}}},
+		},
+	}, false)
+
+	if _, ok := payload["temperature"]; ok {
+		t.Fatalf("expected temperature to be omitted for reasoning model, got %#v", payload["temperature"])
+	}
+	if _, ok := payload["top_p"]; ok {
+		t.Fatalf("expected top_p to be omitted for reasoning model, got %#v", payload["top_p"])
+	}
+	if _, ok := payload["max_output_tokens"]; ok {
+		t.Fatalf("expected max_output_tokens to be absent for gpt-5 responses payload, got %#v", payload["max_output_tokens"])
+	}
+	if got, ok := payload["max_completion_tokens"].(int); !ok || got != maxTokens {
+		t.Fatalf("expected max_completion_tokens=%d, got %#v", maxTokens, payload["max_completion_tokens"])
+	}
+}
+
 func TestCopilotAdapterExecuteStream_RefreshesTokenAndRetriesOnUnauthorized(t *testing.T) {
 	var requestCalls int
 

--- a/internal/providers/kimi/adapter_test.go
+++ b/internal/providers/kimi/adapter_test.go
@@ -22,8 +22,12 @@ func TestBuildOpenAIPayloadThinkingModelDisablesThinkingInsteadOfSendingToolChoi
 		}},
 		ToolChoice: "required",
 	}, false)
-	if val, ok := payload["thinking"]; !ok || val != false {
-		t.Fatalf("expected thinking=false for Kimi thinking tool turn, got %v (present=%v)", val, ok)
+	if val, ok := payload["thinking"]; !ok {
+		t.Fatalf("expected thinking to be present for Kimi thinking tool turn")
+	} else if thinkingMap, ok := val.(map[string]any); !ok {
+		t.Fatalf("expected thinking to be a map[string]any, got %T", val)
+	} else if thinkingMap["type"] != "disabled" {
+		t.Fatalf("expected thinking.type=disabled, got %v", thinkingMap["type"])
 	}
 	if _, ok := payload["tool_choice"]; ok {
 		t.Fatalf("expected tool_choice to be omitted for Kimi thinking tool turn, got %#v", payload["tool_choice"])

--- a/internal/providers/kimi/provider.go
+++ b/internal/providers/kimi/provider.go
@@ -521,7 +521,7 @@ func BuildOpenAIPayload(model string, messages []map[string]interface{}, request
 	if request.ToolChoice != nil {
 		if toolChoice := shared.ConvertCanonicalToolChoiceToOpenAI(request.ToolChoice); toolChoice != nil {
 			if IsThinkingModel(model) && len(request.Tools) > 0 {
-				payload["thinking"] = false
+				payload["thinking"] = map[string]any{"type": "disabled"}
 			} else {
 				payload["tool_choice"] = toolChoice
 			}

--- a/internal/providers/openaicompat/responses.go
+++ b/internal/providers/openaicompat/responses.go
@@ -75,24 +75,18 @@ func BuildResponsesPayload(model string, request *cif.CanonicalRequest, stream b
 		payload["instructions"] = *request.SystemPrompt
 	}
 
-	if !shared.IsReasoningModel(model) {
-		if request.Temperature != nil {
-			payload["temperature"] = *request.Temperature
-		} else if cfg.DefaultTemperature != nil {
-			payload["temperature"] = *cfg.DefaultTemperature
-		}
-		if request.TopP != nil {
-			payload["top_p"] = *request.TopP
-		} else if cfg.DefaultTopP != nil {
-			payload["top_p"] = *cfg.DefaultTopP
-		}
+	if request.Temperature != nil {
+		payload["temperature"] = *request.Temperature
+	} else if cfg.DefaultTemperature != nil {
+		payload["temperature"] = *cfg.DefaultTemperature
+	}
+	if request.TopP != nil {
+		payload["top_p"] = *request.TopP
+	} else if cfg.DefaultTopP != nil {
+		payload["top_p"] = *cfg.DefaultTopP
 	}
 	if request.MaxTokens != nil && *request.MaxTokens > 0 {
-		maxOutputTokens := *request.MaxTokens
-		if maxOutputTokens < 16 {
-			maxOutputTokens = 16
-		}
-		payload["max_output_tokens"] = maxOutputTokens
+		payload["max_output_tokens"] = *request.MaxTokens
 	}
 	if request.UserID != nil {
 		payload["user"] = shared.TruncateOpenAIUserID(*request.UserID)

--- a/internal/providers/openaicompat/serialization.go
+++ b/internal/providers/openaicompat/serialization.go
@@ -233,9 +233,6 @@ func cifAssistantMsg(m cif.CIFAssistantMessage) Message {
 		msg.ReasoningContent = reasoningContent
 	}
 	if len(toolCalls) > 0 {
-		if msg.Content == nil {
-			msg.Content = ""
-		}
 		msg.ToolCalls = toolCalls
 	}
 	return msg

--- a/internal/providers/openaicompat/serialization_test.go
+++ b/internal/providers/openaicompat/serialization_test.go
@@ -170,4 +170,20 @@ func TestExecute_ReturnsAPIErrorDetails(t *testing.T) {
 	}
 }
 
+func TestMarshalAssistantToolOnlyContentShowsEmptyString(t *testing.T) {
+	body, err := Marshal(&ChatRequest{
+		Model: "glm-5.1",
+		Messages: []Message{
+			{Role: "assistant", Content: "", ToolCalls: []ToolCall{{ID: "call_1", Type: "function", Function: FunctionCallSpec{Name: "ls", Arguments: "{}"}}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, `"content":""`) {
+		t.Fatalf("expected content: \"\" in marshaled body: %s", text)
+	}
+}
+
 func stringPtr(s string) *string { return &s }

--- a/internal/providers/openaicompat/serialization_test.go
+++ b/internal/providers/openaicompat/serialization_test.go
@@ -106,7 +106,7 @@ func TestMarshal_ReappliesUserTruncationAfterExtrasMerge(t *testing.T) {
 	}
 }
 
-func TestBuildChatRequest_AssistantToolCallsIncludeEmptyContent(t *testing.T) {
+func TestBuildChatRequest_AssistantToolCallsOmitEmptyContent(t *testing.T) {
 	request := &cif.CanonicalRequest{
 		Model: "deepseek-v4-flash",
 		Messages: []cif.CIFMessage{
@@ -131,8 +131,8 @@ func TestBuildChatRequest_AssistantToolCallsIncludeEmptyContent(t *testing.T) {
 	if len(out.Messages) != 1 {
 		t.Fatalf("unexpected messages: %#v", out.Messages)
 	}
-	if content, ok := out.Messages[0].Content.(string); !ok || content != "" {
-		t.Fatalf("expected assistant tool-call content to be empty string, got %#v", out.Messages[0].Content)
+	if out.Messages[0].Content != nil {
+		t.Fatalf("expected assistant tool-call content to be omitted, got %#v", out.Messages[0].Content)
 	}
 }
 

--- a/internal/providers/openaicompatprovider/adapter_test.go
+++ b/internal/providers/openaicompatprovider/adapter_test.go
@@ -10,6 +10,8 @@ import (
 	"omnillm/internal/cif"
 	"omnillm/internal/providers/openaicompat"
 	"omnillm/internal/providers/shared"
+	"omnillm/internal/providers/types"
+	"strings"
 	"testing"
 )
 
@@ -56,50 +58,14 @@ func TestAdapterUpstreamAPISelection(t *testing.T) {
 	})
 }
 
-func TestDashScopeChatExtras(t *testing.T) {
-	t.Run("disables thinking for qwen tool turns on dashscope", func(t *testing.T) {
-		req := &cif.CanonicalRequest{
-			Model: "qwen3.6-plus",
-			Tools: []cif.CIFTool{{
-				Name:             "Read",
-				ParametersSchema: map[string]interface{}{"type": "object"},
-			}},
-		}
-
-		extras := dashScopeChatExtras("https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "qwen3.6-plus", req)
-		if len(extras) != 1 {
-			t.Fatalf("expected one DashScope extra, got %#v", extras)
-		}
-		if value, ok := extras["enable_thinking"].(bool); !ok || value {
-			t.Fatalf("expected enable_thinking=false, got %#v", extras["enable_thinking"])
-		}
+func TestSetupProviderAuthRejectsDashScopeEndpoints(t *testing.T) {
+	_, _, _, _, err := SetupProviderAuth("test-dashscope", &types.AuthOptions{
+		Endpoint: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+		APIKey:   "test-key",
 	})
-
-	t.Run("does not inject dashscope extras for non tool turns", func(t *testing.T) {
-		extras := dashScopeChatExtras(
-			"https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-			"qwen3.6-plus",
-			&cif.CanonicalRequest{Model: "qwen3.6-plus"},
-		)
-		if extras != nil {
-			t.Fatalf("expected no extras for non-tool request, got %#v", extras)
-		}
-	})
-
-	t.Run("does not inject dashscope extras for other hosts", func(t *testing.T) {
-		req := &cif.CanonicalRequest{
-			Model: "qwen3.6-plus",
-			Tools: []cif.CIFTool{{
-				Name:             "Read",
-				ParametersSchema: map[string]interface{}{"type": "object"},
-			}},
-		}
-
-		extras := dashScopeChatExtras("http://localhost:11434/v1", "qwen3.6-plus", req)
-		if extras != nil {
-			t.Fatalf("expected no extras for non-DashScope host, got %#v", extras)
-		}
-	})
+	if err == nil || !strings.Contains(err.Error(), "DashScope endpoints must use the Alibaba provider") {
+		t.Fatalf("expected DashScope rejection error, got %v", err)
+	}
 }
 
 func TestAdapterExecute_ChatCompletionsTranslatesAnthropicStyleCIF(t *testing.T) {

--- a/internal/providers/openaicompatprovider/provider.go
+++ b/internal/providers/openaicompatprovider/provider.go
@@ -277,22 +277,14 @@ func (a *Adapter) shouldBufferAnthropicStreaming(request *cif.CanonicalRequest) 
 	return a.inboundAPIShape(request) == "anthropic"
 }
 
-func (a *Adapter) responsesConfig(request *cif.CanonicalRequest) openaicompat.ResponsesConfig {
-	cfg := openaicompat.ResponsesConfig{}
-	if extras := dashScopeChatExtras(a.provider.baseURL, a.RemapModel(request.Model), request); len(extras) > 0 {
-		cfg.Extras = extras
-	}
-	return cfg
+func (a *Adapter) responsesConfig(_ *cif.CanonicalRequest) openaicompat.ResponsesConfig {
+	return openaicompat.ResponsesConfig{}
 }
 
-func (a *Adapter) chatCompletionsConfig(request *cif.CanonicalRequest, stream bool) openaicompat.Config {
-	cfg := openaicompat.Config{
+func (a *Adapter) chatCompletionsConfig(_ *cif.CanonicalRequest, stream bool) openaicompat.Config {
+	return openaicompat.Config{
 		IncludeUsageInStream: stream,
 	}
-	if extras := dashScopeChatExtras(a.provider.baseURL, a.RemapModel(request.Model), request); len(extras) > 0 {
-		cfg.Extras = extras
-	}
-	return cfg
 }
 
 func (a *Adapter) selectedUpstreamAPI(request *cif.CanonicalRequest) string {
@@ -349,18 +341,6 @@ func (a *Adapter) forceChatCompletions(request *cif.CanonicalRequest) bool {
 		*request.Extensions.ForceChatCompletions
 }
 
-func dashScopeChatExtras(baseURL, model string, request *cif.CanonicalRequest) map[string]any {
-	if !isDashScopeBaseURL(baseURL) || !isDashScopeReasoningModel(model) || request == nil {
-		return nil
-	}
-	if len(request.Tools) == 0 {
-		return nil
-	}
-	// DashScope rejects required/specific tool_choice while Qwen is left in its
-	// default reasoning mode. Tool turns must explicitly opt out.
-	return map[string]interface{}{"enable_thinking": false}
-}
-
 func isDashScopeBaseURL(rawURL string) bool {
 	u, err := url.Parse(normalizeBaseURL(rawURL))
 	if err != nil {
@@ -372,13 +352,6 @@ func isDashScopeBaseURL(rawURL string) bool {
 	default:
 		return false
 	}
-}
-
-func isDashScopeReasoningModel(model string) bool {
-	lower := strings.ToLower(strings.TrimSpace(model))
-	return strings.Contains(lower, "qwen3") ||
-		strings.Contains(lower, "qwen-plus") ||
-		strings.Contains(lower, "qwq")
 }
 
 // ─── LoadFromDB ───────────────────────────────────────────────────────────────
@@ -428,6 +401,9 @@ func SetupProviderAuth(instanceID string, options *types.AuthOptions) (token, ba
 	endpoint = normalizeBaseURL(endpoint)
 	if err := security.ValidateEndpoint(endpoint, options.AllowLocalEndpoints); err != nil {
 		return "", "", "", nil, fmt.Errorf("openai-compatible: invalid endpoint: %w", err)
+	}
+	if isDashScopeBaseURL(endpoint) {
+		return "", "", "", nil, fmt.Errorf("openai-compatible: DashScope endpoints must use the Alibaba provider")
 	}
 
 	apiKey := strings.TrimSpace(options.APIKey)

--- a/internal/routes/chat.go
+++ b/internal/routes/chat.go
@@ -9,6 +9,7 @@ import (
 	"omnillm/internal/lib/approval"
 	"omnillm/internal/lib/modelrouting"
 	"omnillm/internal/lib/ratelimit"
+	"omnillm/internal/providerdispatch"
 	"omnillm/internal/providers/types"
 	"omnillm/internal/serialization"
 	"time"
@@ -107,80 +108,55 @@ func (h *chatCompletionHandler) handleChatCompletions(c *gin.Context) {
 
 	// Resolve providers for the requested model
 	attempts := resolveRequestedModels(requestIDStr, canonicalRequest.Model)
-
-	var lastErr error
-	for _, attempt := range attempts {
-		attemptRequest := *canonicalRequest
-		attemptRequest.Model = attempt.RequestedModel
-
-		modelRoute, err := modelrouting.ResolveProvidersForModel(
-			attempt.RequestedModel,
-			attempt.NormalizedModel,
-			attempt.ProviderID,
-			modelCache,
-		)
-		if err != nil {
-			log.Error().Err(err).Str("request_id", requestIDStr).Str("model", attempt.RequestedModel).Msg("Failed to resolve providers for model")
-			writeResolveProvidersError(c, err, "provider_error")
-			return
-		}
-
-		if len(modelRoute.CandidateProviders) == 0 {
-			lastErr = fmt.Errorf("model '%s' not found or no providers available", attempt.RequestedModel)
+	executor := providerdispatch.NewExecutor(providerdispatch.ApplyGitHubCopilotSingleUpstreamMode, providerdispatch.DefaultUpstreamAPI)
+	resolveFailed := false
+	lastErr := executor.TryAttempts(
+		toDispatchAttempts(attempts),
+		canonicalRequest,
+		modelCache,
+		modelrouting.ResolveProvidersForModel,
+		func(attempt providerdispatch.Attempt) {
 			log.Warn().Str("request_id", requestIDStr).Str("model", attempt.RequestedModel).Msg("No providers available for model attempt")
-			continue
-		}
-
-		// Only normalize the model name when the attempt is NOT pinned to a specific
-		// provider. When ProviderID is set (e.g. from a virtual-model upstream), the
-		// stored RequestedModel must be used verbatim — it may include a provider
-		// prefix or specific casing that the upstream requires (e.g. "alipay01/DeepSeek-V4-Flash").
-		if attempt.ProviderID == "" && attempt.NormalizedModel != attemptRequest.Model {
-			log.Debug().Str("request_id", requestIDStr).Str("from", attemptRequest.Model).Str("to", attempt.NormalizedModel).Msg("Normalized chat request model")
-			attemptRequest.Model = attempt.NormalizedModel
-		}
-
-		// Try candidate providers in priority order
-		for _, provider := range modelRoute.CandidateProviders {
-			adapter := provider.GetAdapter()
-			if adapter == nil {
-				continue
-			}
-
-			providerRequest := attemptRequest
-			applyGitHubCopilotSingleUpstreamMode(provider, &providerRequest)
-
+		},
+		func(attempt providerdispatch.Attempt, err error) {
+			resolveFailed = true
+			log.Error().Err(err).Str("request_id", requestIDStr).Str("model", attempt.RequestedModel).Msg("Failed to resolve providers for model")
+		},
+		func(candidate *providerdispatch.Candidate, providerID string) error {
 			log.Debug().
 				Str("request_id", requestIDStr).
-				Str("model", providerRequest.Model).
-				Str("provider", provider.GetInstanceID()).
+				Str("model", candidate.CanonicalModel).
+				Str("provider", providerID).
 				Msg("Trying provider for request")
 
-			// Remap model name for this provider
-			remappedModel := adapter.RemapModel(providerRequest.Model)
-			if remappedModel != providerRequest.Model {
-				log.Debug().Str("request_id", requestIDStr).Str("from", providerRequest.Model).Str("to", remappedModel).Msg("Remapped model name")
-				providerRequest.Model = remappedModel
+			if candidate.UpstreamModel != candidate.CanonicalModel {
+				log.Debug().Str("request_id", requestIDStr).Str("from", candidate.CanonicalModel).Str("to", candidate.UpstreamModel).Msg("Remapped model name")
 			}
 
-			if providerRequest.Stream {
-				lastErr = handleStreamingResponse(c, adapter, &providerRequest, requestIDStr, originalModel, provider.GetInstanceID(), startTime)
+			var err error
+			if candidate.Request.Stream {
+				err = handleStreamingResponse(c, candidate.Adapter, candidate.Request, requestIDStr, originalModel, providerID, startTime)
 			} else {
-				lastErr = handleNonStreamingResponse(c, adapter, &providerRequest, requestIDStr, originalModel, provider.GetInstanceID(), startTime)
+				err = handleNonStreamingResponse(c, candidate.Adapter, candidate.Request, requestIDStr, originalModel, providerID, startTime)
 			}
-
-			if lastErr == nil {
-				return // success
+			if err != nil {
+				log.Warn().Err(err).
+					Str("request_id", requestIDStr).
+					Str("provider", providerID).
+					Str("upstream_model", candidate.UpstreamModel).
+					Msg("Provider failed, trying next")
 			}
-
-			log.Warn().Err(lastErr).
-				Str("request_id", requestIDStr).
-				Str("provider", provider.GetInstanceID()).
-				Str("upstream_model", providerRequest.Model).
-				Msg("Provider failed, trying next")
-		}
+			return err
+		},
+	)
+	if lastErr == nil {
+		return
 	}
 
+	if resolveFailed {
+		writeResolveProvidersError(c, lastErr, "provider_error")
+		return
+	}
 	writeProviderFailure(c, "provider_error", lastErr)
 }
 

--- a/internal/routes/copilot_compat.go
+++ b/internal/routes/copilot_compat.go
@@ -2,26 +2,10 @@ package routes
 
 import (
 	"omnillm/internal/cif"
-	"omnillm/internal/providers/shared"
-	"omnillm/internal/providers/types"
+	"omnillm/internal/providerdispatch"
 )
 
-func applyGitHubCopilotSingleUpstreamMode(provider types.Provider, request *cif.CanonicalRequest) {
-	if provider == nil || request == nil || provider.GetID() != string(types.ProviderGitHubCopilot) {
-		return
-	}
-
-	if request.Extensions == nil {
-		request.Extensions = &cif.Extensions{}
-	}
-
-	trueValue := true
-	if !shared.IsGPT5Family(request.Model) {
-		request.Extensions.ForceChatCompletions = &trueValue
-	}
-	request.Extensions.DisableAuthRetry = &trueValue
-	request.Extensions.DisableStreamingFallback = &trueValue
-}
+var applyGitHubCopilotSingleUpstreamMode = providerdispatch.ApplyGitHubCopilotSingleUpstreamMode
 
 func allowStreamingFallback(request *cif.CanonicalRequest) bool {
 	if request == nil || request.Extensions == nil || request.Extensions.DisableStreamingFallback == nil {

--- a/internal/routes/dispatch_helpers.go
+++ b/internal/routes/dispatch_helpers.go
@@ -1,0 +1,15 @@
+package routes
+
+import "omnillm/internal/providerdispatch"
+
+func toDispatchAttempts(attempts []resolvedModelAttempt) []providerdispatch.Attempt {
+	out := make([]providerdispatch.Attempt, 0, len(attempts))
+	for _, attempt := range attempts {
+		out = append(out, providerdispatch.Attempt{
+			RequestedModel:  attempt.RequestedModel,
+			NormalizedModel: attempt.NormalizedModel,
+			ProviderID:      attempt.ProviderID,
+		})
+	}
+	return out
+}

--- a/internal/routes/messages.go
+++ b/internal/routes/messages.go
@@ -8,6 +8,7 @@ import (
 	"omnillm/internal/cif"
 	"omnillm/internal/ingestion"
 	"omnillm/internal/lib/modelrouting"
+	"omnillm/internal/providerdispatch"
 	"omnillm/internal/providers/types"
 	"omnillm/internal/serialization"
 	"strings"
@@ -26,12 +27,7 @@ type alibabaModeProvider interface {
 	AlibabaAPIMode() string
 }
 
-func upstreamAPIForProvider(providerID, model string) string {
-	if providerID == "azure-openai" && strings.Contains(strings.ToLower(model), "gpt-5.4") {
-		return "responses"
-	}
-	return "chat.completions"
-}
+var upstreamAPIForProvider = providerdispatch.DefaultUpstreamAPI
 
 func handleMessages(c *gin.Context) {
 	// Type assertion is zero-allocation vs fmt.Sprintf("%v", requestID)
@@ -78,87 +74,58 @@ func handleMessages(c *gin.Context) {
 
 	// Resolve providers
 	attempts := resolveRequestedModels(requestIDStr, canonicalRequest.Model)
-	var lastErr error
-	for _, attempt := range attempts {
-		attemptRequest := *canonicalRequest
-		attemptRequest.Model = attempt.RequestedModel
-
-		modelRoute, err := modelrouting.ResolveProvidersForModel(
-			attempt.RequestedModel,
-			attempt.NormalizedModel,
-			attempt.ProviderID,
-			modelCache,
-		)
-		if err != nil {
+	executor := providerdispatch.NewExecutor(providerdispatch.ApplyGitHubCopilotSingleUpstreamMode, providerdispatch.DefaultUpstreamAPI)
+	resolveFailed := false
+	lastErr := executor.TryAttempts(
+		toDispatchAttempts(attempts),
+		canonicalRequest,
+		modelCache,
+		modelrouting.ResolveProvidersForModel,
+		nil,
+		func(attempt providerdispatch.Attempt, err error) {
+			resolveFailed = true
 			log.Error().Err(err).Str("request_id", requestIDStr).Str("model", attempt.RequestedModel).Msg("Failed to resolve providers")
-			writeResolveProvidersError(c, err, "api_error")
-			return
-		}
-
-		if len(modelRoute.CandidateProviders) == 0 {
-			lastErr = fmt.Errorf("model '%s' not found or no providers available", attempt.RequestedModel)
-			continue
-		}
-
-		// Only normalize the model name when the attempt is NOT pinned to a specific
-		// provider. When ProviderID is set (e.g. from a virtual-model upstream), the
-		// stored RequestedModel must be used verbatim — it may include a provider
-		// prefix or specific casing that the upstream requires (e.g. "alipay01/DeepSeek-V4-Flash").
-		if attempt.ProviderID == "" && attempt.NormalizedModel != attemptRequest.Model {
+		},
+		func(candidate *providerdispatch.Candidate, providerID string) error {
 			log.Debug().
 				Str("request_id", requestIDStr).
-				Str("from", attemptRequest.Model).
-				Str("to", attempt.NormalizedModel).
-				Msg("Normalized Anthropic request model")
-			attemptRequest.Model = attempt.NormalizedModel
-		}
-
-		// Try candidate providers in priority order
-		for _, provider := range modelRoute.CandidateProviders {
-			adapter := provider.GetAdapter()
-			if adapter == nil {
-				continue
-			}
-
-			providerRequest := attemptRequest
-			applyGitHubCopilotSingleUpstreamMode(provider, &providerRequest)
-
-			log.Debug().
-				Str("request_id", requestIDStr).
-				Str("model", providerRequest.Model).
-				Str("provider", provider.GetInstanceID()).
+				Str("model", candidate.CanonicalModel).
+				Str("provider", providerID).
 				Msg("Trying provider for Anthropic request")
 
-			remappedModel := adapter.RemapModel(providerRequest.Model)
 			log.Debug().
 				Str("request_id", requestIDStr).
-				Str("provider", provider.GetInstanceID()).
+				Str("provider", providerID).
 				Str("api_shape", "anthropic").
 				Str("inbound_path", c.FullPath()).
-				Str("upstream_api", detectUpstreamAPI(provider.GetID(), adapter, &providerRequest, remappedModel)).
-				Str("canonical_model", providerRequest.Model).
-				Str("upstream_model", remappedModel).
+				Str("upstream_api", candidate.UpstreamAPI).
+				Str("canonical_model", candidate.CanonicalModel).
+				Str("upstream_model", candidate.UpstreamModel).
 				Msg("Converted CIF request to upstream model API")
-			providerRequest.Model = remappedModel
 
-			if providerRequest.Stream {
-				lastErr = handleAnthropicStreamingResponse(c, adapter, &providerRequest, requestIDStr, originalModel, provider.GetInstanceID(), startTime)
+			var err error
+			if candidate.Request.Stream {
+				err = handleAnthropicStreamingResponse(c, candidate.Adapter, candidate.Request, requestIDStr, originalModel, providerID, startTime)
 			} else {
-				lastErr = handleAnthropicNonStreamingResponse(c, adapter, &providerRequest, requestIDStr, originalModel, provider.GetInstanceID(), startTime)
+				err = handleAnthropicNonStreamingResponse(c, candidate.Adapter, candidate.Request, requestIDStr, originalModel, providerID, startTime)
 			}
-
-			if lastErr == nil {
-				return
+			if err != nil {
+				log.Warn().Err(err).
+					Str("request_id", requestIDStr).
+					Str("provider", providerID).
+					Str("upstream_model", candidate.UpstreamModel).
+					Msg("Provider failed for Anthropic request, trying next")
 			}
-
-			log.Warn().Err(lastErr).
-				Str("request_id", requestIDStr).
-				Str("provider", provider.GetInstanceID()).
-				Str("upstream_model", providerRequest.Model).
-				Msg("Provider failed for Anthropic request, trying next")
-		}
+			return err
+		},
+	)
+	if lastErr == nil {
+		return
 	}
-
+	if resolveFailed {
+		writeResolveProvidersError(c, lastErr, "api_error")
+		return
+	}
 	writeProviderFailure(c, "api_error", lastErr)
 }
 

--- a/internal/routes/responses.go
+++ b/internal/routes/responses.go
@@ -8,6 +8,7 @@ import (
 	"omnillm/internal/cif"
 	"omnillm/internal/ingestion"
 	"omnillm/internal/lib/modelrouting"
+	"omnillm/internal/providerdispatch"
 	"omnillm/internal/providers/types"
 	"omnillm/internal/serialization"
 	"strings"
@@ -91,51 +92,71 @@ func handleResponses(c *gin.Context) {
 	}
 
 	// Try candidate providers
-	var lastErr error
-	for _, provider := range modelRoute.CandidateProviders {
-		adapter := provider.GetAdapter()
-		if adapter == nil {
-			continue
-		}
+	executor := providerdispatch.NewExecutor(providerdispatch.ApplyGitHubCopilotSingleUpstreamMode, providerdispatch.DefaultUpstreamAPI)
+	resolveFailed := false
+	lastErr := executor.TryAttempts(
+		[]providerdispatch.Attempt{{
+			RequestedModel:  canonicalRequest.Model,
+			NormalizedModel: normalizedModel,
+			ProviderID:      "",
+		}},
+		canonicalRequest,
+		modelCache,
+		modelrouting.ResolveProvidersForModel,
+		nil,
+		func(attempt providerdispatch.Attempt, err error) {
+			resolveFailed = true
+			log.Error().Err(err).Str("request_id", requestIDStr).Str("model", attempt.RequestedModel).Msg("Failed to resolve providers")
+		},
+		func(candidate *providerdispatch.Candidate, providerID string) error {
+			log.Debug().
+				Str("request_id", requestIDStr).
+				Str("model", candidate.CanonicalModel).
+				Str("provider", providerID).
+				Msg("Trying provider for Responses API request")
 
-		providerRequest := *canonicalRequest
-		applyGitHubCopilotSingleUpstreamMode(provider, &providerRequest)
+			log.Debug().
+				Str("request_id", requestIDStr).
+				Str("provider", providerID).
+				Str("api_shape", "responses").
+				Str("inbound_path", c.FullPath()).
+				Str("upstream_api", candidate.UpstreamAPI).
+				Str("canonical_model", candidate.CanonicalModel).
+				Str("upstream_model", candidate.UpstreamModel).
+				Msg("Converted CIF request to upstream model API")
 
-		log.Debug().
-			Str("request_id", requestIDStr).
-			Str("model", providerRequest.Model).
-			Str("provider", provider.GetInstanceID()).
-			Msg("Trying provider for Responses API request")
-
-		remappedModel := adapter.RemapModel(providerRequest.Model)
-		log.Debug().
-			Str("request_id", requestIDStr).
-			Str("provider", provider.GetInstanceID()).
-			Str("api_shape", "responses").
-			Str("inbound_path", c.FullPath()).
-			Str("upstream_api", detectUpstreamAPI(provider.GetID(), adapter, &providerRequest, remappedModel)).
-			Str("canonical_model", providerRequest.Model).
-			Str("upstream_model", remappedModel).
-			Msg("Converted CIF request to upstream model API")
-		providerRequest.Model = remappedModel
-
-		if providerRequest.Stream {
-			lastErr = handleResponsesStreamingResponse(c, adapter, &providerRequest, requestIDStr, originalModel, provider.GetInstanceID(), startTime)
-		} else {
-			lastErr = handleResponsesNonStreamingResponse(c, adapter, &providerRequest, requestIDStr, originalModel, provider.GetInstanceID(), startTime)
-		}
-
-		if lastErr == nil {
-			return
-		}
-
-		log.Warn().Err(lastErr).
-			Str("request_id", requestIDStr).
-			Str("provider", provider.GetInstanceID()).
-			Str("upstream_model", providerRequest.Model).
-			Msg("Provider failed for Responses API request, trying next")
+			var err error
+			if candidate.Request.Stream {
+				err = handleResponsesStreamingResponse(c, candidate.Adapter, candidate.Request, requestIDStr, originalModel, providerID, startTime)
+			} else {
+				err = handleResponsesNonStreamingResponse(c, candidate.Adapter, candidate.Request, requestIDStr, originalModel, providerID, startTime)
+			}
+			if err != nil {
+				log.Warn().Err(err).
+					Str("request_id", requestIDStr).
+					Str("provider", providerID).
+					Str("upstream_model", candidate.UpstreamModel).
+					Msg("Provider failed for Responses API request, trying next")
+			}
+			return err
+		},
+	)
+	if lastErr == nil {
+		return
 	}
-
+	if resolveFailed {
+		writeResolveProvidersError(c, lastErr, "server_error")
+		return
+	}
+	if strings.Contains(lastErr.Error(), "not found or no providers available") {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": gin.H{
+				"message": lastErr.Error(),
+				"type":    "invalid_request_error",
+			},
+		})
+		return
+	}
 	writeProviderFailure(c, "server_error", lastErr)
 }
 

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -10,6 +10,10 @@ import (
 
 const defaultTimeout = 30 * time.Second
 
+func RunShellCommand(ctx context.Context, command string, timeoutSeconds int) Result {
+	return runShellCommand(ctx, command, timeoutSeconds)
+}
+
 func runShellCommand(ctx context.Context, command string, timeoutSeconds int) Result {
 	timeout := defaultTimeout
 	if timeoutSeconds > 0 {


### PR DESCRIPTION
## Summary

- Added `nonReasoningToolModelIDs` set for models that need special tool handling (Qwen3.5-Plus, GLM-5.1)
- Skip `enable_thinking=false` for non-reasoning tool models to avoid 400 errors
- Omit `tool_choice` for non-reasoning tool models
- Added `ensureToolAssistantContent` to set empty string content for tool-only assistant messages
- Added Qwen3.5-Plus to the model list

Closes #94