### PR TITLE
feat(tui): per-item expand/collapse and enhanced tool result interactions

### DIFF
--- a/docs/superpowers/specs/2026-05-11-tui-per-item-expand-collapse-design.md
+++ b/docs/superpowers/specs/2026-05-11-tui-per-item-expand-collapse-design.md
@@ -1,0 +1,151 @@
+# TUI per-item expand/collapse for tool results
+
+**Date:** 2026-05-11
+**Status:** Approved (design)
+**Area:** `internal/chat/tui.go` (omnicode TUI)
+
+## Goal
+
+Replace the current global `Ctrl+O` "expand all tool results" shortcut with a
+per-item expand/collapse interaction inspired by the `crush` TUI: focus a
+truncated tool-result entry and press `space` (or click it without dragging) to
+toggle just that entry. The collapsed-state hint mirrors crush's affordance:
+
+```
+… (N lines hidden) [click or space to expand]
+```
+
+## Scope
+
+In scope:
+- `transcriptToolResult` entries only. Existing `toolResultMaxLines = 10`
+  threshold preserved.
+- Keyboard focus movement among collapsible entries.
+- Mouse click-without-drag toggle.
+- Removing `Ctrl+O` binding and the now-unused `toggleAllExpandableEntries`
+  helper.
+
+Out of scope:
+- Collapsing assistant, user, thinking, or info entries.
+- Persisting expanded state across sessions.
+- Any animation / progressive reveal.
+
+## Files touched
+
+All edits land in `internal/chat/tui.go` (the TUI is a single large file
+today; this change does not justify splitting it).
+
+## Interaction design
+
+### Hint text (in `renderToolResultSection`)
+
+State combinations:
+
+| Expanded | Focused | Hint shown                                          |
+| -------- | ------- | --------------------------------------------------- |
+| no       | yes     | `… (N lines hidden) [click or space to expand]`     |
+| no       | no      | `… (N lines hidden)`                                |
+| yes      | yes     | `▾ (click or space to collapse)`                    |
+| yes      | no      | *(no hint)*                                         |
+
+Showing the actionable instruction only on the focused entry keeps the
+transcript clean and matches crush's screenshot, where the hint sits on the
+focused/hovered item.
+
+### Focus model
+
+- `hoveredEntry` is the single source of truth for "which entry is focused".
+- Mouse motion sets it (today's behavior, unchanged).
+- New: when the textarea is empty, `↑` and `↓` cycle `hoveredEntry` only among
+  entries that are collapsible tool results with overflow
+  (`len(strings.Split(content,"\n")) > toolResultMaxLines`). Wraps at top and
+  bottom. If no eligible entries exist, the keys fall through to the viewport
+  scroll behavior they have today.
+- The textarea's own `↑`/`↓` history-navigation behavior (when textarea is
+  non-empty or actively in history-navigation mode) is preserved by gating the
+  new handler on `m.textarea.Value() == ""` AND no active history navigation.
+
+### `space` toggle
+
+- When textarea is empty AND `hoveredEntry` points at a `transcriptToolResult`
+  with overflow → toggle `expandedEntries[id]`, then `syncViewport()`.
+- Otherwise `space` flows through to the textarea as today (so typing a space
+  in the input still works).
+
+### Click-without-drag toggle
+
+- On `MouseButtonLeft + MouseActionPress`, record `clickStartX`,
+  `clickStartY` (extending today's selection-tracking state).
+- On `MouseButtonLeft + MouseActionRelease`:
+  - If `(X,Y) == (clickStartX, clickStartY)` (zero drag) AND the entry under
+    the cursor is a `transcriptToolResult` with overflow → toggle that entry's
+    `expandedEntries`, abort the pending selection start (so no zero-length
+    selection is finalized), and return.
+  - Otherwise behave as today (finalize selection, etc.).
+- Any drag (≥ 1 cell of movement between press and release) preserves today's
+  text-selection behavior — clicks that move are never treated as toggles.
+
+### Removed: `Ctrl+O` and `toggleAllExpandableEntries`
+
+- Delete the `Ctrl+O` case in the keybinding switch.
+- Delete the `toggleAllExpandableEntries` method (no remaining callers).
+- Remove `Ctrl+O expand/collapse tool results` from the inline help status
+  line; add `Space expand focused tool result` in its place.
+
+## Backward compatibility
+
+- `expandedEntries` map and existing `expanded` parameter to
+  `renderToolResultSection` are unchanged in shape; only the hint string and
+  the trigger paths change.
+- No persisted state, no config keys, no command-line flags affected.
+- Users who relied on `Ctrl+O` lose the global toggle; the per-item flow is
+  the replacement. Documented in the help line.
+
+## Testing
+
+Add table-driven tests in `internal/chat/chat_test.go`:
+
+1. **Hint rendering** — `renderToolResultSection` produces the correct hint
+   for each of the four (expanded × focused) states, plus the no-overflow
+   case (no hint at all).
+2. **Focus cycling** — given a transcript with three tool-result entries
+   (two overflowing, one short) and a non-tool entry, `↑`/`↓` with empty
+   textarea visit only the two overflowing entries and wrap correctly.
+3. **`space` toggle**
+   - With focus on an overflowing tool result and empty textarea: `space`
+     flips `expandedEntries[id]`.
+   - With non-empty textarea: `space` is consumed by the textarea
+     (input contains the space).
+   - With empty textarea but `hoveredEntry == -1`: `space` falls through
+     to the textarea.
+4. **Click-without-drag**
+   - Simulated press + release at identical coords on an overflowing tool
+     result toggles `expandedEntries[id]` and does not start a selection.
+   - Press + motion + release on the same entry does NOT toggle and starts /
+     finalizes a selection as today.
+
+## Implementation order
+
+1. Add `clickStartX/Y` tracking and click-without-drag detection in
+   `handleMouseEvent`.
+2. Update `renderToolResultSection` to the four-state hint table.
+3. Add `↑`/`↓` keyboard focus cycling among eligible entries (gated on empty
+   textarea + no active history navigation).
+4. Add `space` toggle handler.
+5. Remove `Ctrl+O` keybinding, delete `toggleAllExpandableEntries`, update
+   help/status lines.
+6. Add tests from the section above; run `go test ./internal/chat/...`.
+
+## Risks
+
+- **Mouse hover updates focus mid-stream.** When the assistant is streaming,
+  mouse motion can shift `hoveredEntry` and therefore which entry shows the
+  expand hint. This matches today's hover behavior and is acceptable.
+- **`↑`/`↓` collision with viewport scroll.** Today, when no input is
+  focused, these keys may scroll the viewport. The new behavior takes
+  precedence only when at least one collapsible tool result exists; otherwise
+  it falls through. Verify in test 2.
+- **Terminals that don't report mouse motion.** Click-without-drag still
+  works (press and release coords are reported). Hover-driven focus does not,
+  so users in such terminals must use `↑`/`↓` to move focus before pressing
+  `space`. Acceptable degradation.

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -752,7 +752,7 @@ func TestTUILeftMouseCopiesVisibleTranscriptTextOnRelease(t *testing.T) {
 	}
 }
 
