### PR TITLE
Cross-platform Makefile with automatic Bun dependency installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ REBUILD       ?=
 
 GO            := go
 BUN           := bun
+DEPS          := .build/.bun-install.stamp
 
 INSTALL_DIR   := $(HOME)/.local/bin
 BUILD_DIR     := .build/bin
@@ -21,8 +22,16 @@ BUILD_DIR     := .build/bin
 ifeq ($(OS),Windows_NT)
   EXE         := .exe
   INSTALL_DIR := $(USERPROFILE)/.local/bin
+  PRINT_BLANK := @powershell -NoProfile -Command "Write-Host ''"
+  define MKDIR_TARGET
+	if not exist "$(1)" mkdir "$(1)"
+  endef
 else
   EXE         :=
+  PRINT_BLANK := @printf '\n'
+  define MKDIR_TARGET
+	mkdir -p "$(1)"
+  endef
 endif
 
 OMNILLM_BIN   := $(INSTALL_DIR)/omnillm$(EXE)
@@ -30,7 +39,7 @@ OMNIPROXY_BIN := $(INSTALL_DIR)/omniproxy$(EXE)
 
 # ── Phony targets ─────────────────────────────────────────────────────────────
 
-.PHONY: all install build build-go build-frontend build-all \
+.PHONY: all install deps build build-go build-frontend build-all \
         start stop restart restart-rebuild status logs logs-follow \
         dev dev-frontend \
         test test-frontend lint typecheck \
@@ -46,23 +55,31 @@ all: help
 
 ## install: Build all Go binaries and install to ~/.local/bin
 install:
-	@if not exist "$(INSTALL_DIR)" mkdir "$(INSTALL_DIR)"
+	$(call MKDIR_TARGET,$(INSTALL_DIR))
 	$(GO) build -o "$(OMNILLM_BIN)" .
 	$(GO) build -o "$(OMNIPROXY_BIN)" ./cmd/omniproxy
 	@echo Installed omnillm$(EXE) to $(OMNILLM_BIN)
 	@echo Installed omniproxy$(EXE) to $(OMNIPROXY_BIN)
+
+## deps: Install Node.js dependencies with Bun
+deps: $(DEPS)
+
+$(DEPS): bun.lock package.json
+	$(call MKDIR_TARGET,$(BUILD_DIR))
+	$(BUN) install
+	@touch "$(DEPS)"
 
 ## build: Build the Go backend binary and install to ~/.local/bin
 build: build-go
 
 ## build-go: Compile the Go backend and install to ~/.local/bin
 build-go:
-	@if not exist "$(INSTALL_DIR)" mkdir "$(INSTALL_DIR)"
+	$(call MKDIR_TARGET,$(INSTALL_DIR))
 	$(GO) build -o "$(OMNILLM_BIN)" .
 	@echo Built omnillm$(EXE) to $(OMNILLM_BIN)
 
 ## build-frontend: Build the frontend assets (outputs to pages/)
-build-frontend:
+build-frontend: $(DEPS)
 	$(BUN) run build
 
 ## build-all: Build both the Go backend and the frontend assets
@@ -71,85 +88,85 @@ build-all: build-go build-frontend
 # ── Dev / Start ───────────────────────────────────────────────────────────────
 
 ## start: Build the Go backend and start all services in the background
-start:
+start: $(DEPS)
 	$(BUN) run omni start \
 	  --server-port $(SERVER_PORT) \
 	  --frontend-port $(FRONTEND_PORT) \
 	  --host $(HOST)
 
 ## stop: Stop all background services
-stop:
+stop: $(DEPS)
 	$(BUN) run omni stop
 
 ## restart: Restart background services (no rebuild)
-restart:
+restart: $(DEPS)
 	$(BUN) run omni restart $(REBUILD) \
 	  --server-port $(SERVER_PORT) \
 	  --frontend-port $(FRONTEND_PORT) \
 	  --host $(HOST)
 
 ## restart-rebuild: Rebuild everything and restart background services
-restart-rebuild:
+restart-rebuild: $(DEPS)
 	$(BUN) run omni restart --rebuild \
 	  --server-port $(SERVER_PORT) \
 	  --frontend-port $(FRONTEND_PORT) \
 	  --host $(HOST)
 
 ## status: Show running service status and ports
-status:
+status: $(DEPS)
 	$(BUN) run omni status
 
 ## logs: Print the last 50 lines of service logs
-logs:
+logs: $(DEPS)
 	$(BUN) run omni logs
 
 ## logs-follow: Stream service logs in real time
-logs-follow:
+logs-follow: $(DEPS)
 	$(BUN) run omni logs --follow
 
 ## dev: Start both backend and frontend in the foreground (Ctrl+C to stop)
