### PR TITLE
fix(tests): update DeepSeek tool_choice expectations for DashScope

### DIFF
--- a/internal/providers/alibaba/adapter_models_test.go
+++ b/internal/providers/alibaba/adapter_models_test.go
@@ -167,9 +167,9 @@ func TestBuildRequestDeepSeekV4FlashNoEnableThinking(t *testing.T) {
 	if _, ok := chatReq.Extras["enable_thinking"]; ok {
 		t.Fatalf("expected deepseek-v4-flash to not receive enable_thinking, got %#v", chatReq.Extras["enable_thinking"])
 	}
-	// DeepSeek models on DashScope keep their tool_choice (unlike Qwen/GLM).
-	if chatReq.ToolChoice != "required" {
-		t.Fatalf("expected deepseek-v4-flash tool_choice to be preserved, got %#v", chatReq.ToolChoice)
+	// DeepSeek models on DashScope strip tool_choice (like Qwen/GLM).
+	if chatReq.ToolChoice != nil {
+		t.Fatalf("expected deepseek-v4-flash tool_choice to be nil, got %#v", chatReq.ToolChoice)
 	}
 }
 
@@ -240,4 +240,5 @@ func TestAdapterExecuteUsesOpenAIClientWithRawJSONPayload(t *testing.T) {
 		t.Fatalf("stream = %#v, want false", gotPayload["stream"])
 	}
 }
+
 

--- a/internal/providers/alibaba/models_glm_test.go
+++ b/internal/providers/alibaba/models_glm_test.go
@@ -15,9 +15,9 @@ func TestNeedsToolChoiceNil(t *testing.T) {
 		{"alibaba-sk/qwen3.6-plus", true},
 		{"glm-5.1", true},
 		{"GLM-5.1", true},
-		{"deepseek-v3", false},
-		{"deepseek-v4-flash", false},
-		{"deepseek-r1", false},
+		{"deepseek-v3", true},
+		{"deepseek-v4-flash", true},
+		{"deepseek-r1", true},
 		{"gpt-4o", false},
 		{"", false},
 	}
@@ -28,3 +28,4 @@ func TestNeedsToolChoiceNil(t *testing.T) {
 		}
 	}
 }
+


### PR DESCRIPTION
Fixes #136

## Summary
The \
eedsToolChoiceNil\ function in \models_tool_quirks.go\ already includes DeepSeek models as requiring \	ool_choice=nil\, but the tests were not updated to match.

## Changes
- \dapter_models_test.go\: deepseek-v4-flash tool_choice should be nil, not preserved
- \models_glm_test.go\: deepseek-v3/-v4-flash/-r1 all need tool_choice=nil