### PR TITLE
fix(tools): gate speckit lifecycle tools behind the spec skill

### DIFF
--- a/internal/tools/groups.go
+++ b/internal/tools/groups.go
@@ -189,7 +189,7 @@ func InitSkillMembership(r *Registry) {
 	// spec skill
 	for _, name := range []string{
 		"spec_init", "spec_write", "spec_read", "spec_plan", "spec_tasks", "spec_status",
-		"speckit_constitution", "speckit_specify", "speckit_clarify", "speckit_plan", "speckit_tasks", "speckit_analyze", "speckit_implement", "speckit_checklist",
+		"speckit_constitution", "speckit_specify", "speckit_clarify", "speckit_plan", "speckit_tasks", "speckit_analyze", "speckit_implement", "speckit_checklist", "speckit_lifecycle_status", "speckit_complete", "speckit_archive",
 		"openspec_propose", "openspec_explore", "openspec_new", "openspec_continue", "openspec_ff", "openspec_apply", "openspec_verify", "openspec_sync", "openspec_archive", "openspec_bulk_archive", "openspec_onboard",
 		"openspec_legacy_proposal", "openspec_legacy_apply", "openspec_legacy_archive",
 	} {

--- a/internal/tools/skill_test.go
+++ b/internal/tools/skill_test.go
@@ -37,6 +37,27 @@ func TestDefinitionsFiltersByActiveSkill(t *testing.T) {
 	}
 }
 
+func TestSpecKitLifecycleToolsGatedBySpecSkill(t *testing.T) {
+	r := newFullRegistry(t)
+
+	gated := []string{"speckit_lifecycle_status", "speckit_complete", "speckit_archive"}
+
+	before := defNameSet(r.Definitions())
+	for _, name := range gated {
+		if before[name] {
+			t.Errorf("%s should NOT be visible before load_skill(%q)", name, SkillSpec)
+		}
+	}
+
+	r.ActivateSkill(SkillSpec)
+	after := defNameSet(r.Definitions())
+	for _, name := range gated {
+		if !after[name] {
+			t.Errorf("%s should be visible after load_skill(%q)", name, SkillSpec)
+		}
+	}
+}
+
 func TestIsSkillActiveAndActiveSkillNames(t *testing.T) {
 	r := newFullRegistry(t)
 
@@ -75,10 +96,13 @@ func TestToolSkillMembership(t *testing.T) {
 	}
 	// Known skill tools (using actual registered names).
 	cases := map[string]string{
-		"web_fetch":     SkillWeb,
-		"task_create":   SkillTask,
-		"notebook_edit": SkillFilesystem, // notebook_edit is in the filesystem skill group
-		"multiedit":     SkillFilesystem,
+		"web_fetch":                SkillWeb,
+		"task_create":              SkillTask,
+		"notebook_edit":            SkillFilesystem, // notebook_edit is in the filesystem skill group
+		"multiedit":                SkillFilesystem,
+		"speckit_lifecycle_status": SkillSpec,
+		"speckit_complete":         SkillSpec,
+		"speckit_archive":          SkillSpec,
 	}
 	for tool, wantSkill := range cases {
 		got := r.ToolSkill(tool)


### PR DESCRIPTION
speckit_lifecycle_status, speckit_complete, and speckit_archive were registered as core tools in RegisterCoreTools but never added to the spec skill group in InitSkillMembership. Registry.Definitions() treats tools with no skill mapping as always-visible, so these three appeared in every agent session without requiring load_skill("spec") — while their siblings (speckit_specify, speckit_plan, speckit_tasks, etc.) remained correctly gated. The result was an inconsistent tool surface: half the speckit_* lifecycle commands materialised before the agent loaded the skill, half did not.

Add the three names to the spec skill membership list so they follow the same gating rule as the rest of the speckit_* family.

Tests:
- Extend TestToolSkillMembership to assert ToolSkill() returns "spec" for the three previously-leaking tools (guards the mapping).
- Add TestSpecKitLifecycleToolsGatedBySpecSkill which exercises the actual visibility behaviour: the tools must be absent from Definitions() before ActivateSkill("spec") and present after.

Both tests fail on master without the one-line groups.go change and pass with it. Full internal/tools test suite is green.