-dev:
+dev: $(DEPS)
 	$(BUN) run dev \
 	  --server-port $(SERVER_PORT) \
 	  --frontend-port $(FRONTEND_PORT) \
 	  --host $(HOST)
 
 ## dev-frontend: Start only the Vite frontend dev server
-dev-frontend:
+dev-frontend: $(DEPS)
 	$(BUN) run dev:frontend
 
 # ── Test ──────────────────────────────────────────────────────────────────────
 
 ## test: Run the full test suite
-test:
+test: $(DEPS)
 	$(BUN) run test
 
 ## test-frontend: Run frontend tests only
-test-frontend:
+test-frontend: $(DEPS)
 	$(BUN) run test:frontend
 
 # ── Code Quality ──────────────────────────────────────────────────────────────
 
 ## lint: Run ESLint on changed files
-lint:
+lint: $(DEPS)
 	$(BUN) run lint
 
 ## typecheck: Run TypeScript type checking on the frontend
-typecheck:
+typecheck: $(DEPS)
 	$(BUN) run typecheck
 
 # ── Release ───────────────────────────────────────────────────────────────────
 
 ## release-patch: Bump patch version, commit, tag, and push
-release-patch:
+release-patch: $(DEPS)
 	$(BUN) run scripts/release.ts patch
 
 ## release-minor: Bump minor version, commit, tag, and push
-release-minor:
+release-minor: $(DEPS)
 	$(BUN) run scripts/release.ts minor
 
 ## release-major: Bump major version, commit, tag, and push
-release-major:
+release-major: $(DEPS)
 	$(BUN) run scripts/release.ts major
 
 # ── Docker ────────────────────────────────────────────────────────────────────
@@ -168,51 +185,53 @@ docker-run:
 help:
 	@echo OmniLLM Development Tasks
 	@echo Usage: make [target] [VARIABLE=value ...]
-	@cmd /c echo.
+	$(PRINT_BLANK)
 	@echo VARIABLES:
-	@echo   SERVER_PORT=5000       Backend API port (default: 5000)
-	@echo   FRONTEND_PORT=5080     Frontend dev server port (default: 5080)
-	@echo   HOST=127.0.0.1         Bind address (default: 127.0.0.1)
+	@echo   SERVER_PORT=5000       Backend API port - default 5000
+	@echo   FRONTEND_PORT=5080     Frontend dev server port - default 5080
+	@echo   HOST=127.0.0.1         Bind address - default 127.0.0.1
 	@echo   REBUILD=--rebuild      Add --rebuild flag to restart target
-	@cmd /c echo.
+	$(PRINT_BLANK)
 	@echo QUICK START:
 	@echo   start                Build the Go backend and start all services in the background
 	@echo   stop                 Stop all background services
-	@echo   dev                  Start both backend and frontend in the foreground (Ctrl+C to stop)
+	@echo   dev                  Start both backend and frontend in the foreground - Ctrl+C to stop
 	@echo   status               Show running service status and ports
-	@cmd /c echo.
+	$(PRINT_BLANK)
 	@echo BUILD:
+	@echo   deps                 Install Node.js dependencies with Bun
 	@echo   install              Build all Go binaries and install to ~/.local/bin
 	@echo   build                Build the Go backend binary and install to ~/.local/bin
 	@echo   build-go             Compile the Go backend and install to ~/.local/bin
-	@echo   build-frontend       Build the frontend assets (outputs to pages/)
+	@echo   build-frontend       Build the frontend assets - outputs to pages/
 	@echo   build-all            Build both the Go backend and the frontend assets
-	@cmd /c echo.
+	$(PRINT_BLANK)
 	@echo DEVELOPMENT:
 	@echo   dev-frontend         Start only the Vite frontend dev server
-	@echo   restart              Restart background services (no rebuild)
+	@echo   restart              Restart background services - no rebuild
 	@echo   restart-rebuild      Rebuild everything and restart background services
-	@cmd /c echo.
+	$(PRINT_BLANK)
 	@echo MONITORING:
 	@echo   logs                 Print the last 50 lines of service logs
 	@echo   logs-follow          Stream service logs in real time
-	@cmd /c echo.
+	$(PRINT_BLANK)
 	@echo TESTING and QUALITY:
 	@echo   test                 Run the full test suite
 	@echo   test-frontend        Run frontend tests only
 	@echo   lint                 Run ESLint on changed files
 	@echo   typecheck            Run TypeScript type checking on the frontend
-	@cmd /c echo.
+	$(PRINT_BLANK)
 	@echo RELEASE:
 	@echo   release-patch        Bump patch version, commit, tag, and push
 	@echo   release-minor        Bump minor version, commit, tag, and push
 	@echo   release-major        Bump major version, commit, tag, and push
-	@cmd /c echo.
+	$(PRINT_BLANK)
 	@echo DOCKER:
 	@echo   docker-build         Build the Docker image tagged as omnillm
 	@echo   docker-run           Run the Docker image on port 5000
