### PR TITLE
Remove legacy provider placeholder add path

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ The current codebase supports these provider families in user-facing flows:
 | Codex | API key | OpenAI Codex provider integration |
 | Antigravity | Google OAuth | Onboarded through the admin OAuth flow |
 
+The admin UI adds providers through auth-first onboarding: credentials or OAuth are validated before the provider instance is registered, so failed setup attempts do not leave unauthenticated placeholder providers behind.
+
 See [docs/ADDING_A_PROVIDER.md](docs/ADDING_A_PROVIDER.md) if you want to add another provider.
 
 ## API Surface

--- a/docs/ADDING_A_PROVIDER.md
+++ b/docs/ADDING_A_PROVIDER.md
@@ -185,16 +185,7 @@ In `internal/providers/types/types.go`:
 const Provider<Name> ProviderID = "<provider-type>"
 ```
 
-### 2b. Add provider instance creation
-
-In `internal/routes/admin_providers.go`, add a case to `handleAddProviderInstance`:
-
-```go
-case "<provider-type>":
-    provider = <name>pkg.NewProvider(instanceID, "")
-```
-
-### 2c. Add auth-and-create handler
+### 2b. Add auth-and-create handler
 
 In `internal/routes/admin_providers.go`, add a case to `handleAuthAndCreateProvider`:
 
@@ -239,7 +230,7 @@ For **OAuth/device-code flows** (like GitHub Copilot), the handler needs to:
 2. Return `{ requiresAuth: true, user_code, verification_uri, pending_id }` to the frontend
 3. Poll for completion in a background goroutine
 
-### 2d. Add config normalization (if the provider has custom config fields)
+### 2c. Add config normalization (if the provider has custom config fields)
 
 In `internal/routes/admin_provider_config.go`, add cases to:
 
@@ -291,7 +282,6 @@ In `frontend/src/pages/ProvidersPage.tsx`:
 The frontend API layer (`frontend/src/api/index.ts`) already provides generic functions:
 
 - `authAndCreateProvider(type, body)` — POST `/api/admin/providers/auth-and-create/:type`
-- `addProviderInstance(type)` — POST `/api/admin/providers/add/:type`
 - `authProvider(id, body)` — POST `/api/admin/providers/:id/auth`
 - `updateProviderConfig(id, config)` — PUT `/api/admin/providers/:id/config`
 - `getProviderModels(id)` — GET `/api/admin/providers/:id/models`
@@ -353,7 +343,6 @@ The following stores are available (all in `internal/database/`):
 - [ ] Implemented `types.ProviderAdapter` (Execute, ExecuteStream, RemapModel)
 - [ ] Added token/config persistence via `TokenStore` and `ProviderConfigStore`
 - [ ] Implemented `LoadFromDB` or `ensureConfig` for startup rehydration
-- [ ] Added case to `handleAddProviderInstance` in `admin_providers.go`
 - [ ] Added case to `handleAuthAndCreateProvider` in `admin_providers.go`
 - [ ] Added config normalization in `admin_provider_config.go` (if needed)
 - [ ] Added provider to frontend registry (`providerRegistry.ts`)

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -416,12 +416,6 @@ export const authProvider = (id: string, body: Record<string, string>) =>
     { method: "POST", body: JSON.stringify(body) },
   )
 
-export const addProviderInstance = (providerType: string) =>
-  apiFetch<{ success?: boolean; provider?: Provider }>(
-    `/api/admin/providers/add/${providerType}`,
-    { method: "POST" },
-  )
-
 export const authAndCreateProvider = (
   providerType: string,
   body: Record<string, string>,

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useRef, useState } from "react"
 
 import {
   activateProvider,
-  addProviderInstance,
   authAndCreateProvider,
   authProvider,
   cancelAuth,
@@ -4428,134 +4427,6 @@ const PROVIDER_TYPES = [
   },
 ]
 
-function _AddProviderModal({
-  onAdd,
-  disabled,
-}: {
-  onAdd: (type: string) => void
-  disabled: boolean
-}) {
-  const [open, setOpen] = useState(false)
-
-  return (
-    <>
-      <button
-        className="btn btn-primary btn-sm"
-        disabled={disabled}
-        onClick={() => setOpen(true)}
-      >
-        Add Provider
-      </button>
-      {open && (
-        <div
-          className="dialog-overlay"
-          onClick={(e) => {
-            if (e.target === e.currentTarget) setOpen(false)
-          }}
-        >
-          <div className="dialog-box" style={{ maxWidth: 460 }}>
-            <div className="dialog-header">
-              <div
-                style={{
-                  fontFamily: "var(--font-display)",
-                  fontWeight: 600,
-                  fontSize: 15,
-                }}
-              >
-                Add Provider
-              </div>
-              <button
-                className="btn btn-ghost btn-sm"
-                onClick={() => setOpen(false)}
-              >
-                ✕
-              </button>
-            </div>
-            <div className="dialog-body">
-              <p
-                style={{
-                  fontSize: 13,
-                  color: "var(--color-text-secondary)",
-                  marginBottom: 16,
-                }}
-              >
-                Select a provider type. You can add multiple accounts of the
-                same type.
-              </p>
-              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                {PROVIDER_TYPES.map((pt) => {
-                  const accent = PROVIDER_ACCENT[pt.id] ?? "#0a84ff"
-                  return (
-                    <button
-                      key={pt.id}
-                      onClick={() => {
-                        onAdd(pt.id)
-                        setOpen(false)
-                      }}
-                      className="provider-type-btn"
-                      style={
-                        { "--provider-accent": accent } as React.CSSProperties
-                      }
-                    >
-                      <div
-                        style={{
-                          width: 38,
-                          height: 38,
-                          borderRadius: "var(--radius-sm)",
-                          background: `${accent}18`,
-                          border: `1px solid ${accent}28`,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          color: accent,
-                          flexShrink: 0,
-                        }}
-                      >
-                        {PROVIDER_ICONS[pt.id] ?? (
-                          <span style={{ fontSize: 18 }}>◌</span>
-                        )}
-                      </div>
-                      <div>
-                        <div
-                          style={{
-                            fontWeight: 600,
-                            fontSize: 14,
-                            letterSpacing: "-0.01em",
-                          }}
-                        >
-                          {pt.name}
-                        </div>
-                        <div
-                          style={{
-                            fontSize: 12,
-                            color: "var(--color-text-secondary)",
-                            marginTop: 2,
-                          }}
-                        >
-                          {pt.desc}
-                        </div>
-                      </div>
-                      <span
-                        style={{
-                          marginLeft: "auto",
-                          color: "var(--color-text-tertiary)",
-                          fontSize: 16,
-                        }}
-                      >
-                        ›
-                      </span>
-                    </button>
-                  )
-                })}
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-    </>
-  )
-}
-
 // ─── Collapsible Group Header ─────────────────────────────────────────────────
 
 // ─── Providers Page ───────────────────────────────────────────────────────────
@@ -4745,21 +4616,6 @@ export function ProvidersPage({ showToast }: ProvidersPageProps) {
     } catch (e) {
       showToast(
         "Auth failed: " + (e instanceof Error ? e.message : String(e)),
-        "error",
-      )
-    }
-  }
-
-  const _handleAddInstance = async (providerType: string) => {
-    try {
-      const result = await addProviderInstance(providerType)
-      if (result.success && result.provider) {
-        showToast(`Created ${result.provider.name}`)
-        await load()
-      }
-    } catch (e) {
-      showToast(
-        "Add failed: " + (e instanceof Error ? e.message : String(e)),
         "error",
       )
     }

--- a/internal/routes/admin_auth_create_test.go
+++ b/internal/routes/admin_auth_create_test.go
@@ -101,6 +101,30 @@ func resetAdminTestState(t *testing.T) {
 	activeAuthFlowMu.Unlock()
 }
 
+func TestHandleAddProviderInstanceRouteIsRemoved(t *testing.T) {
+	resetAdminTestState(t)
+	t.Cleanup(func() { resetAdminTestState(t) })
+
+	router := newAdminTestRouter()
+
+	recorder := performJSONRequest(
+		t,
+		router,
+		http.MethodPost,
+		"/api/admin/providers/add/alibaba",
+		`{}`,
+	)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("expected legacy add-provider route to be removed with 404, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+
+	reg := registry.GetProviderRegistry()
+	if reg.IsRegistered("alibaba") {
+		t.Fatal("did not expect legacy add route to register placeholder alibaba provider")
+	}
+}
+
 func TestHandleAuthAndCreateProviderAzureOpenAISavesAuthenticatedProvider(t *testing.T) {
 	resetAdminTestState(t)
 	t.Cleanup(func() { resetAdminTestState(t) })

--- a/internal/routes/admin_providers.go
+++ b/internal/routes/admin_providers.go
@@ -7,21 +7,19 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/rs/zerolog/log"
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
 
+	"omnillm/internal/database"
 	alibabapkg "omnillm/internal/providers/alibaba"
-	antigravitypkg "omnillm/internal/providers/antigravity"
 	azurepkg "omnillm/internal/providers/azure"
 	codexpkg "omnillm/internal/providers/codex"
 	copilot "omnillm/internal/providers/copilot"
-	googlepkg "omnillm/internal/providers/google"
+	kimipkg "omnillm/internal/providers/kimi"
 	modelscopepkg "omnillm/internal/providers/modelscope"
 	openaicompatprovider "omnillm/internal/providers/openaicompatprovider"
-	kimipkg "omnillm/internal/providers/kimi"
-	"omnillm/internal/database"
-	"omnillm/internal/registry"
 	"omnillm/internal/providers/types"
+	"omnillm/internal/registry"
 	ghservice "omnillm/internal/services/github"
 )
 
@@ -114,57 +112,6 @@ func handleSwitchProvider(c *gin.Context) {
 		"success":  true,
 		"message":  fmt.Sprintf("Switched to provider %s", provider.GetInstanceID()),
 		"provider": provider.GetInstanceID(),
-	})
-}
-
-func handleAddProviderInstance(c *gin.Context) {
-	providerType := c.Param("type")
-
-	providerRegistry := registry.GetProviderRegistry()
-	instanceID := providerRegistry.NextInstanceID(providerType)
-
-	var provider types.Provider
-	switch providerType {
-	case "github-copilot":
-		provider = copilot.NewGitHubCopilotProvider(instanceID, "")
-	case "alibaba-modelscope":
-		provider = modelscopepkg.NewProvider(instanceID, "")
-	case "antigravity":
-		provider = antigravitypkg.NewProvider(instanceID, "")
-	case "alibaba":
-		provider = alibabapkg.NewProvider(instanceID, "")
-	case "azure-openai":
-		provider = azurepkg.NewProvider(instanceID, "")
-	case "google":
-		provider = googlepkg.NewProvider(instanceID, "")
-	case "kimi":
-		provider = kimipkg.NewProvider(instanceID, "")
-	case "openai-compatible":
-		provider = openaicompatprovider.NewProvider(instanceID, "")
-	default:
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": fmt.Sprintf("Unknown provider type '%s'", providerType),
-		})
-		return
-	}
-
-	if err := providerRegistry.Register(provider, true); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"success": false,
-			"error":   fmt.Sprintf("Failed to register provider: %v", err),
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"success": true,
-		"provider": gin.H{
-			"id":         provider.GetInstanceID(),
-			"type":       provider.GetID(),
-			"name":       provider.GetName(),
-			"isActive":   false,
-			"authStatus": "unauthenticated",
-		},
 	})
 }
 
@@ -537,10 +484,18 @@ func handleAuthAndCreateProvider(c *gin.Context) {
 						deployment, _ := typed["deployment"].(string)
 						model = strings.TrimSpace(model)
 						deployment = strings.TrimSpace(deployment)
-						if model == "" { model = deployment }
-						if deployment == "" { deployment = model }
-						if model != "" { _ = modelStateStore.SetEnabled(prov.GetInstanceID(), model, true) }
-						if deployment != "" && deployment != model { _ = modelStateStore.SetEnabled(prov.GetInstanceID(), deployment, true) }
+						if model == "" {
+							model = deployment
+						}
+						if deployment == "" {
+							deployment = model
+						}
+						if model != "" {
+							_ = modelStateStore.SetEnabled(prov.GetInstanceID(), model, true)
+						}
+						if deployment != "" && deployment != model {
+							_ = modelStateStore.SetEnabled(prov.GetInstanceID(), deployment, true)
+						}
 					}
 				}
 			}

--- a/internal/routes/admin_routes.go
+++ b/internal/routes/admin_routes.go
@@ -28,7 +28,6 @@ func SetupAdminRoutes(router *gin.RouterGroup, port int) {
 	router.POST("/providers/:id/deactivate", handleDeactivateProvider)
 
 	// Provider type-specific routes (use specific path to avoid conflicts with wildcard :id routes)
-	router.POST("/providers/add/:type", handleAddProviderInstance)
 	router.POST("/providers/auth-and-create/:type", handleAuthAndCreateProvider)
 
 	// Antigravity Google OAuth2 authorization-code flow


### PR DESCRIPTION
## Summary
- Remove the legacy `/api/admin/providers/add/:type` route and backend placeholder-registration handler.
- Drop unused frontend `addProviderInstance` and dead provider-add modal/helper code.
- Update provider docs and README to describe auth-first provider onboarding.

Closes #135.

## Test plan
- [x] `go test ./internal/routes/...`
- [x] `bun test tests/frontend/auth-and-create-provider.test.ts tests/frontend/pages/ProvidersPage.test.tsx`
- [x] `bun run typecheck`