### PR TITLE
feat: unify /openspec:* namespace, add /speckit.taskstoissues, simplify code

### DIFF
--- a/internal/agent/session_runner.go
+++ b/internal/agent/session_runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"omnillm/internal/tools"
@@ -170,6 +171,11 @@ func detectHostOS() string {
 	return osName
 }
 
+// systemPromptCache memoizes the rendered system prompt per OS. The prompt
+// is ~2KB and rendered on every agent turn; the inputs are stable per run, so
+// the result is safe to cache for the lifetime of the process.
+var systemPromptCache sync.Map // map[string]string
+
 // buildSystemPrompt returns an OS-aware system prompt so the LLM generates
 // shell commands appropriate for the host platform.
 func buildSystemPrompt(osName string) string {
@@ -177,6 +183,15 @@ func buildSystemPrompt(osName string) string {
 	if osName == "" {
 		osName = detectHostOS()
 	}
+	if cached, ok := systemPromptCache.Load(osName); ok {
+		return cached.(string)
+	}
+	prompt := renderSystemPrompt(osName)
+	systemPromptCache.Store(osName, prompt)
+	return prompt
+}
+
+func renderSystemPrompt(osName string) string {
 	shellTool := "bash"
 	shellSyntax := "bash/sh"
 	wrongShellRule := "Do not use the powershell tool unless the OS is windows."

--- a/internal/chat/repl.go
+++ b/internal/chat/repl.go
@@ -480,6 +480,11 @@ func handleDirectSpecCommand(w io.Writer, fields []string) (bool, error) {
 		return false, nil
 	}
 	name := strings.ToLower(fields[0])
+	// Backwards compat: rewrite the deprecated /opsx:* aliases to canonical
+	// /openspec:* form so the switch below only needs one branch per command.
+	if strings.HasPrefix(name, "/opsx:") {
+		name = "/openspec:" + strings.TrimPrefix(name, "/opsx:")
+	}
 	arg := strings.TrimSpace(strings.Join(fields[1:], " "))
 
 	switch name {
@@ -493,7 +498,7 @@ func handleDirectSpecCommand(w io.Writer, fields []string) (bool, error) {
 			_, _ = fmt.Fprintf(w, "Error: %v\n", err)
 		}
 		return true, nil
-	case "/openspec:init", "/opsx:init":
+	case "/openspec:init":
 		if arg == "" {
 			_, _ = fmt.Fprintln(w, "Usage: /openspec:init <change-name>")
 			_, _ = fmt.Fprintln(w, "Example: /openspec:init add-user-auth")
@@ -515,7 +520,7 @@ func handleDirectSpecCommand(w io.Writer, fields []string) (bool, error) {
 	case "/speckit.help":
 		_, _ = fmt.Fprint(w, specKitHelpMarkdown())
 		return true, nil
-	case "/openspec:help", "/opsx:help":
+	case "/openspec:help":
 		_, _ = fmt.Fprint(w, openSpecHelpMarkdown())
 		return true, nil
 	}

--- a/internal/chat/slash_commands.go
+++ b/internal/chat/slash_commands.go
@@ -14,53 +14,58 @@ type slashCommand struct {
 	TakesArgs bool     // true when the command accepts arguments
 }
 
+// slashCommandCatalog is the canonical built-in slash command list. The
+// order is what /help and the empty-filter picker use.
+var slashCommandCatalog = []slashCommand{
+	{Name: "/help", Aliases: []string{"?"}, Summary: "show available commands"},
+	{Name: "/new", TakesArgs: true, Summary: "start a new session [title]"},
+	{Name: "/sessions", Summary: "browse and resume a previous session"},
+	{Name: "/session", Summary: "show current session info"},
+	{Name: "/mode", TakesArgs: true, Summary: "show or switch mode (chat|agent)"},
+	{Name: "/apishape", Aliases: []string{"/api-shape"}, TakesArgs: true, Summary: "show or set the agent API request shape"},
+	{Name: "/permissions", Summary: "toggle autopilot (auto-approve tool calls)"},
+	{Name: "/model", TakesArgs: true, Summary: "show or switch model"},
+	{Name: "/agent", TakesArgs: true, Summary: "show or set the agent backend"},
+	{Name: "/max-turns", TakesArgs: true, Summary: "show or set max agent turns (1-100)"},
+	{Name: "/models", Summary: "open model picker"},
+	{Name: "/specify.init", TakesArgs: true, Summary: "Spec Kit: scaffold a new spec directory [title] (offline)"},
+	{Name: "/speckit.constitution", TakesArgs: true, Summary: "Spec Kit: create/update project constitution"},
+	{Name: "/speckit.specify", TakesArgs: true, Summary: "Spec Kit: create/update feature spec"},
+	{Name: "/speckit.clarify", TakesArgs: true, Summary: "Spec Kit: clarify open questions"},
+	{Name: "/speckit.plan", TakesArgs: true, Summary: "Spec Kit: create implementation plan"},
+	{Name: "/speckit.tasks", TakesArgs: true, Summary: "Spec Kit: generate tasks"},
+	{Name: "/speckit.analyze", TakesArgs: true, Summary: "Spec Kit: analyze artifact consistency"},
+	{Name: "/speckit.implement", TakesArgs: true, Summary: "Spec Kit: implement task plan"},
+	{Name: "/speckit.taskstoissues", TakesArgs: true, Summary: "Spec Kit: convert tasks.md into GitHub issues (requires gh)"},
+	{Name: "/speckit.lifecycle", TakesArgs: true, Summary: "Spec Kit: show lifecycle state and guidance"},
+	{Name: "/speckit.complete", TakesArgs: true, Summary: "Spec Kit: mark a spec completed"},
+	{Name: "/speckit.archive", TakesArgs: true, Summary: "Spec Kit: archive a completed spec"},
+	{Name: "/speckit.checklist", TakesArgs: true, Summary: "Spec Kit: generate checklist"},
+	{Name: "/speckit.status", TakesArgs: true, Summary: "Spec Kit: list specs and artifact status [dir] (offline)"},
+	{Name: "/speckit.help", Summary: "Spec Kit: show workflow help and command list"},
+	{Name: "/openspec:init", TakesArgs: true, Aliases: []string{"/opsx:init"}, Summary: "OpenSpec: scaffold a new change directory [name] (offline)"},
+	{Name: "/openspec:propose", TakesArgs: true, Aliases: []string{"/opsx:propose"}, Summary: "OpenSpec: create a change and planning artifacts"},
+	{Name: "/openspec:explore", TakesArgs: true, Aliases: []string{"/opsx:explore"}, Summary: "OpenSpec: explore ideas before a change"},
+	{Name: "/openspec:apply", TakesArgs: true, Aliases: []string{"/opsx:apply"}, Summary: "OpenSpec: implement or report pending tasks"},
+	{Name: "/openspec:sync", TakesArgs: true, Aliases: []string{"/opsx:sync"}, Summary: "OpenSpec: sync delta specs into main specs"},
+	{Name: "/openspec:archive", TakesArgs: true, Aliases: []string{"/opsx:archive"}, Summary: "OpenSpec: archive a completed change"},
+	{Name: "/openspec:new", TakesArgs: true, Aliases: []string{"/opsx:new"}, Summary: "OpenSpec: start a change scaffold"},
+	{Name: "/openspec:continue", TakesArgs: true, Aliases: []string{"/opsx:continue"}, Summary: "OpenSpec: create next ready artifact"},
+	{Name: "/openspec:ff", TakesArgs: true, Aliases: []string{"/opsx:ff"}, Summary: "OpenSpec: fast-forward planning artifacts"},
+	{Name: "/openspec:verify", TakesArgs: true, Aliases: []string{"/opsx:verify"}, Summary: "OpenSpec: verify implementation against artifacts"},
+	{Name: "/openspec:bulk-archive", TakesArgs: true, Aliases: []string{"/opsx:bulk-archive"}, Summary: "OpenSpec: archive multiple changes"},
+	{Name: "/openspec:onboard", Aliases: []string{"/opsx:onboard"}, Summary: "OpenSpec: guided workflow tutorial"},
+	{Name: "/openspec:help", Aliases: []string{"/opsx:help"}, Summary: "OpenSpec: show workflow help and command list"},
+	{Name: "/clear", Aliases: []string{"/cls"}, Summary: "clear the screen"},
+	{Name: "/quit", Aliases: []string{"/exit"}, Summary: "quit"},
+}
+
 // slashCommands returns the static catalog of built-in slash commands.
-// The order is the order in which they are presented in /help and as
-// the initial picker order before any filter is applied.
+// The returned slice is a defensive copy so callers may sort/filter freely.
 func slashCommands() []slashCommand {
-	return []slashCommand{
-		{Name: "/help", Aliases: []string{"?"}, Summary: "show available commands"},
-		{Name: "/new", TakesArgs: true, Summary: "start a new session [title]"},
-		{Name: "/sessions", Summary: "browse and resume a previous session"},
-		{Name: "/session", Summary: "show current session info"},
-		{Name: "/mode", TakesArgs: true, Summary: "show or switch mode (chat|agent)"},
-		{Name: "/apishape", Aliases: []string{"/api-shape"}, TakesArgs: true, Summary: "show or set the agent API request shape"},
-		{Name: "/permissions", Summary: "toggle autopilot (auto-approve tool calls)"},
-		{Name: "/model", TakesArgs: true, Summary: "show or switch model"},
-		{Name: "/agent", TakesArgs: true, Summary: "show or set the agent backend"},
-		{Name: "/max-turns", TakesArgs: true, Summary: "show or set max agent turns (1-100)"},
-		{Name: "/models", Summary: "open model picker"},
-		{Name: "/specify.init", TakesArgs: true, Summary: "Spec Kit: scaffold a new spec directory [title] (offline)"},
-		{Name: "/speckit.constitution", TakesArgs: true, Summary: "Spec Kit: create/update project constitution"},
-		{Name: "/speckit.specify", TakesArgs: true, Summary: "Spec Kit: create/update feature spec"},
-		{Name: "/speckit.clarify", TakesArgs: true, Summary: "Spec Kit: clarify open questions"},
-		{Name: "/speckit.plan", TakesArgs: true, Summary: "Spec Kit: create implementation plan"},
-		{Name: "/speckit.tasks", TakesArgs: true, Summary: "Spec Kit: generate tasks"},
-		{Name: "/speckit.analyze", TakesArgs: true, Summary: "Spec Kit: analyze artifact consistency"},
-		{Name: "/speckit.implement", TakesArgs: true, Summary: "Spec Kit: implement task plan"},
-		{Name: "/speckit.taskstoissues", TakesArgs: true, Summary: "Spec Kit: convert tasks.md into GitHub issues (requires gh)"},
-		{Name: "/speckit.lifecycle", TakesArgs: true, Summary: "Spec Kit: show lifecycle state and guidance"},
-		{Name: "/speckit.complete", TakesArgs: true, Summary: "Spec Kit: mark a spec completed"},
-		{Name: "/speckit.archive", TakesArgs: true, Summary: "Spec Kit: archive a completed spec"},
-		{Name: "/speckit.checklist", TakesArgs: true, Summary: "Spec Kit: generate checklist"},
-		{Name: "/speckit.status", TakesArgs: true, Summary: "Spec Kit: list specs and artifact status [dir] (offline)"},
-		{Name: "/speckit.help", Summary: "Spec Kit: show workflow help and command list"},
-		{Name: "/openspec:init", TakesArgs: true, Aliases: []string{"/opsx:init"}, Summary: "OpenSpec: scaffold a new change directory [name] (offline)"},
-		{Name: "/openspec:propose", TakesArgs: true, Aliases: []string{"/opsx:propose"}, Summary: "OpenSpec: create a change and planning artifacts"},
-		{Name: "/openspec:explore", TakesArgs: true, Aliases: []string{"/opsx:explore"}, Summary: "OpenSpec: explore ideas before a change"},
-		{Name: "/openspec:apply", TakesArgs: true, Aliases: []string{"/opsx:apply"}, Summary: "OpenSpec: implement or report pending tasks"},
-		{Name: "/openspec:sync", TakesArgs: true, Aliases: []string{"/opsx:sync"}, Summary: "OpenSpec: sync delta specs into main specs"},
-		{Name: "/openspec:archive", TakesArgs: true, Aliases: []string{"/opsx:archive"}, Summary: "OpenSpec: archive a completed change"},
-		{Name: "/openspec:new", TakesArgs: true, Aliases: []string{"/opsx:new"}, Summary: "OpenSpec: start a change scaffold"},
-		{Name: "/openspec:continue", TakesArgs: true, Aliases: []string{"/opsx:continue"}, Summary: "OpenSpec: create next ready artifact"},
-		{Name: "/openspec:ff", TakesArgs: true, Aliases: []string{"/opsx:ff"}, Summary: "OpenSpec: fast-forward planning artifacts"},
-		{Name: "/openspec:verify", TakesArgs: true, Aliases: []string{"/opsx:verify"}, Summary: "OpenSpec: verify implementation against artifacts"},
-		{Name: "/openspec:bulk-archive", TakesArgs: true, Aliases: []string{"/opsx:bulk-archive"}, Summary: "OpenSpec: archive multiple changes"},
-		{Name: "/openspec:onboard", Aliases: []string{"/opsx:onboard"}, Summary: "OpenSpec: guided workflow tutorial"},
-		{Name: "/openspec:help", Aliases: []string{"/opsx:help"}, Summary: "OpenSpec: show workflow help and command list"},
-		{Name: "/clear", Aliases: []string{"/cls"}, Summary: "clear the screen"},
-		{Name: "/quit", Aliases: []string{"/exit"}, Summary: "quit"},
-	}
+	out := make([]slashCommand, len(slashCommandCatalog))
+	copy(out, slashCommandCatalog)
+	return out
 }
 
 // fuzzySlashFilter ranks the catalog against filter using the same

--- a/internal/chat/spec_repl.go
+++ b/internal/chat/spec_repl.go
@@ -17,7 +17,7 @@ import (
 // speckit_tasks steps.
 func specREPLInit(w io.Writer, title string) error {
 	specsRoot := "specs"
-	number, err := nextSpecNumber(specsRoot)
+	number, err := specdriven.NextSpecNumber(specsRoot)
 	if err != nil {
 		return err
 	}
@@ -78,13 +78,23 @@ func openSpecREPLInit(w io.Writer, changeName string) error {
 		if err := os.MkdirAll(filepath.Dir(artPath), 0o755); err != nil {
 			return fmt.Errorf("create dir for %s: %w", art.Filename, err)
 		}
-		if _, err := os.Stat(artPath); err == nil {
-			continue // do not overwrite existing artifacts
-		}
 		body := fmt.Sprintf("# %s — %s\n\nTODO: fill in this artifact.\n",
 			strings.ToTitle(art.ID), changeName)
-		if err := os.WriteFile(artPath, []byte(body), 0o644); err != nil {
+		// O_EXCL avoids the TOCTOU race of stat-then-write; if the file
+		// already exists we leave it untouched and continue.
+		f, err := os.OpenFile(artPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if err != nil {
+			if os.IsExist(err) {
+				continue
+			}
 			return fmt.Errorf("write %s: %w", art.Filename, err)
+		}
+		if _, err := f.WriteString(body); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("write %s: %w", art.Filename, err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", art.Filename, err)
 		}
 		created = append(created, artPath)
 	}
@@ -96,7 +106,7 @@ func openSpecREPLInit(w io.Writer, changeName string) error {
 	_, _ = fmt.Fprintln(w, "")
 	_, _ = fmt.Fprintln(w, "Next steps:")
 	_, _ = fmt.Fprintln(w, "  1. Switch to agent mode:  /mode agent")
-	_, _ = fmt.Fprintf(w, "  2. Refine via the agent:  /opsx:propose %s\n", changeName)
+	_, _ = fmt.Fprintf(w, "  2. Refine via the agent:  /openspec:propose %s\n", changeName)
 	return nil
 }
 
@@ -136,31 +146,8 @@ func specREPLStatus(w io.Writer, specsRoot string) error {
 	return nil
 }
 
-// nextSpecNumber scans specsRoot for existing numbered directories and returns
-// the next zero-padded number string. Mirrors the same helper in specdriven.go.
-func nextSpecNumber(specsRoot string) (string, error) {
-	entries, err := os.ReadDir(specsRoot)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "001", nil
-		}
-		return "", err
-	}
-	max := 0
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if len(name) >= 3 {
-			var n int
-			if _, err := fmt.Sscanf(name[:3], "%d", &n); err == nil && n > max {
-				max = n
-			}
-		}
-	}
-	return fmt.Sprintf("%03d", max+1), nil
-}
+
+
 
 // specKitHelpMarkdown returns the help text for the Spec Kit workflow,
 // shown by /speckit.help. It documents the lifecycle, the offline scaffold

--- a/internal/specdriven/openspec.go
+++ b/internal/specdriven/openspec.go
@@ -16,28 +16,29 @@ type OpenSpecCommand struct {
 	Profile  string
 }
 
+// openSpecCommands is the canonical OpenSpec inventory under the
+// `/openspec:*` namespace. The previous `/opsx:*` aliases remain accepted at
+// the chat layer for backwards compatibility but are not enumerated here.
+var openSpecCommands = []OpenSpecCommand{
+	{Slash: "/openspec:propose", Tool: "openspec_propose", Summary: "create a change and generate planning artifacts", Artifact: "openspec/changes/<change>/", Profile: "core"},
+	{Slash: "/openspec:explore", Tool: "openspec_explore", Summary: "investigate ideas before committing to a change", Artifact: "exploration notes", Profile: "core"},
+	{Slash: "/openspec:apply", Tool: "openspec_apply", Summary: "implement or report pending tasks from a change", Artifact: "tasks.md status", Profile: "core"},
+	{Slash: "/openspec:sync", Tool: "openspec_sync", Summary: "merge delta specs into main OpenSpec specs", Artifact: "openspec/specs/", Profile: "core"},
+	{Slash: "/openspec:archive", Tool: "openspec_archive", Summary: "archive a completed change", Artifact: "openspec/changes/archive/", Profile: "core"},
+	{Slash: "/openspec:new", Tool: "openspec_new", Summary: "start a new change scaffold", Artifact: ".openspec.yaml", Profile: "expanded"},
+	{Slash: "/openspec:continue", Tool: "openspec_continue", Summary: "create the next ready artifact", Artifact: "next missing artifact", Profile: "expanded"},
+	{Slash: "/openspec:ff", Tool: "openspec_ff", Summary: "fast-forward all planning artifacts", Artifact: "proposal/specs/design/tasks", Profile: "expanded"},
+	{Slash: "/openspec:verify", Tool: "openspec_verify", Summary: "validate implementation against artifacts", Artifact: "verification.md", Profile: "expanded"},
+	{Slash: "/openspec:bulk-archive", Tool: "openspec_bulk_archive", Summary: "archive multiple completed changes", Artifact: "archive folders", Profile: "expanded"},
+	{Slash: "/openspec:onboard", Tool: "openspec_onboard", Summary: "guided tutorial through the workflow", Artifact: "onboarding plan", Profile: "expanded"},
+}
+
 // OpenSpecCommands returns the supported OpenSpec command inventory.
-//
-// As of the unification, all modern commands live under the `/openspec:*`
-// namespace. The previous `/opsx:*` aliases remain accepted at the chat
-// layer for one release for backwards compatibility, but are not enumerated
-// here. The original three `/openspec:proposal`, `/openspec:apply`,
-// `/openspec:archive` legacy commands have been retired (the modern
-// `/openspec:apply` and `/openspec:archive` now serve the same purpose).
+// Returned slice is a copy; callers may mutate it freely.
 func OpenSpecCommands() []OpenSpecCommand {
-	return []OpenSpecCommand{
-		{Slash: "/openspec:propose", Tool: "openspec_propose", Summary: "create a change and generate planning artifacts", Artifact: "openspec/changes/<change>/", Profile: "core"},
-		{Slash: "/openspec:explore", Tool: "openspec_explore", Summary: "investigate ideas before committing to a change", Artifact: "exploration notes", Profile: "core"},
-		{Slash: "/openspec:apply", Tool: "openspec_apply", Summary: "implement or report pending tasks from a change", Artifact: "tasks.md status", Profile: "core"},
-		{Slash: "/openspec:sync", Tool: "openspec_sync", Summary: "merge delta specs into main OpenSpec specs", Artifact: "openspec/specs/", Profile: "core"},
-		{Slash: "/openspec:archive", Tool: "openspec_archive", Summary: "archive a completed change", Artifact: "openspec/changes/archive/", Profile: "core"},
-		{Slash: "/openspec:new", Tool: "openspec_new", Summary: "start a new change scaffold", Artifact: ".openspec.yaml", Profile: "expanded"},
-		{Slash: "/openspec:continue", Tool: "openspec_continue", Summary: "create the next ready artifact", Artifact: "next missing artifact", Profile: "expanded"},
-		{Slash: "/openspec:ff", Tool: "openspec_ff", Summary: "fast-forward all planning artifacts", Artifact: "proposal/specs/design/tasks", Profile: "expanded"},
-		{Slash: "/openspec:verify", Tool: "openspec_verify", Summary: "validate implementation against artifacts", Artifact: "verification.md", Profile: "expanded"},
-		{Slash: "/openspec:bulk-archive", Tool: "openspec_bulk_archive", Summary: "archive multiple completed changes", Artifact: "archive folders", Profile: "expanded"},
-		{Slash: "/openspec:onboard", Tool: "openspec_onboard", Summary: "guided tutorial through the workflow", Artifact: "onboarding plan", Profile: "expanded"},
-	}
+	out := make([]OpenSpecCommand, len(openSpecCommands))
+	copy(out, openSpecCommands)
+	return out
 }
 
 // RenderOpenSpecCommandTable returns a compact markdown table for help output.
@@ -45,8 +46,8 @@ func RenderOpenSpecCommandTable() string {
 	var sb strings.Builder
 	sb.WriteString("| Command | Agent tool | Profile | Purpose | Artifact |\n")
 	sb.WriteString("| --- | --- | --- | --- | --- |\n")
-	for _, cmd := range OpenSpecCommands() {
-		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %s | %s | `%s` |\n", cmd.Slash, cmd.Tool, cmd.Profile, cmd.Summary, cmd.Artifact))
+	for _, cmd := range openSpecCommands {
+		fmt.Fprintf(&sb, "| `%s` | `%s` | %s | %s | `%s` |\n", cmd.Slash, cmd.Tool, cmd.Profile, cmd.Summary, cmd.Artifact)
 	}
 	return sb.String()
 }

--- a/internal/specdriven/spec.go
+++ b/internal/specdriven/spec.go
@@ -11,6 +11,7 @@ package specdriven
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -191,4 +192,32 @@ func Slugify(title string) string {
 		slug = strings.TrimRight(slug, "-")
 	}
 	return slug
+}
+
+// NextSpecNumber scans specsRoot for existing numbered directories and
+// returns the next zero-padded 3-digit number. Returns "001" if specsRoot
+// does not exist.
+func NextSpecNumber(specsRoot string) (string, error) {
+	entries, err := os.ReadDir(specsRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "001", nil
+		}
+		return "", err
+	}
+	max := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if len(name) < 3 {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(name[:3], "%d", &n); err == nil && n > max {
+			max = n
+		}
+	}
+	return fmt.Sprintf("%03d", max+1), nil
 }

--- a/internal/specdriven/speckit.go
+++ b/internal/specdriven/speckit.go
@@ -16,22 +16,30 @@ type SpecKitCommand struct {
 	Artifact string
 }
 
+// specKitCommands is the canonical Spec Kit inventory. It is immutable;
+// callers receive a fresh slice copy via SpecKitCommands() to avoid
+// accidental mutation of the package-level data.
+var specKitCommands = []SpecKitCommand{
+	{Slash: "/speckit.constitution", Tool: "speckit_constitution", Summary: "create or update project principles", Artifact: "memory/constitution.md"},
+	{Slash: "/speckit.specify", Tool: "speckit_specify", Summary: "create or update the feature specification", Artifact: "specs/<N>-<slug>/spec.md"},
+	{Slash: "/speckit.clarify", Tool: "speckit_clarify", Summary: "capture targeted clarifications for the current spec", Artifact: "spec.md"},
+	{Slash: "/speckit.plan", Tool: "speckit_plan", Summary: "create the technical implementation plan", Artifact: "plan.md"},
+	{Slash: "/speckit.tasks", Tool: "speckit_tasks", Summary: "generate dependency-ordered implementation tasks", Artifact: "tasks.md"},
+	{Slash: "/speckit.analyze", Tool: "speckit_analyze", Summary: "check spec/plan/tasks consistency", Artifact: "analysis.md"},
+	{Slash: "/speckit.implement", Tool: "speckit_implement", Summary: "summarize or execute implementation tasks", Artifact: "tasks.md status"},
+	{Slash: "/speckit.taskstoissues", Tool: "speckit_taskstoissues", Summary: "convert tasks.md into GitHub issues via `gh`", Artifact: "GitHub issues"},
+	{Slash: "/speckit.lifecycle", Tool: "speckit_lifecycle_status", Summary: "show lifecycle state and next-step guidance", Artifact: ".speckit-state.json"},
+	{Slash: "/speckit.complete", Tool: "speckit_complete", Summary: "mark a spec completed while preserving artifacts", Artifact: ".speckit-state.json"},
+	{Slash: "/speckit.archive", Tool: "speckit_archive", Summary: "archive a completed spec under specs/archive/", Artifact: "specs/archive/<N>-<slug>/"},
+	{Slash: "/speckit.checklist", Tool: "speckit_checklist", Summary: "generate a quality checklist", Artifact: "checklists/*.md"},
+}
+
 // SpecKitCommands returns the supported core Spec Kit command inventory.
+// Returned slice is a copy; callers may mutate it freely.
 func SpecKitCommands() []SpecKitCommand {
-	return []SpecKitCommand{
-		{Slash: "/speckit.constitution", Tool: "speckit_constitution", Summary: "create or update project principles", Artifact: "memory/constitution.md"},
-		{Slash: "/speckit.specify", Tool: "speckit_specify", Summary: "create or update the feature specification", Artifact: "specs/<N>-<slug>/spec.md"},
-		{Slash: "/speckit.clarify", Tool: "speckit_clarify", Summary: "capture targeted clarifications for the current spec", Artifact: "spec.md"},
-		{Slash: "/speckit.plan", Tool: "speckit_plan", Summary: "create the technical implementation plan", Artifact: "plan.md"},
-		{Slash: "/speckit.tasks", Tool: "speckit_tasks", Summary: "generate dependency-ordered implementation tasks", Artifact: "tasks.md"},
-		{Slash: "/speckit.analyze", Tool: "speckit_analyze", Summary: "check spec/plan/tasks consistency", Artifact: "analysis.md"},
-		{Slash: "/speckit.implement", Tool: "speckit_implement", Summary: "summarize or execute implementation tasks", Artifact: "tasks.md status"},
-		{Slash: "/speckit.taskstoissues", Tool: "speckit_taskstoissues", Summary: "convert tasks.md into GitHub issues via `gh`", Artifact: "GitHub issues"},
-		{Slash: "/speckit.lifecycle", Tool: "speckit_lifecycle_status", Summary: "show lifecycle state and next-step guidance", Artifact: ".speckit-state.json"},
-		{Slash: "/speckit.complete", Tool: "speckit_complete", Summary: "mark a spec completed while preserving artifacts", Artifact: ".speckit-state.json"},
-		{Slash: "/speckit.archive", Tool: "speckit_archive", Summary: "archive a completed spec under specs/archive/", Artifact: "specs/archive/<N>-<slug>/"},
-		{Slash: "/speckit.checklist", Tool: "speckit_checklist", Summary: "generate a quality checklist", Artifact: "checklists/*.md"},
-	}
+	out := make([]SpecKitCommand, len(specKitCommands))
+	copy(out, specKitCommands)
+	return out
 }
 
 // RenderSpecKitCommandTable returns a compact markdown table for help output.
@@ -39,8 +47,8 @@ func RenderSpecKitCommandTable() string {
 	var sb strings.Builder
 	sb.WriteString("| Command | Agent tool | Purpose | Artifact |\n")
 	sb.WriteString("| --- | --- | --- | --- |\n")
-	for _, cmd := range SpecKitCommands() {
-		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %s | `%s` |\n", cmd.Slash, cmd.Tool, cmd.Summary, cmd.Artifact))
+	for _, cmd := range specKitCommands {
+		fmt.Fprintf(&sb, "| `%s` | `%s` | %s | `%s` |\n", cmd.Slash, cmd.Tool, cmd.Summary, cmd.Artifact)
 	}
 	return sb.String()
 }

--- a/internal/tools/specdriven.go
+++ b/internal/tools/specdriven.go
@@ -13,7 +13,7 @@ import (
 	"omnillm/internal/specdriven"
 )
 
-// ─── Internal helpers (extracted from legacy spec_* tools) ────────────────────
+// ─── Internal helpers ────────────────────────────────────────────────────────
 
 // runSpecInit creates a new spec directory and populates an initial spec.md template.
 // Input shape: {title, overview, specs_dir}
@@ -35,7 +35,7 @@ func runSpecInit(_ context.Context, call Context, input json.RawMessage) Result 
 	}
 
 	// Determine next feature number.
-	number, err := nextSpecNumber(specsRoot)
+	number, err := specdriven.NextSpecNumber(specsRoot)
 	if err != nil {
 		return Result{Output: "error determining spec number: " + err.Error(), IsError: true}
 	}
@@ -795,31 +795,7 @@ func deriveTitle(feature string) string {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-// nextSpecNumber scans the specs directory and returns the next zero-padded number.
-func nextSpecNumber(specsRoot string) (string, error) {
-	entries, err := os.ReadDir(specsRoot)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "001", nil
-		}
-		return "", err
-	}
-	max := 0
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if len(name) >= 3 {
-			var n int
-			_, err := fmt.Sscanf(name[:3], "%d", &n)
-			if err == nil && n > max {
-				max = n
-			}
-		}
-	}
-	return fmt.Sprintf("%03d", max+1), nil
-}
+// nextSpecNumber moved to specdriven.NextSpecNumber.
 
 // loadSpecHeader reads a spec.md and extracts the minimal header fields
 // (Number, Slug, Title, Overview, CreatedAt, Entities) without full parsing.
@@ -866,10 +842,7 @@ type openSpecArchiveTool struct{}
 type openSpecBulkArchiveTool struct{}
 type openSpecOnboardTool struct{}
 
-// Legacy /openspec:proposal, /openspec:apply, /openspec:archive wrapper
-// tools have been removed. The modern openspec_propose / openspec_apply /
-// openspec_archive tools cover the same functionality and the slash
-// commands now share the /openspec: namespace.
+
 
 func OpenSpecPropose() Tool        { return &openSpecProposeTool{} }
 func OpenSpecExplore() Tool        { return &openSpecExploreTool{} }


### PR DESCRIPTION
## Summary

Unifies the OpenSpec command namespace, adds the missing `/speckit.taskstoissues` command for upstream parity, removes retired `/spec *` commands, and applies code simplification fixes from a three-agent review.

### Changes

**OpenSpec namespace unification**
- Renamed all 11 modern commands from `/opsx:*` → `/openspec:*` (canonical)
- `/opsx:*` kept as deprecated aliases for backwards compatibility
- Removed 3 legacy wrapper tools (`openspec_legacy_proposal/apply/archive`)
- Updated help text, slash catalog, and agent routing

**New commands**
- `/speckit.taskstoissues` — parses `tasks.md`, validates GitHub remote, creates issues via `gh issue create` (dry-run support, label/assignee/milestone params)
- `/specify.init`, `/openspec:init` — offline scaffold commands (replacing `/spec init`)
- `/speckit.status` — offline bulk status view (replacing `/spec status`)
- `/speckit.help`, `/openspec:help` — workflow documentation

**Removed**
- All `/spec *` commands (`/spec mode`, `/spec init`, `/spec status`, `/spec help`)
- `specHelpMarkdown`, `specKitWorkflowSummary`, `openSpecWorkflowSummary`, `isValidSpecMode`, `specSlashChoices`, `specSlashCommandName`, `handleSpecCommand`

**Code simplification** (from 3-agent review)
- Exported `specdriven.NextSpecNumber`, deleted duplicate copies in chat and tools
- Cached `buildSystemPrompt` per OS via `sync.Map` (saves ~2KB alloc per agent turn)
- Promoted `SpecKitCommands`/ `OpenSpecCommands`/ `slashCommands` to package vars
- Fixed TOCTOU race in `openSpecREPLInit` (atomic `O_EXCL`)
- Removed stale change-narrative comments
- Applied generic `/opsx:` → `/openspec:` rewrite in both dispatch paths

### Verification
```
ok  omnillm/internal/chat        7.3s
ok  omnillm/internal/specdriven  3.1s
ok  omnillm/internal/tools       9.3s
ok  omnillm/internal/agent       415s
```
`go build ./...` clean.