### PR TITLE
fix(chat/tui): disable single-letter viewport keybindings to avoid conflict with text input

### DIFF
--- a/internal/chat/tui.go
+++ b/internal/chat/tui.go
@@ -618,6 +618,15 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		vpH := max(msg.Height-10, 3)
 		if !m.ready {
 			m.viewport = viewport.New(m.mainWidth, vpH)
+			// Disable single-letter viewport keybindings (b, u, d, f, j, k, h, l)
+			// that conflict with text input in the textarea.
+			m.viewport.KeyMap.PageUp.SetKeys("pgup")
+			m.viewport.KeyMap.HalfPageUp.SetKeys("ctrl+u")
+			m.viewport.KeyMap.HalfPageDown.SetKeys("ctrl+d")
+			m.viewport.KeyMap.Down.SetKeys("down")
+			m.viewport.KeyMap.Up.SetKeys("up")
+			m.viewport.KeyMap.Left.SetKeys("left")
+			m.viewport.KeyMap.Right.SetKeys("right")
 			m.ready = true
 		} else {
 			m.viewport.Width = m.mainWidth


### PR DESCRIPTION
## Description

Single-letter keybindings for viewport scrolling (b, u, d, f, j, k, h, l) conflict with normal text input in the chat textarea. When typing in the textarea, pressing these keys triggers viewport scrolling instead of inserting the character.

## Changes

- Remapped PageUp/HalfPageUp/HalfPageDown/Down/Up/Left/Right to non-letter keys
- File changed: \internal/chat/tui.go\ (+9 lines)

Closes #116