-	@cmd /c echo.
+	$(PRINT_BLANK)
 	@echo EXAMPLES:
+	@echo   make deps
 	@echo   make dev
 	@echo   make start SERVER_PORT=5000 FRONTEND_PORT=5080
 	@echo   make restart REBUILD=--rebuild

--- a/README.md
+++ b/README.md
@@ -73,18 +73,18 @@ Prerequisites:
 Build and run the main binary:
 
 ```sh
-bun install
-bun run build:go
+make build-go
 $HOME/.local/bin/omnillm start
 ```
 
 Windows PowerShell:
 
 ```powershell
-bun install
-bun run build:go
-$env:USERPROFILE/.local/bin/omnillm.exe start
+make build-go
+$env:USERPROFILE\.local\bin\omnillm.exe start
 ```
+
+For Bun-based workflows such as frontend builds, linting, tests, or dev mode, use `make deps` to install dependencies explicitly, or just run the relevant `make` target and let it install dependencies automatically when needed.
 
 ### Run `omniproxy`
 
@@ -154,12 +154,18 @@ bun run dev
 Useful scripts:
 
 ```sh
-bun run dev
-bun run dev:frontend
-bun run omni start
-bun run omni status
-bun run omni restart --rebuild
+make help
+make deps
+make build-go
+make build-frontend
+make dev
+make dev-frontend
+make start
+make status
+make restart REBUILD=--rebuild
 ```
+
+The `make` targets wrap the same Bun-based workflows for Linux and Windows. On Windows, use PowerShell or Command Prompt with `make` available in `PATH`. Bun-backed targets automatically run `bun install` when dependencies are missing or when `bun.lock` or `package.json` changes.
 
 The `bun run omni` wrapper is a development manager around the backend binary and Vite server. It is not the same thing as the production runtime path.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,18 +69,18 @@ bunx omnillm@latest start
 构建并运行主二进制：
 
 ```sh
-bun install
-bun run build:go
+make build-go
 $HOME/.local/bin/omnillm start
 ```
 
 Windows PowerShell：
 
 ```powershell
-bun install
-bun run build:go
-$env:USERPROFILE/.local/bin/omnillm.exe start
+make build-go
+$env:USERPROFILE\.local\bin\omnillm.exe start
 ```
+
+对于前端构建、lint、测试或开发模式这类依赖 Bun 的流程，你可以显式运行 `make deps` 安装依赖，也可以直接执行对应的 `make` 目标，让它在需要时自动安装依赖。
 
 ### 运行 `omniproxy`
 
@@ -150,12 +150,18 @@ bun run dev
 常用脚本：
 
 ```sh
-bun run dev
-bun run dev:frontend
-bun run omni start
-bun run omni status
-bun run omni restart --rebuild
+make help
+make deps
+make build-go
+make build-frontend
+make dev
+make dev-frontend
+make start
+make status
+make restart REBUILD=--rebuild
 ```
+
+这些 `make` 目标对 Linux 和 Windows 使用同一套 Bun 驱动流程。在 Windows 上，请使用已经把 `make` 加入 `PATH` 的 PowerShell 或命令提示符。所有依赖 Bun 的目标会在缺少依赖，或 `bun.lock` / `package.json` 发生变化时自动执行 `bun install`。
 
 其中 `bun run omni` 是开发环境管理器，用来同时管理后端二进制和 Vite 服务，不等同于生产或发布时的运行方式。
 


### PR DESCRIPTION
## Summary

The Makefile currently uses Windows-only shell commands (`if not exist`, `cmd /c echo`) which break on Linux. Furthermore, Bun-backed targets (`build-frontend`, `start`, `dev`, `test`, `lint`, `typecheck`, etc.) fail on a fresh checkout because there is no dependency-install step in the Makefile — users must remember to run `bun install` manually.

This PR resolves both issues by introducing OS-aware helper macros and automatic Bun dependency installation.

## Changes

### `Makefile`
- Replaced Windows-only commands with OS-aware helpers (`MKDIR_TARGET`, `PRINT_BLANK`) that work on both Linux and Windows
- Added a `deps` target that automatically runs `bun install` when `bun.lock` or `package.json` changes, using a stamp file (`.build/.bun-install.stamp`) to avoid unnecessary reinstalls
- Wired all Bun-backed targets to depend on `$(DEPS)` for automatic dependency installation

### `README.md` and `README.zh-CN.md`
- Removed manual `bun install` from quick-start instructions
- Updated development workflow section to use `make`-based commands

## Verification

- `make help` works on Linux
- `make build-frontend` auto-runs `bun install` on a clean state, skips it on subsequent runs, and reinstalls when `bun.lock` changes
- `make build-all` succeeds end-to-end
- `make lint` runs through the dependency flow

Closes #143