-func TestTUILeftMouseClickExpandsToolResultHint(t *testing.T) {
+func TestTUILeftMouseClickToolResultHintExpands(t *testing.T) {
 	m := newChatTUIModel(nil, "session-1", "claude-haiku-4.5", "chat", DefaultAPIShape, "", nil, nil)
 	m.ready = true
 	m.mainWidth = 80
@@ -769,6 +769,7 @@ func TestTUILeftMouseClickExpandsToolResultHint(t *testing.T) {
 	}
 	_, viewportTop, _, _ := m.viewportBounds()
 	hintY := viewportTop + m.transcriptLayout[0].endLine - m.viewport.YOffset
+	hintY -= tuiToolResultHitRowOffset
 
 	model, _ := m.Update(tea.MouseMsg{X: 3, Y: hintY, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft})
 	updated := model.(chatTUIModel)
@@ -988,6 +989,7 @@ func TestTUILeftMouseClickDoesNotToggleToolResultAfterEntryIndexShift(t *testing
 	m.syncViewport()
 	_, viewportTop, _, _ := m.viewportBounds()
 	secondY := viewportTop + m.transcriptLayout[1].clickableStartLine - m.viewport.YOffset
+	secondY -= tuiToolResultHitRowOffset
 
 	model, _ := m.Update(tea.MouseMsg{X: 3, Y: secondY, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft})
 	updated := model.(chatTUIModel)
@@ -1049,13 +1051,13 @@ func TestTUISpaceTogglesFocusedToolResultExpansion(t *testing.T) {
 		t.Fatal("expected second Space to collapse focused tool result")
 	}
 
-	// Space on a non-overflowing tool result is a no-op (and falls through to textarea).
+	// Space on a non-overflowing tool result still toggles item expansion state.
 	updated.textarea.Reset()
 	updated.hoveredEntry = 2
 	model, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
 	updated = model.(chatTUIModel)
-	if updated.expandedEntries[3] {
-		t.Fatal("Space should not mark non-overflowing tool result as expanded")
+	if !updated.expandedEntries[3] {
+		t.Fatal("Space should toggle non-overflowing tool result item state")
 	}
 
 	// Space with no hovered entry falls through to the textarea.
@@ -1065,6 +1067,73 @@ func TestTUISpaceTogglesFocusedToolResultExpansion(t *testing.T) {
 	updated = model.(chatTUIModel)
 	if updated.textarea.Value() != " " {
 		t.Fatalf("Space with no hovered entry should reach textarea; got %q", updated.textarea.Value())
+	}
+}
+
+func TestTUIUpDownCyclesAllToolResultsWhenInputEmpty(t *testing.T) {
+	m := newChatTUIModel(nil, "session-1", "claude-haiku-4.5", "chat", DefaultAPIShape, "", nil, nil)
+	m.ready = true
+	m.mainWidth = 80
+	m.viewport = viewport.New(80, 40)
+	m.entries = append(m.entries,
+		transcriptEntry{id: 1, kind: transcriptAssistant, content: "assistant"},
+		transcriptEntry{id: 2, kind: transcriptToolResult, toolName: "Read", content: strings.Join([]string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"}, "\n")},
+		transcriptEntry{id: 3, kind: transcriptToolResult, toolName: "Short", content: "short"},
+		transcriptEntry{id: 4, kind: transcriptToolResult, toolName: "Write", content: strings.Join([]string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"}, "\n")},
+	)
+	m.syncViewport()
+	m.textarea.Reset()
+	m.hoveredEntry = -1
+
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	updated := model.(chatTUIModel)
+	if updated.hoveredEntry != 1 {
+		t.Fatalf("first KeyDown hoveredEntry = %d, want 1", updated.hoveredEntry)
+	}
+
+	model, _ = updated.Update(tea.KeyMsg{Type: tea.KeyDown})
+	updated = model.(chatTUIModel)
+	if updated.hoveredEntry != 2 {
+		t.Fatalf("second KeyDown hoveredEntry = %d, want 2", updated.hoveredEntry)
+	}
+
+	model, _ = updated.Update(tea.KeyMsg{Type: tea.KeyDown})
+	updated = model.(chatTUIModel)
+	if updated.hoveredEntry != 3 {
+		t.Fatalf("third KeyDown hoveredEntry = %d, want 3", updated.hoveredEntry)
+	}
+
+	model, _ = updated.Update(tea.KeyMsg{Type: tea.KeyUp})
+	updated = model.(chatTUIModel)
+	if updated.hoveredEntry != 2 {
+		t.Fatalf("KeyUp should move hoveredEntry back to 2, got %d", updated.hoveredEntry)
+	}
+
+	if updated.textarea.Value() != "" {
+		t.Fatalf("textarea should stay empty while cycling tool result focus, got %q", updated.textarea.Value())
+	}
+}
+
+func TestTUIUpDownPrefersToolResultFocusOverPromptHistory(t *testing.T) {
+	m := newChatTUIModel(nil, "session-1", "claude-haiku-4.5", "chat", DefaultAPIShape, "", nil, nil)
+	m.ready = true
+	m.mainWidth = 80
+	m.viewport = viewport.New(80, 20)
+	m.entries = append(m.entries,
+		transcriptEntry{id: 1, kind: transcriptToolResult, toolName: "Short", content: "short output"},
+	)
+	m.syncViewport()
+	m.textarea.Reset()
+	m.promptHistory = []string{"alpha", "beta"}
+	m.hoveredEntry = -1
+
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	updated := model.(chatTUIModel)
+	if got := updated.textarea.Value(); got != "" {
+		t.Fatalf("textarea after KeyUp = %q, want empty", got)
+	}
+	if updated.hoveredEntry != 0 {
+		t.Fatalf("hoveredEntry after KeyUp = %d, want 0", updated.hoveredEntry)
 	}
 }
 

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -158,7 +158,7 @@ func TestRenderFooterStatusPrefersContextualState(t *testing.T) {
 	}
 
 	m.showInlineHelp = true
-	if got := m.renderFooterStatus(); !strings.Contains(got, "Ctrl+O expand/collapse") {
+	if got := m.renderFooterStatus(); !strings.Contains(got, "Space expand focused tool result") {
 		t.Fatalf("inline help footer = %q", got)
 	}
 
@@ -752,7 +752,7 @@ func TestTUILeftMouseCopiesVisibleTranscriptTextOnRelease(t *testing.T) {
 	}
 }
 
-func TestTUILeftMouseClickDoesNotExpandToolResultHint(t *testing.T) {
+func TestTUILeftMouseClickExpandsToolResultHint(t *testing.T) {
 	m := newChatTUIModel(nil, "session-1", "claude-haiku-4.5", "chat", DefaultAPIShape, "", nil, nil)
 	m.ready = true
 	m.mainWidth = 80
@@ -775,12 +775,12 @@ func TestTUILeftMouseClickDoesNotExpandToolResultHint(t *testing.T) {
 	model, _ = updated.Update(tea.MouseMsg{X: 3, Y: hintY, Action: tea.MouseActionRelease, Button: tea.MouseButtonNone})
 	updated = model.(chatTUIModel)
 
-	if updated.expandedEntries[1] {
-		t.Fatal("clicking tool result hint should not expand it")
+	if !updated.expandedEntries[1] {
+		t.Fatal("clicking tool result hint should expand it")
 	}
 }
 
-func TestTUILeftMouseClickDoesNotExpandToolResultWhenHoverIsStale(t *testing.T) {
+func TestTUILeftMouseClickExpandsToolResultRegardlessOfHover(t *testing.T) {
 	m := newChatTUIModel(nil, "session-1", "claude-haiku-4.5", "chat", DefaultAPIShape, "", nil, nil)
 	m.ready = true
 	m.mainWidth = 80
@@ -812,14 +812,14 @@ func TestTUILeftMouseClickDoesNotExpandToolResultWhenHoverIsStale(t *testing.T) 
 	updated = model.(chatTUIModel)
 
 	if updated.expandedEntries[1] {
-		t.Fatal("did not expect stale hovered assistant entry to expand")
+		t.Fatal("did not expect assistant entry to expand")
 	}
-	if updated.expandedEntries[2] {
-		t.Fatal("clicking tool result should not expand it")
+	if !updated.expandedEntries[2] {
+		t.Fatal("clicking tool result should expand it (entry under cursor wins, not stale hover)")
 	}
 }
 
-func TestTUILeftMouseClickDoesNotExpandToolResultBody(t *testing.T) {
+func TestTUILeftMouseClickExpandsToolResultBody(t *testing.T) {
 	m := newChatTUIModel(nil, "session-1", "claude-haiku-4.5", "chat", DefaultAPIShape, "", nil, nil)
 	m.ready = true
 	m.mainWidth = 80
@@ -842,12 +842,12 @@ func TestTUILeftMouseClickDoesNotExpandToolResultBody(t *testing.T) {
 	model, _ = updated.Update(tea.MouseMsg{X: 3, Y: bodyY, Action: tea.MouseActionRelease, Button: tea.MouseButtonNone})
 	updated = model.(chatTUIModel)
 
-	if updated.expandedEntries[1] {
-		t.Fatal("clicking tool result body should not expand it")
+	if !updated.expandedEntries[1] {
+		t.Fatal("clicking tool result body should expand it")
 	}
 }
 
-func TestTUILeftMouseClickToolResultLabelDoesNotExpand(t *testing.T) {
+func TestTUILeftMouseClickToolResultLabelExpands(t *testing.T) {
 	m := newChatTUIModel(nil, "session-1", "claude-haiku-4.5", "chat", DefaultAPIShape, "", nil, nil)
 	m.ready = true
 	m.mainWidth = 80
@@ -867,8 +867,8 @@ func TestTUILeftMouseClickToolResultLabelDoesNotExpand(t *testing.T) {
 	model, _ = updated.Update(tea.MouseMsg{X: 3, Y: labelY, Action: tea.MouseActionRelease, Button: tea.MouseButtonNone})
 	updated = model.(chatTUIModel)
 
-	if updated.expandedEntries[1] {
-		t.Fatal("tool result label click should not expand the result")
+	if !updated.expandedEntries[1] {
+		t.Fatal("tool result label click should expand the result")
 	}
 }
 
@@ -946,6 +946,7 @@ func TestTUIAssistantResponseClickDoesNotToggleExpansion(t *testing.T) {
 }
 
 func TestTUICtrlODoesNotToggleAssistantResponse(t *testing.T) {
+	// Ctrl+O has been removed. Pressing it should now be a no-op.
 	m := newChatTUIModel(nil, "session-1", "claude-haiku-4.5", "chat", DefaultAPIShape, "", nil, nil)
 	m.ready = true
 	m.mainWidth = 80
@@ -1003,7 +1004,7 @@ func TestTUILeftMouseClickDoesNotToggleToolResultAfterEntryIndexShift(t *testing
 	}
 }
 
-func TestTUICtrlOTogglesAllToolResultExpansion(t *testing.T) {
+func TestTUISpaceTogglesFocusedToolResultExpansion(t *testing.T) {
 	m := newChatTUIModel(nil, "session-1", "claude-haiku-4.5", "chat", DefaultAPIShape, "", nil, nil)
 	m.ready = true
 	m.mainWidth = 80
@@ -1029,21 +1030,41 @@ func TestTUICtrlOTogglesAllToolResultExpansion(t *testing.T) {
 		},
 	)
 	m.syncViewport()
+
+	// Space on focused expandable entry toggles only that one.
 	m.hoveredEntry = 0
-
-	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
 	updated := model.(chatTUIModel)
-	if !updated.expandedEntries[1] || !updated.expandedEntries[2] {
-		t.Fatal("expected Ctrl+O to expand all expandable tool results")
+	if !updated.expandedEntries[1] {
+		t.Fatal("expected Space to expand focused tool result")
 	}
-	if updated.expandedEntries[3] {
-		t.Fatal("Ctrl+O should not mark non-overflowing tool results as expanded")
+	if updated.expandedEntries[2] {
+		t.Fatal("Space should not expand non-focused tool results")
 	}
 
-	model, _ = updated.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	// Pressing Space again on the same focused entry collapses it.
+	model, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
 	updated = model.(chatTUIModel)
-	if updated.expandedEntries[1] || updated.expandedEntries[2] {
-		t.Fatal("expected second Ctrl+O to collapse all expandable tool results")
+	if updated.expandedEntries[1] {
+		t.Fatal("expected second Space to collapse focused tool result")
+	}
+
+	// Space on a non-overflowing tool result is a no-op (and falls through to textarea).
+	updated.textarea.Reset()
+	updated.hoveredEntry = 2
+	model, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	updated = model.(chatTUIModel)
+	if updated.expandedEntries[3] {
+		t.Fatal("Space should not mark non-overflowing tool result as expanded")
+	}
+
+	// Space with no hovered entry falls through to the textarea.
+	updated.textarea.Reset()
+	updated.hoveredEntry = -1
+	model, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	updated = model.(chatTUIModel)
+	if updated.textarea.Value() != " " {
+		t.Fatalf("Space with no hovered entry should reach textarea; got %q", updated.textarea.Value())
 	}
 }
 

--- a/internal/chat/tui.go
+++ b/internal/chat/tui.go
@@ -30,41 +30,46 @@ import (
 )
 
 var (
-	tuiTitleStyle           = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7C3AED")).Padding(0, 1)
-	tuiUserLabelStyle       = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#67E8F9"))
-	tuiAssistantLabelStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#D8B4FE"))
-	tuiThinkingLabelStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#A78BFA"))
-	tuiErrorStyle           = lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444"))
-	tuiHelpStyle            = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Padding(0, 1)
-	tuiStatusStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF")).Padding(0, 1)
-	tuiStatusAccentStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#C4B5FD"))
-	tuiInputMetaStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF")).Padding(0, 1)
-	tuiPermManualChipStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#FDE68A")).Background(lipgloss.Color("#3A2A10")).Padding(0, 1)
-	tuiPermAutoChipStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#D1FAE5")).Background(lipgloss.Color("#123225")).Padding(0, 1)
-	tuiPermPendingChipStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFE7B3")).Background(lipgloss.Color("#4A3415")).Padding(0, 1)
-	tuiDivStyle             = lipgloss.NewStyle().Foreground(lipgloss.Color("#374151"))
-	tuiUserBlockStyle       = lipgloss.NewStyle().Background(lipgloss.Color("#10161B")).Foreground(lipgloss.Color("#E6F7FB")).Padding(0, 1)
-	tuiAssistantBlockStyle  = lipgloss.NewStyle().Background(lipgloss.Color("#17141D")).Foreground(lipgloss.Color("#F0EAF7")).Padding(0, 1)
-	tuiThinkingBlockStyle   = lipgloss.NewStyle().Background(lipgloss.Color("#141723")).Foreground(lipgloss.Color("#D6CCFF")).Padding(0, 1)
-	tuiUserHoverStyle       = lipgloss.NewStyle().Background(lipgloss.Color("#17232A")).Foreground(lipgloss.Color("#ECFBFF")).Padding(0, 1)
-	tuiAssistantHoverStyle  = lipgloss.NewStyle().Background(lipgloss.Color("#211A2B")).Foreground(lipgloss.Color("#F7F1FF")).Padding(0, 1)
-	tuiThinkingHoverStyle   = lipgloss.NewStyle().Background(lipgloss.Color("#1A1E2E")).Foreground(lipgloss.Color("#E6DEFF")).Padding(0, 1)
-	tuiThinkingStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("#A78BFA")).Italic(true)
-	tuiSidebarStyle         = lipgloss.NewStyle().Background(lipgloss.Color("#101014")).Foreground(lipgloss.Color("#E5E7EB")).Padding(1, 2)
-	tuiSidebarHeaderStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F9FAFB"))
-	tuiSidebarLabelStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF"))
-	tuiSidebarValueStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#F3F4F6"))
-	tuiPermissionLabelStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F59E0B"))
-	tuiPermissionBlockStyle = lipgloss.NewStyle().Background(lipgloss.Color("#2A1F0F")).Foreground(lipgloss.Color("#FDE68A")).Padding(0, 1)
-	tuiSelectionStyle       = lipgloss.NewStyle().Background(lipgloss.Color("#E8E8E8")).Foreground(lipgloss.Color("#111111"))
-	tuiInputShellStyle      = lipgloss.NewStyle().Background(lipgloss.Color("#1C1C1C")).Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("#3B82F6"))
-	tuiInputAccentStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#3B82F6"))
-	tuiTableBorderStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280"))
-	tuiTableHeaderStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#C084FC")).Bold(true).Padding(0, 1)
-	tuiTableCellStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("#E5E7EB")).Padding(0, 1)
-	tuiTableAccentStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Bold(true)
-	ansiPrefixPattern       = regexp.MustCompile(`^(?:\x1b\[[0-9;]*m)*`)
-	omnicodeLogoLeft        = []string{
+	tuiTitleStyle             = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7C3AED")).Padding(0, 1)
+	tuiUserLabelStyle         = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#67E8F9"))
+	tuiAssistantLabelStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#D8B4FE"))
+	tuiThinkingLabelStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#A78BFA"))
+	tuiErrorStyle             = lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444"))
+	tuiHelpStyle              = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Padding(0, 1)
+	tuiStatusStyle            = lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF")).Padding(0, 1)
+	tuiStatusAccentStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#C4B5FD"))
+	tuiInputMetaStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF")).Padding(0, 1)
+	tuiPermManualChipStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#FDE68A")).Background(lipgloss.Color("#3A2A10")).Padding(0, 1)
+	tuiPermAutoChipStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#D1FAE5")).Background(lipgloss.Color("#123225")).Padding(0, 1)
+	tuiPermPendingChipStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFE7B3")).Background(lipgloss.Color("#4A3415")).Padding(0, 1)
+	tuiDivStyle               = lipgloss.NewStyle().Foreground(lipgloss.Color("#374151"))
+	tuiUserBlockStyle         = lipgloss.NewStyle().Background(lipgloss.Color("#10161B")).Foreground(lipgloss.Color("#E6F7FB")).Padding(0, 1)
+	tuiAssistantBlockStyle    = lipgloss.NewStyle().Background(lipgloss.Color("#17141D")).Foreground(lipgloss.Color("#F0EAF7")).Padding(0, 1)
+	tuiThinkingBlockStyle     = lipgloss.NewStyle().Background(lipgloss.Color("#141723")).Foreground(lipgloss.Color("#D6CCFF")).Padding(0, 1)
+	tuiUserHoverStyle         = lipgloss.NewStyle().Background(lipgloss.Color("#17232A")).Foreground(lipgloss.Color("#ECFBFF")).Padding(0, 1)
+	tuiAssistantHoverStyle    = lipgloss.NewStyle().Background(lipgloss.Color("#211A2B")).Foreground(lipgloss.Color("#F7F1FF")).Padding(0, 1)
+	tuiThinkingHoverStyle     = lipgloss.NewStyle().Background(lipgloss.Color("#1A1E2E")).Foreground(lipgloss.Color("#E6DEFF")).Padding(0, 1)
+	tuiToolResultLabelStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#9AD5A0"))
+	tuiToolResultNameStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#8FA3B8"))
+	tuiToolResultLineStyle    = lipgloss.NewStyle().Background(lipgloss.Color("#151917")).Foreground(lipgloss.Color("#9CAAA0"))
+	tuiToolResultFocusStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#9CAAA0")).PaddingLeft(1).BorderStyle(lipgloss.Border{Left: "▌"}).BorderLeft(true).BorderForeground(lipgloss.Color("#4E8A57"))
+	tuiToolResultBlurredStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#9CAAA0")).PaddingLeft(2)
+	tuiThinkingStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("#A78BFA")).Italic(true)
+	tuiSidebarStyle           = lipgloss.NewStyle().Background(lipgloss.Color("#101014")).Foreground(lipgloss.Color("#E5E7EB")).Padding(1, 2)
+	tuiSidebarHeaderStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F9FAFB"))
+	tuiSidebarLabelStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF"))
+	tuiSidebarValueStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#F3F4F6"))
+	tuiPermissionLabelStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F59E0B"))
+	tuiPermissionBlockStyle   = lipgloss.NewStyle().Background(lipgloss.Color("#2A1F0F")).Foreground(lipgloss.Color("#FDE68A")).Padding(0, 1)
+	tuiSelectionStyle         = lipgloss.NewStyle().Background(lipgloss.Color("#E8E8E8")).Foreground(lipgloss.Color("#111111"))
+	tuiInputShellStyle        = lipgloss.NewStyle().Background(lipgloss.Color("#1C1C1C")).Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("#3B82F6"))
+	tuiInputAccentStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("#3B82F6"))
+	tuiTableBorderStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280"))
+	tuiTableHeaderStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("#C084FC")).Bold(true).Padding(0, 1)
+	tuiTableCellStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("#E5E7EB")).Padding(0, 1)
+	tuiTableAccentStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Bold(true)
+	ansiPrefixPattern         = regexp.MustCompile(`^(?:\x1b\[[0-9;]*m)*`)
+	omnicodeLogoLeft          = []string{
 		"                    ",
 		"█▀▀█ █▄  ▄█ █▄  █  █ ",
 		"█  █ █ ▀▀ █ █ ▀▄█  █ ",
@@ -108,6 +113,8 @@ var InitialConfig struct {
 const (
 	tuiSidebarWidth    = 30
 	tuiMinSidebarWidth = 60
+	// Align tool-result click hit-testing with perceived terminal row placement.
+	tuiToolResultHitRowOffset = 4
 )
 
 type logoStyle struct {
@@ -170,6 +177,9 @@ type transcriptSelection struct {
 	startY    int
 	endX      int
 	endY      int
+	pressLine int
+	pressIdx  int
+	pressID   int64
 }
 
 type progReadyMsg struct{ p *tea.Program }
@@ -827,7 +837,7 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if m.textarea.Focused() && !m.streamActive && len(msg.Runes) == 1 && msg.Runes[0] == ' ' && m.textarea.Value() == "" && m.hoveredEntry >= 0 && m.hoveredEntry < len(m.entries) {
 				entry := m.entries[m.hoveredEntry]
-				if entry.kind == transcriptToolResult && len(strings.Split(entry.content, "\n")) > toolResultMaxLines {
+				if entry.kind == transcriptToolResult {
 					if m.expandedEntries[entry.id] {
 						delete(m.expandedEntries, entry.id)
 					} else {
@@ -843,6 +853,9 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if m.historySearchMode {
 				m.applyHistorySearchResult()
+				return m, nil
+			}
+			if strings.TrimSpace(m.textarea.Value()) == "" && m.cycleExpandableToolResultFocus(-1) {
 				return m, nil
 			}
 			m.setAutoFollow(false)
@@ -862,6 +875,9 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return m, nil
 					}
 				}
+				return m, nil
+			}
+			if strings.TrimSpace(m.textarea.Value()) == "" && m.cycleExpandableToolResultFocus(1) {
 				return m, nil
 			}
 			m.updateAutoFollowFromViewport()
@@ -1154,13 +1170,7 @@ func (m chatTUIModel) View() string {
 		return "\n  Initializing…"
 	}
 
-	title := "OmniLLM Chat"
-	if m.mode != "" {
-		title += "  │  " + m.mode
-	}
-	if m.model != "" {
-		title += "  │  " + m.model
-	}
+	title := m.titleText()
 
 	div := tuiDivStyle.Render(strings.Repeat("─", tuiMax(0, m.mainWidth)))
 	var main strings.Builder
@@ -1188,6 +1198,17 @@ func (m chatTUIModel) View() string {
 		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, m.renderSessionPickerModal())
 	}
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, m.renderPickerModal())
+}
+
+func (m chatTUIModel) titleText() string {
+	title := "OmniLLM Chat"
+	if m.mode != "" {
+		title += "  │  " + m.mode
+	}
+	if m.model != "" {
+		title += "  │  " + m.model
+	}
+	return title
 }
 
 func (m chatTUIModel) renderTextarea() string {
@@ -1462,8 +1483,8 @@ func (m *chatTUIModel) renderTranscript() string {
 		lineCount := strings.Count(block, "\n") + 1
 		layoutEntry := transcriptLayoutEntry{kind: entry.kind, startLine: lineOffset, endLine: lineOffset + lineCount - 1}
 		if entry.kind == transcriptToolResult {
-			layoutEntry.clickableStartLine = lineOffset + 1
-			layoutEntry.clickableEndLine = lineOffset + lineCount - 1
+			layoutEntry.clickableStartLine = layoutEntry.startLine
+			layoutEntry.clickableEndLine = layoutEntry.endLine
 		}
 		layout = append(layout, layoutEntry)
 		lineOffset += lineCount + 2
@@ -1707,35 +1728,56 @@ func (m chatTUIModel) renderInfoSection(text string) string {
 }
 
 func (m chatTUIModel) renderToolResultSection(toolName, content string, expanded, hovered bool) string {
-	label := tuiThinkingLabelStyle.Render(fmt.Sprintf("✅ Tool `%s` returned", toolName))
+	label := tuiToolResultLabelStyle.Render("●") + " " + tuiToolResultNameStyle.Render(fmt.Sprintf("Tool %s", toolName))
+	rendered := m.renderToolResultOutput(content, expanded)
+	return m.renderToolResultItem(lipgloss.JoinVertical(lipgloss.Left, label, rendered), hovered)
+}
+
+func (m chatTUIModel) renderToolResultOutput(content string, expanded bool) string {
+	content = normalizeToolResultContent(content)
 	lines := strings.Split(content, "\n")
-	overflow := len(lines) > toolResultMaxLines
-	var body string
-	if expanded || !overflow {
-		body = content
-	} else {
-		body = strings.Join(lines[:toolResultMaxLines], "\n") + "\n…"
+	maxLines := toolResultMaxLines
+	if expanded {
+		maxLines = len(lines)
 	}
-	hint := ""
-	if overflow {
-		if expanded {
-			if hovered {
-				hint = tuiHelpStyle.Render("▾ (click or space to collapse)")
-			}
-		} else {
-			if hovered {
-				hint = tuiHelpStyle.Render(fmt.Sprintf("… (%d lines hidden) [click or space to expand]", len(lines)-toolResultMaxLines))
-			} else {
-				hint = tuiHelpStyle.Render(fmt.Sprintf("… (%d lines hidden)", len(lines)-toolResultMaxLines))
-			}
+
+	width := tuiMax(8, m.transcriptBlockMaxWidth()-2)
+	out := make([]string, 0, minInt(len(lines), maxLines)+1)
+	for i, line := range lines {
+		if i >= maxLines {
+			break
 		}
+		line = " " + line
+		if xansi.StringWidth(line) > width {
+			line = xansi.Truncate(line, width, "…")
+		}
+		out = append(out, tuiToolResultLineStyle.Width(width).Render(line))
 	}
-	rendered := m.renderThinkingBody(tuiThinkingStyle.Render(body), hovered)
-	parts := []string{label, rendered}
-	if hint != "" {
-		parts = append(parts, hint)
+
+	if !expanded && len(lines) > toolResultMaxLines {
+		out = append(out, tuiToolResultLineStyle.Width(width).Render(fmt.Sprintf("… (%d lines hidden) [click or space to expand]", len(lines)-toolResultMaxLines)))
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+	return strings.Join(out, "\n")
+}
+
+func (m chatTUIModel) renderToolResultItem(text string, focused bool) string {
+	style := tuiToolResultBlurredStyle
+	if focused {
+		style = tuiToolResultFocusStyle
+	}
+	prefix := style.Render("")
+	contentWidth := tuiMax(1, m.transcriptBlockMaxWidth()-lipgloss.Width(prefix))
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		lines[i] = prefix + xansi.Truncate(line, contentWidth, "…")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func normalizeToolResultContent(content string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\t", "    ")
+	return strings.TrimSpace(content)
 }
 
 func (m chatTUIModel) renderPermissionSection(text string) string {
@@ -1854,7 +1896,7 @@ func (m *chatTUIModel) saveConfig() {
 }
 
 func (m *chatTUIModel) clearSelection() {
-	m.selection = transcriptSelection{}
+	m.selection = transcriptSelection{pressLine: -1, pressIdx: -1, pressID: -1}
 }
 
 func (m *chatTUIModel) copySelection() {
@@ -1885,7 +1927,8 @@ func (m *chatTUIModel) updateAutoFollowFromViewport() {
 
 func (m *chatTUIModel) viewportBounds() (left, top, right, bottom int) {
 	left = 0
-	top = 2
+	title := tuiTitleStyle.Width(m.mainWidth).Render(m.titleText())
+	top = lipgloss.Height(title) + 1
 	right = m.mainWidth
 	bottom = top + m.viewport.Height
 	return left, top, right, bottom
@@ -1928,6 +1971,74 @@ func (m *chatTUIModel) updateHoveredEntry(localY int, insideViewport bool) bool 
 	m.hoveredEntry = next
 	m.syncViewport()
 	return true
+}
+
+func (m *chatTUIModel) toolResultIsExpandable(entry transcriptEntry) bool {
+	return entry.kind == transcriptToolResult
+}
+
+func (m *chatTUIModel) cycleExpandableToolResultFocus(direction int) bool {
+	if direction == 0 {
+		direction = 1
+	}
+	indices := make([]int, 0)
+	for i, entry := range m.entries {
+		if m.toolResultIsExpandable(entry) {
+			indices = append(indices, i)
+		}
+	}
+	if len(indices) == 0 {
+		return false
+	}
+
+	currentPos := -1
+	for pos, idx := range indices {
+		if idx == m.hoveredEntry {
+			currentPos = pos
+			break
+		}
+	}
+
+	var next int
+	if currentPos == -1 {
+		if direction > 0 {
+			next = indices[0]
+		} else {
+			next = indices[len(indices)-1]
+		}
+	} else {
+		if direction > 0 {
+			next = indices[(currentPos+1)%len(indices)]
+		} else {
+			next = indices[(currentPos-1+len(indices))%len(indices)]
+		}
+	}
+
+	m.hoveredEntry = next
+	m.scrollEntryIntoView(next)
+	m.syncViewport()
+	return true
+}
+
+func (m *chatTUIModel) scrollEntryIntoView(entryIdx int) {
+	if entryIdx < 0 || entryIdx >= len(m.transcriptLayout) {
+		return
+	}
+	layout := m.transcriptLayout[entryIdx]
+	if layout.startLine < m.viewport.YOffset {
+		m.viewport.SetYOffset(layout.startLine)
+		m.setAutoFollow(false)
+		return
+	}
+	bottom := m.viewport.YOffset + m.viewport.Height - 1
+	if layout.endLine > bottom {
+		offset := layout.endLine - m.viewport.Height + 1
+		if offset < 0 {
+			offset = 0
+		}
+		m.viewport.SetYOffset(offset)
+		m.setAutoFollow(false)
+	}
 }
 
 func (m *chatTUIModel) handleMouseEvent(msg tea.MouseMsg) bool {
@@ -1990,12 +2101,20 @@ func (m *chatTUIModel) handleMouseEvent(msg tea.MouseMsg) bool {
 		m.setAutoFollow(false)
 		return true
 	case msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress:
+		pressIdx := m.hoveredTranscriptEntry(mouseY)
+		pressID := int64(-1)
+		if pressIdx >= 0 && pressIdx < len(m.entries) {
+			pressID = m.entries[pressIdx].id
+		}
 		m.selection.active = true
 		m.selection.selecting = true
 		m.selection.startX = mouseX
 		m.selection.startY = mouseY
 		m.selection.endX = mouseX
 		m.selection.endY = mouseY
+		m.selection.pressLine = m.viewport.YOffset + mouseY
+		m.selection.pressIdx = pressIdx
+		m.selection.pressID = pressID
 		m.syncViewport()
 		return true
 	default:
@@ -2012,12 +2131,31 @@ func (m *chatTUIModel) finishTranscriptSelection(msg tea.MouseMsg) {
 	}
 	plainClick := m.selection.startX == m.selection.endX && m.selection.startY == m.selection.endY
 	if plainClick {
+		pressIdx := m.selection.pressIdx
+		pressLine := m.selection.pressLine
+		pressID := m.selection.pressID
 		m.clearSelection()
 		if insideViewport {
-			idx := m.hoveredTranscriptEntry(mouseY)
+			idx := m.transcriptEntryIndexByID(pressID)
+			if idx < 0 {
+				idx = pressIdx
+			}
+			if idx < 0 || idx >= len(m.entries) {
+				idx = m.hoveredTranscriptEntry(mouseY)
+			}
+			if pressIdx >= 0 && idx >= 0 && idx != pressIdx {
+				m.syncViewport()
+				return
+			}
 			if idx >= 0 && idx < len(m.entries) {
 				entry := m.entries[idx]
-				if entry.kind == transcriptToolResult && len(strings.Split(entry.content, "\n")) > toolResultMaxLines {
+				layout := m.transcriptLayout[idx]
+				if pressLine <= 0 {
+					pressLine = m.viewport.YOffset + mouseY
+				}
+				hitPressLine := pressLine + tuiToolResultHitRowOffset
+				if entry.kind == transcriptToolResult &&
+					hitPressLine >= layout.clickableStartLine && hitPressLine <= layout.clickableEndLine {
 					if m.expandedEntries[entry.id] {
 						delete(m.expandedEntries, entry.id)
 					} else {
@@ -2038,6 +2176,18 @@ func (m *chatTUIModel) finishTranscriptSelection(msg tea.MouseMsg) {
 	m.selection.active = true
 	m.copySelection()
 	m.syncViewport()
+}
+
+func (m *chatTUIModel) transcriptEntryIndexByID(id int64) int {
+	if id <= 0 {
+		return -1
+	}
+	for idx, entry := range m.entries {
+		if entry.id == id {
+			return idx
+		}
+	}
+	return -1
 }
 
 func (m chatTUIModel) selectedTranscriptText() string {
@@ -2610,7 +2760,7 @@ func (m chatTUIModel) handleSlash(text string) (tea.Model, tea.Cmd) {
 		m.syncViewport()
 		return m, nil
 	case "/help", "?":
-		add(m.renderMD("**Commands:**\n\n- `/help` or `?` — show this help\n- `/new [title]` — start a new session\n- `/sessions` — browse and resume a previous session\n- `/session` — show current session info\n- `/mode` — show current mode\n- `/mode <chat|agent>` — switch mode\n- `/apishape` — show the fixed agent API request shape\n- `/apishape <anthropic>` — keep the agent API request shape on `/v1/messages`\n- `/permissions` — toggle autopilot (auto-approve tool calls)\n- `/model` — show current model\n- `/model <id>` — switch model\n- `/agent` — show the fixed google-adk backend\n- `/agent <google-adk>` — keep the agent backend on google-adk\n- `/max-turns [1-100]` — show or set max agent turns (default 25)\n- `/models` — open model picker\n- `/clear` or `/cls` — clear the screen\n- `/quit` or `/exit` — quit\n\n**Keyboard shortcuts:**\n\n- `Shift+Tab` — toggle autopilot (auto-approve tool calls)\n- `Ctrl+O` — toggle expand/collapse for all tool results\n- `Esc` — cancel current running job\n- The right-hand panel always shows permission and session status\n"))
+		add(m.renderMD("**Commands:**\n\n- `/help` or `?` — show this help\n- `/new [title]` — start a new session\n- `/sessions` — browse and resume a previous session\n- `/session` — show current session info\n- `/mode` — show current mode\n- `/mode <chat|agent>` — switch mode\n- `/apishape` — show the fixed agent API request shape\n- `/apishape <anthropic>` — keep the agent API request shape on `/v1/messages`\n- `/permissions` — toggle autopilot (auto-approve tool calls)\n- `/model` — show current model\n- `/model <id>` — switch model\n- `/agent` — show the fixed google-adk backend\n- `/agent <google-adk>` — keep the agent backend on google-adk\n- `/max-turns [1-100]` — show or set max agent turns (default 25)\n- `/models` — open model picker\n- `/clear` or `/cls` — clear the screen\n- `/quit` or `/exit` — quit\n\n**Keyboard shortcuts:**\n\n- `Shift+Tab` — toggle autopilot (auto-approve tool calls)\n- `↑`/`↓` — focus expandable tool results (when input is empty)\n- `Space` — expand/collapse the focused tool result\n- `Esc` — cancel current running job\n- The right-hand panel always shows permission and session status\n"))
 		return m, nil
 	case "/session":
 		add(m.renderMD(fmt.Sprintf("**Session:** `%s`\n**Mode:** `%s`\n**API Shape:** `%s`\n**Model:** `%s`", m.sessionID, m.mode, formatAPIShape(m.apiShape), m.model)))

--- a/internal/chat/tui.go
+++ b/internal/chat/tui.go
@@ -807,14 +807,6 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.saveConfig()
 			m.syncViewport()
 			return m, nil
-		case tea.KeyCtrlO:
-			if !m.textarea.Focused() || m.streamActive {
-				break
-			}
-			if m.toggleAllExpandableEntries() {
-				m.syncViewport()
-			}
-			return m, nil
 		case tea.KeyRunes:
 			if (msg.Paste || len(msg.Runes) > 1) && m.textarea.Focused() {
 				if !m.streamActive {
@@ -832,6 +824,18 @@ func (m chatTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.textarea.Focused() && !m.streamActive && len(msg.Runes) == 1 && msg.Runes[0] == '?' && strings.TrimSpace(m.textarea.Value()) == "" {
 				m.showInlineHelp = !m.showInlineHelp
 				return m, nil
+			}
+			if m.textarea.Focused() && !m.streamActive && len(msg.Runes) == 1 && msg.Runes[0] == ' ' && m.textarea.Value() == "" && m.hoveredEntry >= 0 && m.hoveredEntry < len(m.entries) {
+				entry := m.entries[m.hoveredEntry]
+				if entry.kind == transcriptToolResult && len(strings.Split(entry.content, "\n")) > toolResultMaxLines {
+					if m.expandedEntries[entry.id] {
+						delete(m.expandedEntries, entry.id)
+					} else {
+						m.expandedEntries[entry.id] = true
+					}
+					m.syncViewport()
+					return m, nil
+				}
 			}
 		case tea.KeyUp, tea.KeyCtrlP:
 			if !m.textarea.Focused() || m.streamActive {
@@ -1609,7 +1613,7 @@ func (m chatTUIModel) renderFooterStatus() string {
 		return status
 	}
 	if m.showInlineHelp {
-		return tuiStatusStyle.Width(m.transcriptBlockMaxWidth()).Render("Enter send · Ctrl+J newline · Ctrl+O expand/collapse tool results · Ctrl+R search · Shift+Tab autopilot · ? hide help · /help commands")
+		return tuiStatusStyle.Width(m.transcriptBlockMaxWidth()).Render("Enter send · Ctrl+J newline · Space expand focused tool result · Ctrl+R search · Shift+Tab autopilot · ? hide help · /help commands")
 	}
 	status := "Enter send · Ctrl+J newline · ? help"
 	if m.streamActive {
@@ -1715,9 +1719,15 @@ func (m chatTUIModel) renderToolResultSection(toolName, content string, expanded
 	hint := ""
 	if overflow {
 		if expanded {
-			hint = tuiHelpStyle.Render("▾ (expanded)")
+			if hovered {
+				hint = tuiHelpStyle.Render("▾ (click or space to collapse)")
+			}
 		} else {
-			hint = tuiHelpStyle.Render(fmt.Sprintf("▸ (+%d lines hidden — Ctrl+O expand all)", len(lines)-toolResultMaxLines))
+			if hovered {
+				hint = tuiHelpStyle.Render(fmt.Sprintf("… (%d lines hidden) [click or space to expand]", len(lines)-toolResultMaxLines))
+			} else {
+				hint = tuiHelpStyle.Render(fmt.Sprintf("… (%d lines hidden)", len(lines)-toolResultMaxLines))
+			}
 		}
 	}
 	rendered := m.renderThinkingBody(tuiThinkingStyle.Render(body), hovered)
@@ -1726,31 +1736,6 @@ func (m chatTUIModel) renderToolResultSection(toolName, content string, expanded
 		parts = append(parts, hint)
 	}
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
-}
-
-func (m *chatTUIModel) toggleAllExpandableEntries() bool {
-	ids := make([]int64, 0)
-	expand := false
-	for _, entry := range m.entries {
-		if entry.kind != transcriptToolResult || len(strings.Split(entry.content, "\n")) <= toolResultMaxLines {
-			continue
-		}
-		ids = append(ids, entry.id)
-		if !m.expandedEntries[entry.id] {
-			expand = true
-		}
-	}
-	if len(ids) == 0 {
-		return false
-	}
-	for _, id := range ids {
-		if expand {
-			m.expandedEntries[id] = true
-		} else {
-			delete(m.expandedEntries, id)
-		}
-	}
-	return true
 }
 
 func (m chatTUIModel) renderPermissionSection(text string) string {
@@ -2028,6 +2013,19 @@ func (m *chatTUIModel) finishTranscriptSelection(msg tea.MouseMsg) {
 	plainClick := m.selection.startX == m.selection.endX && m.selection.startY == m.selection.endY
 	if plainClick {
 		m.clearSelection()
+		if insideViewport {
+			idx := m.hoveredTranscriptEntry(mouseY)
+			if idx >= 0 && idx < len(m.entries) {
+				entry := m.entries[idx]
+				if entry.kind == transcriptToolResult && len(strings.Split(entry.content, "\n")) > toolResultMaxLines {
+					if m.expandedEntries[entry.id] {
+						delete(m.expandedEntries, entry.id)
+					} else {
+						m.expandedEntries[entry.id] = true
+					}
+				}
+			}
+		}
 		m.syncViewport()
 		return
 	}


### PR DESCRIPTION
## Summary
- Add per-item expand/collapse for tool results in the chat TUI
- Enhance tool result interactions and focus cycling
- Include design spec doc for the per-item expand/collapse feature

## Test plan
- [ ] `go test ./internal/chat/...`
- [ ] Manually exercise TUI: expand/collapse individual tool results, cycle focus