### PR TITLE
feat: add model parameter to OpenAISDKDispatch for default model fallback

### DIFF
--- a/internal/agent/dispatch_openai_sdk.go
+++ b/internal/agent/dispatch_openai_sdk.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openai/openai-go/v3/shared"
 )
 
-func OpenAISDKDispatch(apiKey, baseURL string) DispatchFn {
+func OpenAISDKDispatch(apiKey, baseURL, model string) DispatchFn {
 	opts := []option.RequestOption{}
 	if apiKey != "" {
 		opts = append(opts, option.WithAPIKey(apiKey))
@@ -24,6 +24,9 @@ func OpenAISDKDispatch(apiKey, baseURL string) DispatchFn {
 	client := openai.NewClient(opts...)
 
 	return func(ctx context.Context, req *MessagesRequest) (<-chan *MessagesResponse, error) {
+		if req.Model == "" {
+			req.Model = model
+		}
 		params, err := openAIParamsFromRequest(req)
 		if err != nil {
 			return nil, fmt.Errorf("openai-sdk: build params: %w", err)

--- a/internal/agent/dispatch_openai_sdk_test.go
+++ b/internal/agent/dispatch_openai_sdk_test.go
@@ -42,7 +42,7 @@ func TestOpenAISDKDispatchConvertsRequest(t *testing.T) {
 	}))
 	defer server.Close()
 
-	dispatch := OpenAISDKDispatch("test-openai-key", server.URL)
+	dispatch := OpenAISDKDispatch("test-openai-key", server.URL, "gpt-4o-mini")
 	req := testMessagesRequest("gpt-4o-mini", testUserMessage("Hello"))
 	req.System = []ContentBlock{TextBlock("You are concise.")}
 	req.Tools = []tools.ToolDefinition{testToolDefinition("lookup", stringPtr("Look up data"), map[string]any{
@@ -134,7 +134,7 @@ func TestOpenAISDKDispatchConvertsToolCalls(t *testing.T) {
 	}))
 	defer server.Close()
 
-	dispatch := OpenAISDKDispatch("test-openai-key", server.URL)
+	dispatch := OpenAISDKDispatch("test-openai-key", server.URL, "gpt-4o-mini")
 	respCh, err := dispatch(context.Background(), testMessagesRequest("gpt-4o-mini", testUserMessage("call a tool")))
 	if err != nil {
 		t.Fatalf("dispatch error: %v", err)

--- a/internal/agent/session_runner.go
+++ b/internal/agent/session_runner.go
@@ -51,7 +51,7 @@ func StreamTurn(ctx context.Context, c Client, sessionID, model, backend, apiSha
 func selectDispatch(c Client, model, _, apiShape string) DispatchFn {
 	switch normalizeAPIShape(apiShape) {
 	case "openai":
-		return OpenAISDKDispatch(omniLLMAPIKey(c), omniLLMOpenAIBaseURL(c))
+		return OpenAISDKDispatch(omniLLMAPIKey(c), omniLLMOpenAIBaseURL(c), model)
 	default:
 		return NewDispatch(c, model, DefaultAPIShape)
 	}


### PR DESCRIPTION
## Summary

\OpenAISDKDispatch\ now accepts a \model\ string parameter. When \eq.Model\ is empty, the dispatch function falls back to the provided \model\ value as the default.

## Changes

- \internal/agent/dispatch_openai_sdk.go\ — added \model\ parameter, default fallback logic
- \internal/agent/dispatch_openai_sdk_test.go\ — updated test calls with model arg
- \internal/agent/session_runner.go\ — passes \model\ to \OpenAISDKDispatch\

## Related Issue

Closes #118