### PR TITLE
feat: show tool call payload inline in TUI progress messages

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -127,7 +128,7 @@ func (a *Agent) Stream(ctx context.Context, sessionID string, prompt string) (<-
 			}
 
 			for _, tc := range toolCalls {
-				events <- Event{Type: EventToolCall, Tool: tc.Name, Content: tc.ID}
+				events <- Event{Type: EventToolCall, Tool: tc.Name, Content: formatToolCallPayload(tc)}
 			}
 
 			toolResults := a.registry.ExecuteCalls(ctx, sessionID, toolCalls)
@@ -193,7 +194,6 @@ func (a *Agent) dispatchAndCollect(ctx context.Context, step int, prompt string)
 	return response, nil
 }
 
-
 func (a *Agent) buildRequest(step int, prompt string) *MessagesRequest {
 	messages := a.memory.Messages()
 	toolDefs := a.registry.Definitions()
@@ -216,9 +216,9 @@ func (a *Agent) buildRequest(step int, prompt string) *MessagesRequest {
 
 	req := &MessagesRequest{
 		MaxTokens: 4096,
-		Messages: filtered,
-		Tools:    toolDefs,
-		Stream:   false,
+		Messages:  filtered,
+		Tools:     toolDefs,
+		Stream:    false,
 	}
 	if systemPrompt != "" {
 		req.System = []ContentBlock{TextBlock(systemPrompt)}
@@ -292,6 +292,17 @@ func extractToolCalls(content []ContentBlock) []tools.ToolCall {
 		}
 	}
 	return calls
+}
+
+func formatToolCallPayload(call tools.ToolCall) string {
+	if command, ok := call.Arguments["command"].(string); ok && command != "" {
+		return command
+	}
+	encoded, err := json.Marshal(call.Arguments)
+	if err != nil {
+		return call.ID
+	}
+	return string(encoded)
 }
 
 func extractTextContent(content []ContentBlock) string {

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -779,6 +779,29 @@ func TestTUILeftMouseClickExpandsToolResult(t *testing.T) {
 	}
 }
 
+func TestFormatToolCallProgressShowsPayloadInline(t *testing.T) {
+	got := formatToolCallProgress("powershell", "Get-NetIPAddress -AddressFamily IPv4")
+	want := "🔧 Calling tool `powershell`: Get-NetIPAddress -AddressFamily IPv4"
+	if got != want {
+		t.Fatalf("formatToolCallProgress() = %q, want %q", got, want)
+	}
+}
+
+func TestTUIAgentToolCallProgressShowsPayloadInline(t *testing.T) {
+	m := newChatTUIModel(nil, "session-1", "claude-haiku-4.5", "chat", DefaultAPIShape, "", nil, nil)
+	m.ready = true
+	m.mainWidth = 120
+	m.viewport = viewport.New(120, 10)
+
+	model, _ := m.Update(agentProgressMsg{text: "🔧 Calling tool `powershell`: Get-NetIPAddress -AddressFamily IPv4"})
+	updated := model.(chatTUIModel)
+	rendered := updated.renderTranscript()
+
+	if !strings.Contains(rendered, "Calling tool `powershell`: Get-NetIPAddress -AddressFamily IPv4") {
+		t.Fatalf("rendered transcript missing inline payload:\n%s", rendered)
+	}
+}
+
 func TestTUISelectionHighlightStripsNestedANSICodes(t *testing.T) {
 	line := "prefix \x1b[31mred\x1b[0m suffix"
 	highlighted := highlightVisibleRange(line, 7, 10)
@@ -1287,12 +1310,14 @@ func TestStreamAgentTurnWithCheckerAllowsEmptyFinalTurnAndDropsPreToolNarration(
 
 	var finalContent string
 	var toolCalls, toolResults, doneCount int
+	var toolCallContent string
 	for event := range eventCh {
 		switch event.Type {
 		case "token":
 			finalContent += event.Content
 		case "tool_call":
 			toolCalls++
+			toolCallContent = event.Content
 			finalContent = ""
 		case "tool_result":
 			toolResults++
@@ -1308,6 +1333,9 @@ func TestStreamAgentTurnWithCheckerAllowsEmptyFinalTurnAndDropsPreToolNarration(
 	}
 	if toolCalls != 1 {
 		t.Fatalf("toolCalls = %d, want 1", toolCalls)
+	}
+	if toolCallContent != "Write-Output disk-ok" {
+		t.Fatalf("tool call content = %q, want command payload", toolCallContent)
 	}
 	if toolResults != 1 {
 		t.Fatalf("toolResults = %d, want 1", toolResults)

--- a/internal/chat/tui.go
+++ b/internal/chat/tui.go
@@ -2397,7 +2397,7 @@ func (m *chatTUIModel) sendAndStream(userText string) tea.Cmd {
 				case agentpkg.EventToolCall:
 					finalContent = ""
 					if prog != nil {
-						prog.Send(agentProgressMsg{text: fmt.Sprintf("🔧 Calling tool `%s`…", event.Tool)})
+						prog.Send(agentProgressMsg{text: formatToolCallProgress(event.Tool, event.Content)})
 					}
 				case agentpkg.EventToolResult:
 					if prog != nil {
@@ -2428,6 +2428,13 @@ func (m *chatTUIModel) sendAndStream(userText string) tea.Cmd {
 		go m.runStream(messages)
 		return nil
 	}
+}
+
+func formatToolCallProgress(toolName, payload string) string {
+	if strings.TrimSpace(payload) == "" {
+		return fmt.Sprintf("🔧 Calling tool `%s`…", toolName)
+	}
+	return fmt.Sprintf("🔧 Calling tool `%s`: %s", toolName, payload)
 }
 
 func (m *chatTUIModel) makeTUIPermissionChecker() toolspkg.PermissionChecker {


### PR DESCRIPTION
﻿## Description

Replace the tool call ID with the actual command or JSON payload when displaying tool call progress in the chat TUI. This makes it easier for users to see what command is being executed without expanding details.

## Changes

- Add `formatToolCallPayload()` to extract command from tool call arguments
- Add `formatToolCallProgress()` to render payload inline in progress msg
- Update `EventToolCall` handler to pass the formatted payload
- Add tests for the new inline payload display
- Update existing test to verify command payload in tool call content

## Related Issue

Closes #114
