### PR TITLE
Improve hot-path caching and async shutdown

### DIFF
--- a/internal/database/async_workers.go
+++ b/internal/database/async_workers.go
@@ -1,0 +1,126 @@
+package database
+
+import (
+	"sync"
+
+	"github.com/rs/zerolog/log"
+)
+
+// asyncWorkers holds the bounded channel-based worker pools for fire-and-forget
+// database writes that must never block or slow down the request path.
+//
+// Both pools are started once via StartAsyncWorkers (called from database init)
+// and drained via StopAsyncWorkers (called from server shutdown).
+var asyncWorkers struct {
+	mu      sync.Mutex
+	metering chan MeteringRecord
+	lastUsed chan string // access token ID
+	wg      sync.WaitGroup
+	running bool
+}
+
+const (
+	meteringBufSize = 4096
+	lastUsedBufSize = 4096
+	meteringWorkers = 4
+	lastUsedWorkers = 2
+)
+
+// StartAsyncWorkers starts the bounded background worker pools.
+// If workers are already running they are stopped first (supports re-init in tests).
+func StartAsyncWorkers() {
+	asyncWorkers.mu.Lock()
+	defer asyncWorkers.mu.Unlock()
+
+	// Stop any previously running workers (e.g. test re-init).
+	if asyncWorkers.running {
+		stopWorkersLocked()
+	}
+
+	asyncWorkers.metering = make(chan MeteringRecord, meteringBufSize)
+	asyncWorkers.lastUsed = make(chan string, lastUsedBufSize)
+	asyncWorkers.running = true
+
+	for range meteringWorkers {
+		asyncWorkers.wg.Add(1)
+		go func() {
+			defer asyncWorkers.wg.Done()
+			db := GetDatabase()
+			for rec := range asyncWorkers.metering {
+				if err := db.InsertMeteringRecord(rec); err != nil {
+					log.Error().Err(err).Str("request_id", rec.RequestID).Msg("Failed to record metering data")
+				}
+			}
+		}()
+	}
+
+	for range lastUsedWorkers {
+		asyncWorkers.wg.Add(1)
+		go func() {
+			defer asyncWorkers.wg.Done()
+			db := GetDatabase()
+			for id := range asyncWorkers.lastUsed {
+				if _, err := db.db.Exec(`UPDATE access_tokens SET last_used_at = datetime('now') WHERE id = ?`, id); err != nil {
+					log.Debug().Err(err).Str("token_id", id).Msg("Failed to stamp access token last_used_at")
+				}
+			}
+		}()
+	}
+}
+
+// StopAsyncWorkers closes both worker channels and waits for all pending
+// writes to finish. Call from server shutdown.
+func StopAsyncWorkers() {
+	asyncWorkers.mu.Lock()
+	defer asyncWorkers.mu.Unlock()
+	stopWorkersLocked()
+}
+
+func stopWorkersLocked() {
+	if !asyncWorkers.running {
+		return
+	}
+	asyncWorkers.running = false
+	if asyncWorkers.metering != nil {
+		close(asyncWorkers.metering)
+		asyncWorkers.metering = nil
+	}
+	if asyncWorkers.lastUsed != nil {
+		close(asyncWorkers.lastUsed)
+		asyncWorkers.lastUsed = nil
+	}
+	asyncWorkers.wg.Wait()
+}
+
+// EnqueueMeteringRecord sends rec to the metering worker pool.
+// If the buffer is full (overload), the record is dropped and a warning is logged.
+func EnqueueMeteringRecord(rec MeteringRecord) {
+	asyncWorkers.mu.Lock()
+	ch := asyncWorkers.metering
+	asyncWorkers.mu.Unlock()
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- rec:
+	default:
+		log.Warn().Str("request_id", rec.RequestID).Msg("Metering worker pool full, dropping record")
+	}
+}
+
+// EnqueueLastUsedAt sends an access token ID to the last-used-at worker pool.
+// If the buffer is full the update is silently skipped — this is metadata-only.
+func EnqueueLastUsedAt(tokenID string) {
+	asyncWorkers.mu.Lock()
+	ch := asyncWorkers.lastUsed
+	asyncWorkers.mu.Unlock()
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- tokenID:
+	default:
+		// Drop silently; last_used_at is informational only.
+	}
+}
+

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -20,6 +20,12 @@ func TestMain(m *testing.M) {
 	if err := InitializeDatabase(tmpDir); err != nil {
 		panic(err)
 	}
+	defer func() {
+		if err := GetDatabase().Close(); err != nil {
+			panic(err)
+		}
+	}()
+	defer StopAsyncWorkers()
 
 	os.Exit(m.Run())
 }

--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -31,9 +31,12 @@ func InitializeDatabase(configDir string) error {
 		return fmt.Errorf("failed to open database: %w", err)
 	}
 
-	// SQLite file database works best with a single writer connection
+	// WAL mode (already set in DSN) allows concurrent readers + serialized writes.
+	// Keep a single connection to prevent write-write lock contention on SQLite.
+	// The async worker pools (metering, last-used-at) write through the same pool
+	// and the busy_timeout in the DSN handles transient contention.
 	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(4)
+	db.SetMaxIdleConns(1)
 
 	globalDB = &Database{db: db}
 
@@ -42,6 +45,13 @@ func InitializeDatabase(configDir string) error {
 	}
 
 	log.Debug().Msg("SQLite database initialized successfully")
+
+	// Start bounded background worker pools for async DB writes.
+	// Also reset the in-memory resolution caches for this DB instance.
+	globalModelResCache = &ModelResolutionCache{}
+	globalModelStateCache = &ModelStateCache{}
+	StartAsyncWorkers()
+
 	return nil
 }
 

--- a/internal/database/model_resolution_cache.go
+++ b/internal/database/model_resolution_cache.go
@@ -1,0 +1,316 @@
+package database
+
+import (
+	"strings"
+	"sync"
+)
+
+// ModelResolutionCache is a read-heavy in-memory cache for the three data sets
+// that are queried on every hot-path request:
+//
+//  1. Virtual models: map[lowercaseName → *VirtualModelRecord]
+//  2. Virtual model upstreams: map[virtualModelID → []VirtualModelUpstreamRecord]
+//  3. Provider instances: []ProviderInstanceRecord (sorted by priority asc)
+//
+// All data is populated lazily on first access and invalidated whenever the
+// underlying store performs a write.  Reads are lock-free after the first load
+// (swap to new map pointer under write lock; readers hold read lock for pointer
+// copy only).
+//
+// Model state (enabled/disabled per instance) is cached separately in
+// ModelStateCache, which is invalidated by SetEnabled/Delete on ModelStateStore.
+type ModelResolutionCache struct {
+	mu sync.RWMutex
+
+	vmByName     map[string]*VirtualModelRecord            // key: lowercase name/id
+	vmUpstreams  map[string][]VirtualModelUpstreamRecord   // key: virtualModelID
+	provInst     []ProviderInstanceRecord
+	instByID     map[string]ProviderInstanceRecord         // key: instanceID
+	instByLcSub  map[string]string                        // key: lc subtitle → instanceID
+
+	vmLoaded   bool
+	instLoaded bool
+}
+
+// ModelStateCache caches GetAllByInstance results keyed by instanceID.
+type ModelStateCache struct {
+	mu    sync.RWMutex
+	data  map[string]map[string]bool // instanceID → modelID → enabled
+	loaded bool
+}
+
+var (
+	globalModelResCache = &ModelResolutionCache{}
+	globalModelStateCache = &ModelStateCache{}
+)
+
+// GetModelResolutionCache returns the process-wide model resolution cache.
+func GetModelResolutionCache() *ModelResolutionCache { return globalModelResCache }
+
+// GetModelStateCache returns the process-wide model state cache.
+func GetModelStateCache() *ModelStateCache { return globalModelStateCache }
+
+// ─── ModelResolutionCache ─────────────────────────────────────────────────────
+
+func (c *ModelResolutionCache) ensureVMLoaded() {
+	c.mu.RLock()
+	ok := c.vmLoaded
+	c.mu.RUnlock()
+	if ok {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.vmLoaded {
+		return
+	}
+	c.loadVMsLocked()
+}
+
+func (c *ModelResolutionCache) loadVMsLocked() {
+	db := GetDatabase()
+	rows, err := db.db.Query(`
+		SELECT virtual_model_id, name, description, api_shape, lb_strategy, enabled, created_at, updated_at
+		FROM virtual_models ORDER BY created_at ASC
+	`)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	byName := make(map[string]*VirtualModelRecord)
+	upstreams := make(map[string][]VirtualModelUpstreamRecord)
+
+	var vms []VirtualModelRecord
+	for rows.Next() {
+		var r VirtualModelRecord
+		var enabledInt int
+		var createdAtStr, updatedAtStr string
+		if err := rows.Scan(&r.VirtualModelID, &r.Name, &r.Description, &r.APIShape, &r.LbStrategy, &enabledInt, &createdAtStr, &updatedAtStr); err != nil {
+			continue
+		}
+		r.Enabled = enabledInt == 1
+		r.CreatedAt = parseTime(createdAtStr)
+		r.UpdatedAt = parseTime(updatedAtStr)
+		vms = append(vms, r)
+	}
+	_ = rows.Err()
+
+	for i := range vms {
+		key := strings.ToLower(vms[i].VirtualModelID)
+		rec := vms[i]
+		byName[key] = &rec
+	}
+
+	// Load all upstreams in one query.
+	uRows, err := db.db.Query(`
+		SELECT id, virtual_model_id, provider_id, model_id, weight, priority, created_at, updated_at
+		FROM virtual_model_upstreams ORDER BY priority ASC, id ASC
+	`)
+	if err == nil {
+		defer uRows.Close()
+		for uRows.Next() {
+			var u VirtualModelUpstreamRecord
+			var createdAtStr, updatedAtStr string
+			if err := uRows.Scan(&u.ID, &u.VirtualModelID, &u.ProviderID, &u.ModelID, &u.Weight, &u.Priority, &createdAtStr, &updatedAtStr); err != nil {
+				continue
+			}
+			u.CreatedAt = parseTime(createdAtStr)
+			u.UpdatedAt = parseTime(updatedAtStr)
+			upstreams[u.VirtualModelID] = append(upstreams[u.VirtualModelID], u)
+		}
+	}
+
+	c.vmByName = byName
+	c.vmUpstreams = upstreams
+	c.vmLoaded = true
+}
+
+// GetVirtualModel returns the cached virtual model record for the given name/id.
+func (c *ModelResolutionCache) GetVirtualModel(nameOrID string) *VirtualModelRecord {
+	c.ensureVMLoaded()
+	c.mu.RLock()
+	r := c.vmByName[strings.ToLower(nameOrID)]
+	c.mu.RUnlock()
+	return r
+}
+
+// GetUpstreams returns the cached upstream list for the given virtual model ID.
+func (c *ModelResolutionCache) GetUpstreams(virtualModelID string) []VirtualModelUpstreamRecord {
+	c.ensureVMLoaded()
+	c.mu.RLock()
+	u := c.vmUpstreams[virtualModelID]
+	c.mu.RUnlock()
+	return u
+}
+
+// InvalidateVMs drops the virtual model + upstream cache. The next read reloads from DB.
+func (c *ModelResolutionCache) InvalidateVMs() {
+	c.mu.Lock()
+	c.vmLoaded = false
+	c.vmByName = nil
+	c.vmUpstreams = nil
+	c.mu.Unlock()
+}
+
+// ─── Provider instance cache ─────────────────────────────────────────────────
+
+func (c *ModelResolutionCache) ensureInstLoaded() {
+	c.mu.RLock()
+	ok := c.instLoaded
+	c.mu.RUnlock()
+	if ok {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.instLoaded {
+		return
+	}
+	c.loadInstLocked()
+}
+
+func (c *ModelResolutionCache) loadInstLocked() {
+	db := GetDatabase()
+	rows, err := db.db.Query(`
+		SELECT instance_id, provider_id, name, subtitle, priority, activated, created_at, updated_at
+		FROM provider_instances ORDER BY priority ASC
+	`)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	var records []ProviderInstanceRecord
+	byID := make(map[string]ProviderInstanceRecord)
+	byLcSub := make(map[string]string)
+
+	for rows.Next() {
+		var r ProviderInstanceRecord
+		var activated int
+		var createdAtStr, updatedAtStr string
+		if err := rows.Scan(&r.InstanceID, &r.ProviderID, &r.Name, &r.Subtitle, &r.Priority, &activated, &createdAtStr, &updatedAtStr); err != nil {
+			continue
+		}
+		r.Activated = activated != 0
+		r.CreatedAt = parseTime(createdAtStr)
+		r.UpdatedAt = parseTime(updatedAtStr)
+		records = append(records, r)
+		byID[r.InstanceID] = r
+		lcs := strings.ToLower(r.Subtitle)
+		if lcs != "" {
+			if _, exists := byLcSub[lcs]; !exists {
+				byLcSub[lcs] = r.InstanceID
+			}
+		}
+	}
+
+	c.provInst = records
+	c.instByID = byID
+	c.instByLcSub = byLcSub
+	c.instLoaded = true
+}
+
+// GetAllProviderInstances returns the cached, priority-sorted provider instance list.
+func (c *ModelResolutionCache) GetAllProviderInstances() []ProviderInstanceRecord {
+	c.ensureInstLoaded()
+	c.mu.RLock()
+	r := c.provInst
+	c.mu.RUnlock()
+	return r
+}
+
+// ResolveProviderPrefix maps a prefix to an instance ID using the cache.
+func (c *ModelResolutionCache) ResolveProviderPrefix(prefix string) string {
+	c.ensureInstLoaded()
+	c.mu.RLock()
+	byID := c.instByID
+	byLcSub := c.instByLcSub
+	c.mu.RUnlock()
+
+	if _, ok := byID[prefix]; ok {
+		return prefix
+	}
+	if id, ok := byLcSub[strings.ToLower(prefix)]; ok {
+		return id
+	}
+	return prefix
+}
+
+// InvalidateInstances drops the provider instance cache.
+func (c *ModelResolutionCache) InvalidateInstances() {
+	c.mu.Lock()
+	c.instLoaded = false
+	c.provInst = nil
+	c.instByID = nil
+	c.instByLcSub = nil
+	c.mu.Unlock()
+}
+
+// ─── ModelStateCache ─────────────────────────────────────────────────────────
+
+func (c *ModelStateCache) ensure() {
+	c.mu.RLock()
+	ok := c.loaded
+	c.mu.RUnlock()
+	if ok {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.loaded {
+		return
+	}
+
+	db := GetDatabase()
+	rows, err := db.db.Query(`
+		SELECT instance_id, model_id, enabled FROM provider_model_states
+	`)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	data := make(map[string]map[string]bool)
+	for rows.Next() {
+		var instID, modelID string
+		var enabledInt int
+		if err := rows.Scan(&instID, &modelID, &enabledInt); err != nil {
+			continue
+		}
+		if data[instID] == nil {
+			data[instID] = make(map[string]bool)
+		}
+		data[instID][modelID] = enabledInt == 1
+	}
+
+	c.data = data
+	c.loaded = true
+}
+
+// GetDisabledModels returns the set of disabled model IDs for the given instance.
+func (c *ModelStateCache) GetDisabledModels(instanceID string) map[string]bool {
+	c.ensure()
+	c.mu.RLock()
+	states := c.data[instanceID]
+	c.mu.RUnlock()
+
+	disabled := make(map[string]bool)
+	for modelID, enabled := range states {
+		if !enabled {
+			disabled[modelID] = true
+		}
+	}
+	return disabled
+}
+
+// Invalidate drops the model state cache.
+func (c *ModelStateCache) Invalidate() {
+	c.mu.Lock()
+	c.loaded = false
+	c.data = nil
+	c.mu.Unlock()
+}

--- a/internal/database/store_access_tokens.go
+++ b/internal/database/store_access_tokens.go
@@ -123,9 +123,7 @@ func (s *AccessTokenStore) ValidateByHash(tokenHash string) (*AccessTokenRecord,
 		rec.LastUsedAt = &t
 	}
 
-	go func() {
-		_, _ = s.db.db.Exec(`UPDATE access_tokens SET last_used_at = datetime('now') WHERE id = ?`, rec.ID)
-	}()
+	EnqueueLastUsedAt(rec.ID)
 
 	return &rec, nil
 }

--- a/internal/database/store_model_state.go
+++ b/internal/database/store_model_state.go
@@ -72,6 +72,9 @@ func (ms *ModelStateStore) SetEnabled(instanceID, modelID string, enabled bool) 
 			enabled = excluded.enabled,
 			updated_at = datetime('now')
 	`, instanceID, modelID, enabledInt)
+	if err == nil {
+		GetModelStateCache().Invalidate()
+	}
 	return err
 }
 
@@ -80,5 +83,8 @@ func (ms *ModelStateStore) Delete(instanceID, modelID string) error {
 		"DELETE FROM provider_model_states WHERE instance_id = ? AND model_id = ?",
 		instanceID, modelID,
 	)
+	if err == nil {
+		GetModelStateCache().Invalidate()
+	}
 	return err
 }

--- a/internal/database/store_provider_instances.go
+++ b/internal/database/store_provider_instances.go
@@ -77,11 +77,17 @@ func (pis *ProviderInstanceStore) Save(record *ProviderInstanceRecord) error {
 			activated = excluded.activated,
 			updated_at = datetime('now')
 	`, record.InstanceID, record.ProviderID, record.Name, record.Subtitle, record.Priority, activated)
+	if err == nil {
+		GetModelResolutionCache().InvalidateInstances()
+	}
 	return err
 }
 
 func (pis *ProviderInstanceStore) Delete(instanceID string) error {
 	_, err := pis.db.db.Exec("DELETE FROM provider_instances WHERE instance_id = ?", instanceID)
+	if err == nil {
+		GetModelResolutionCache().InvalidateInstances()
+	}
 	return err
 }
 
@@ -96,6 +102,9 @@ func (pis *ProviderInstanceStore) SetActivation(instanceID string, activated boo
 		SET activated = ?, updated_at = datetime('now')
 		WHERE instance_id = ?
 	`, activatedInt, instanceID)
+	if err == nil {
+		GetModelResolutionCache().InvalidateInstances()
+	}
 	return err
 }
 
@@ -104,28 +113,28 @@ func (pis *ProviderInstanceStore) UpdateMetadata(instanceID string, name *string
 		return nil
 	}
 
+	var err error
 	if name != nil && subtitle != nil {
-		_, err := pis.db.db.Exec(`
+		_, err = pis.db.db.Exec(`
 			UPDATE provider_instances
 			SET name = ?, subtitle = ?, updated_at = datetime('now')
 			WHERE instance_id = ?
 		`, *name, *subtitle, instanceID)
-		return err
-	}
-
-	if name != nil {
-		_, err := pis.db.db.Exec(`
+	} else if name != nil {
+		_, err = pis.db.db.Exec(`
 			UPDATE provider_instances
 			SET name = ?, updated_at = datetime('now')
 			WHERE instance_id = ?
 		`, *name, instanceID)
-		return err
+	} else {
+		_, err = pis.db.db.Exec(`
+			UPDATE provider_instances
+			SET subtitle = ?, updated_at = datetime('now')
+			WHERE instance_id = ?
+		`, *subtitle, instanceID)
 	}
-
-	_, err := pis.db.db.Exec(`
-		UPDATE provider_instances
-		SET subtitle = ?, updated_at = datetime('now')
-		WHERE instance_id = ?
-	`, *subtitle, instanceID)
+	if err == nil {
+		GetModelResolutionCache().InvalidateInstances()
+	}
 	return err
 }

--- a/internal/database/store_virtual.go
+++ b/internal/database/store_virtual.go
@@ -73,6 +73,9 @@ func (s *VirtualModelStore) Create(r *VirtualModelRecord) error {
 		INSERT INTO virtual_models (virtual_model_id, name, description, api_shape, lb_strategy, enabled)
 		VALUES (?, ?, ?, ?, ?, ?)
 	`, r.VirtualModelID, r.Name, r.Description, r.APIShape, string(r.LbStrategy), enabledInt)
+	if err == nil {
+		GetModelResolutionCache().InvalidateVMs()
+	}
 	return err
 }
 
@@ -86,11 +89,17 @@ func (s *VirtualModelStore) Update(r *VirtualModelRecord) error {
 		SET name = ?, description = ?, api_shape = ?, lb_strategy = ?, enabled = ?, updated_at = datetime('now')
 		WHERE virtual_model_id = ?
 	`, r.Name, r.Description, r.APIShape, string(r.LbStrategy), enabledInt, r.VirtualModelID)
+	if err == nil {
+		GetModelResolutionCache().InvalidateVMs()
+	}
 	return err
 }
 
 func (s *VirtualModelStore) Delete(virtualModelID string) error {
 	_, err := s.db.db.Exec("DELETE FROM virtual_models WHERE virtual_model_id = ?", virtualModelID)
+	if err == nil {
+		GetModelResolutionCache().InvalidateVMs()
+	}
 	return err
 }
 
@@ -125,7 +134,11 @@ func (s *VirtualModelStore) Rename(oldID string, newID string) error {
 		return err
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	GetModelResolutionCache().InvalidateVMs()
+	return nil
 }
 
 // ─── Virtual model upstream operations ───────────────────────────────────────
@@ -183,5 +196,9 @@ func (s *VirtualModelUpstreamStore) SetForVModel(virtualModelID string, upstream
 			return err
 		}
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	GetModelResolutionCache().InvalidateVMs()
+	return nil
 }

--- a/internal/ingestion/from_responses.go
+++ b/internal/ingestion/from_responses.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"omnillm/internal/cif"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 )
@@ -141,14 +142,7 @@ func translateResponsesInput(input interface{}) ([]cif.CIFMessage, error) {
 			if !ok {
 				return nil, fmt.Errorf("invalid input item type: %T", item)
 			}
-			itemBytes, err := json.Marshal(itemMap)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal input item: %w", err)
-			}
-			var inputItem InputItem
-			if err := json.Unmarshal(itemBytes, &inputItem); err != nil {
-				return nil, fmt.Errorf("failed to decode input item: %w", err)
-			}
+			inputItem := inputItemFromMap(itemMap)
 
 			switch inputItemType(inputItem) {
 			case "message":
@@ -246,14 +240,7 @@ func translateInputContent(content interface{}) ([]cif.CIFContentPart, error) {
 			if !ok {
 				return nil, fmt.Errorf("invalid input content block type: %T", block)
 			}
-			blockBytes, err := json.Marshal(blockMap)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal input content block: %w", err)
-			}
-			var cb InputContentBlock
-			if err := json.Unmarshal(blockBytes, &cb); err != nil {
-				return nil, fmt.Errorf("failed to decode input content block: %w", err)
-			}
+			cb := inputContentBlockFromMap(blockMap)
 			switch cb.Type {
 			case "input_text", "output_text", "text":
 				parts = append(parts, cif.CIFTextPart{Type: "text", Text: cb.Text})
@@ -278,15 +265,15 @@ func extractInputText(content interface{}) string {
 	case string:
 		return v
 	case []interface{}:
-		text := ""
+		var sb strings.Builder
 		for _, block := range v {
 			if blockMap, ok := block.(map[string]interface{}); ok {
 				if t, ok := blockMap["text"].(string); ok {
-					text += t
+					sb.WriteString(t)
 				}
 			}
 		}
-		return text
+		return sb.String()
 	default:
 		return ""
 	}
@@ -383,5 +370,40 @@ func translateResponsesTextFormat(f *ResponsesTextFormat) map[string]interface{}
 		return map[string]interface{}{"type": "text"}
 	default:
 		return map[string]interface{}{"type": f.Type}
+	}
+}
+
+// inputItemFromMap extracts an InputItem directly from a map[string]interface{}
+// without a marshal+unmarshal roundtrip.
+func inputItemFromMap(m map[string]interface{}) InputItem {
+	getString := func(key string) string {
+		v, _ := m[key].(string)
+		return v
+	}
+	return InputItem{
+		Type:      getString("type"),
+		Role:      getString("role"),
+		Content:   m["content"],
+		ID:        getString("id"),
+		CallID:    getString("call_id"),
+		Name:      getString("name"),
+		Arguments: getString("arguments"),
+		Output:    getString("output"),
+	}
+}
+
+// inputContentBlockFromMap extracts an InputContentBlock directly from a
+// map[string]interface{} without a marshal+unmarshal roundtrip.
+func inputContentBlockFromMap(m map[string]interface{}) InputContentBlock {
+	getString := func(key string) string {
+		v, _ := m[key].(string)
+		return v
+	}
+	return InputContentBlock{
+		Type:     getString("type"),
+		Text:     getString("text"),
+		ImageURL: getString("image_url"),
+		FileID:   getString("file_id"),
+		Detail:   getString("detail"),
 	}
 }

--- a/internal/lib/modelrouting/modelrouting.go
+++ b/internal/lib/modelrouting/modelrouting.go
@@ -66,7 +66,7 @@ func GetCachedOrFetchModels(provider types.Provider, cache *ModelCache) (*types.
 
 func GetEnabledModelsByProvider(providers []types.Provider, cache *ModelCache) (map[string][]types.Model, error) {
 	modelsByProvider := make(map[string][]types.Model)
-	modelStateStore := database.NewModelStateStore()
+	stateCache := database.GetModelStateCache()
 
 	for _, provider := range providers {
 		providerModels, err := GetCachedOrFetchModels(provider, cache)
@@ -75,16 +75,7 @@ func GetEnabledModelsByProvider(providers []types.Provider, cache *ModelCache) (
 		}
 
 		instanceID := provider.GetInstanceID()
-
-		// Build set of disabled model IDs from DB
-		disabledModels := make(map[string]bool)
-		if states, err := modelStateStore.GetAllByInstance(instanceID); err == nil {
-			for _, state := range states {
-				if !state.Enabled {
-					disabledModels[state.ModelID] = true
-				}
-			}
-		}
+		disabledModels := stateCache.GetDisabledModels(instanceID)
 
 		enabledModels := make([]types.Model, 0, len(providerModels.Data))
 		for _, m := range providerModels.Data {
@@ -102,15 +93,11 @@ func SortProvidersByPriority(providers []types.Provider) []types.Provider {
 	sorted := make([]types.Provider, len(providers))
 	copy(sorted, providers)
 
-	// Load priorities from database
-	instanceStore := database.NewProviderInstanceStore()
-	priorityMap := make(map[string]int)
-
-	instances, err := instanceStore.GetAll()
-	if err == nil {
-		for _, inst := range instances {
-			priorityMap[inst.InstanceID] = inst.Priority
-		}
+	// Load priorities from the in-memory cache (zero DB queries on hot path).
+	instances := database.GetModelResolutionCache().GetAllProviderInstances()
+	priorityMap := make(map[string]int, len(instances))
+	for _, inst := range instances {
+		priorityMap[inst.InstanceID] = inst.Priority
 	}
 
 	sort.Slice(sorted, func(i, j int) bool {

--- a/internal/providers/alibaba/auth.go
+++ b/internal/providers/alibaba/auth.go
@@ -2,13 +2,13 @@
 package alibaba
 
 import (
-	"net/http"
+	"omnillm/internal/providers/shared"
 	"time"
 )
 
 var (
-	alibabaHTTPClient   = &http.Client{Timeout: 120 * time.Second}
-	alibabaStreamClient = &http.Client{}
+	alibabaHTTPClient   = shared.DefaultHTTPClient(120 * time.Second)
+	alibabaStreamClient = shared.DefaultStreamClient()
 )
 
 // ─── Base URL constants ───────────────────────────────────────────────────────

--- a/internal/providers/antigravity/oauth.go
+++ b/internal/providers/antigravity/oauth.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"omnillm/internal/providers/shared"
 	"time"
 )
 
@@ -35,7 +36,7 @@ type OAuthTokenResponse struct {
 	ErrorDesc    string `json:"error_description,omitempty"`
 }
 
-var oauthHTTPClient = &http.Client{Timeout: 30 * time.Second}
+var oauthHTTPClient = shared.DefaultHTTPClient(30 * time.Second)
 
 // BuildAuthURL returns the Google OAuth2 authorization URL that the user
 // should visit to grant access.

--- a/internal/providers/antigravity/provider.go
+++ b/internal/providers/antigravity/provider.go
@@ -170,7 +170,7 @@ func Stream(ctx context.Context, token, baseURL, projectID string, request *cif.
 	}
 
 	eventCh := make(chan cif.CIFStreamEvent, 64)
-	go ParseAntigravitySSE(resp.Body, eventCh)
+	go ParseAntigravitySSE(ctx, resp.Body, eventCh)
 	return eventCh, nil
 }
 

--- a/internal/providers/antigravity/provider_test.go
+++ b/internal/providers/antigravity/provider_test.go
@@ -1,6 +1,7 @@
 package antigravity
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -173,7 +174,7 @@ func TestParseAntigravitySSETextStream(t *testing.T) {
 	})
 
 	eventCh := make(chan cif.CIFStreamEvent, 16)
-	go ParseAntigravitySSE(newReadCloser(sseData), eventCh)
+	go ParseAntigravitySSE(context.Background(), newReadCloser(sseData), eventCh)
 
 	var events []cif.CIFStreamEvent
 	for event := range eventCh {
@@ -241,7 +242,7 @@ func TestParseAntigravitySSEToolCall(t *testing.T) {
 	})
 
 	eventCh := make(chan cif.CIFStreamEvent, 16)
-	go ParseAntigravitySSE(newReadCloser(sseData), eventCh)
+	go ParseAntigravitySSE(context.Background(), newReadCloser(sseData), eventCh)
 
 	var events []cif.CIFStreamEvent
 	for event := range eventCh {
@@ -300,7 +301,7 @@ func TestCollectStreamFromSSE(t *testing.T) {
 	})
 
 	eventCh := make(chan cif.CIFStreamEvent, 16)
-	go ParseAntigravitySSE(newReadCloser(sseData), eventCh)
+	go ParseAntigravitySSE(context.Background(), newReadCloser(sseData), eventCh)
 
 	// Manually collect
 	var textBuf strings.Builder

--- a/internal/providers/antigravity/stream.go
+++ b/internal/providers/antigravity/stream.go
@@ -3,6 +3,7 @@ package antigravity
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,9 +15,11 @@ import (
 )
 
 // ParseAntigravitySSE parses an Antigravity (Cloud Code) SSE stream into CIF events.
-func ParseAntigravitySSE(body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
+func ParseAntigravitySSE(ctx context.Context, body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
 	defer body.Close()
 	defer close(eventCh)
+	stop := context.AfterFunc(ctx, func() { body.Close() })
+	defer stop()
 
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 4*1024), 4*1024*1024)

--- a/internal/providers/antigravity/stream_test.go
+++ b/internal/providers/antigravity/stream_test.go
@@ -1,6 +1,7 @@
 package antigravity
 
 import (
+	"context"
 	"io"
 	"omnillm/internal/cif"
 	"strings"
@@ -13,7 +14,7 @@ func sseBody(s string) io.ReadCloser {
 
 func collectAntigravity(body io.ReadCloser) []cif.CIFStreamEvent {
 	ch := make(chan cif.CIFStreamEvent, 64)
-	go ParseAntigravitySSE(body, ch)
+	go ParseAntigravitySSE(context.Background(), body, ch)
 	var events []cif.CIFStreamEvent
 	for evt := range ch {
 		events = append(events, evt)

--- a/internal/providers/azure/chat.go
+++ b/internal/providers/azure/chat.go
@@ -187,6 +187,6 @@ func StreamOpenAI(ctx context.Context, url string, headers map[string]string, re
 	}
 
 	eventCh := make(chan cif.CIFStreamEvent, 64)
-	go shared.ParseOpenAISSE(resp.Body, eventCh)
+	go shared.ParseOpenAISSE(ctx, resp.Body, eventCh)
 	return eventCh, nil
 }

--- a/internal/providers/codex/codex.go
+++ b/internal/providers/codex/codex.go
@@ -447,7 +447,7 @@ func (a *CodexAdapter) ExecuteStream(ctx context.Context, request *cif.Canonical
 	}
 
 	ch := make(chan cif.CIFStreamEvent, 64)
-	go shared.ParseOpenAISSE(resp.Body, ch)
+	go shared.ParseOpenAISSE(ctx, resp.Body, ch)
 	return ch, nil
 }
 

--- a/internal/providers/copilot/responses.go
+++ b/internal/providers/copilot/responses.go
@@ -440,7 +440,7 @@ func (a *CopilotAdapter) executeResponsesStreamWithRetry(ctx context.Context, re
 	}
 
 	eventCh := make(chan cif.CIFStreamEvent, 64)
-	go parseResponsesSSE(resp.Body, eventCh)
+	go parseResponsesSSE(ctx, resp.Body, eventCh)
 	return eventCh, nil
 }
 
@@ -470,9 +470,11 @@ type responsesSSEState struct {
 	toolCallHasDelta  map[int]bool
 }
 
-func parseResponsesSSE(body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
+func parseResponsesSSE(ctx context.Context, body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
 	defer body.Close()
 	defer close(eventCh)
+	stop := context.AfterFunc(ctx, func() { body.Close() })
+	defer stop()
 
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 4*1024), 1024*1024)

--- a/internal/providers/google/provider.go
+++ b/internal/providers/google/provider.go
@@ -317,7 +317,7 @@ func Stream(ctx context.Context, token, baseURL string, request *cif.CanonicalRe
 	}
 
 	eventCh := make(chan cif.CIFStreamEvent, 64)
-	go ParseGeminiSSE(resp.Body, eventCh)
+	go ParseGeminiSSE(ctx, resp.Body, eventCh)
 	return eventCh, nil
 }
 

--- a/internal/providers/google/provider_test.go
+++ b/internal/providers/google/provider_test.go
@@ -292,7 +292,7 @@ func TestParseGeminiSSETextStream(t *testing.T) {
 data: {"candidates":[{"content":{"parts":[{"text":" world"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3}}
 `
 	eventCh := make(chan cif.CIFStreamEvent, 16)
-	go ParseGeminiSSE(newReadCloser(sseData), eventCh)
+	go ParseGeminiSSE(context.Background(), newReadCloser(sseData), eventCh)
 
 	var events []cif.CIFStreamEvent
 	for event := range eventCh {
@@ -337,7 +337,7 @@ func TestParseGeminiSSEToolCall(t *testing.T) {
 	sseData := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"search","args":{"q":"test"}}}],"role":"model"},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}}
 `
 	eventCh := make(chan cif.CIFStreamEvent, 16)
-	go ParseGeminiSSE(newReadCloser(sseData), eventCh)
+	go ParseGeminiSSE(context.Background(), newReadCloser(sseData), eventCh)
 
 	var events []cif.CIFStreamEvent
 	for event := range eventCh {
@@ -378,7 +378,7 @@ func TestParseGeminiSSESafetyFilter(t *testing.T) {
 	sseData := `data: {"candidates":[{"content":{"parts":[],"role":"model"},"finishReason":"SAFETY"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":0}}
 `
 	eventCh := make(chan cif.CIFStreamEvent, 16)
-	go ParseGeminiSSE(newReadCloser(sseData), eventCh)
+	go ParseGeminiSSE(context.Background(), newReadCloser(sseData), eventCh)
 
 	var events []cif.CIFStreamEvent
 	for event := range eventCh {

--- a/internal/providers/google/stream.go
+++ b/internal/providers/google/stream.go
@@ -3,6 +3,7 @@ package google
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,9 +15,11 @@ import (
 )
 
 // ParseGeminiSSE parses a Google Gemini SSE stream into CIF events.
-func ParseGeminiSSE(body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
+func ParseGeminiSSE(ctx context.Context, body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
 	defer body.Close()
 	defer close(eventCh)
+	stop := context.AfterFunc(ctx, func() { body.Close() })
+	defer stop()
 
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 4*1024), 4*1024*1024)

--- a/internal/providers/google/stream_test.go
+++ b/internal/providers/google/stream_test.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"context"
 	"io"
 	"omnillm/internal/cif"
 	"strings"
@@ -13,7 +14,7 @@ func sseBody(s string) io.ReadCloser {
 
 func collectGemini(body io.ReadCloser) []cif.CIFStreamEvent {
 	ch := make(chan cif.CIFStreamEvent, 64)
-	go ParseGeminiSSE(body, ch)
+	go ParseGeminiSSE(context.Background(), body, ch)
 	var events []cif.CIFStreamEvent
 	for evt := range ch {
 		events = append(events, evt)

--- a/internal/providers/kimi/provider.go
+++ b/internal/providers/kimi/provider.go
@@ -23,8 +23,8 @@ const BaseURL = "https://api.moonshot.cn/v1"
 
 // Shared HTTP clients.
 var (
-	kimiHTTPClient   = &http.Client{Timeout: 120 * time.Second}
-	kimiStreamClient = &http.Client{}
+	kimiHTTPClient   = shared.DefaultHTTPClient(120 * time.Second)
+	kimiStreamClient = shared.DefaultStreamClient()
 )
 
 // Model catalog for Kimi.

--- a/internal/providers/modelscope/provider.go
+++ b/internal/providers/modelscope/provider.go
@@ -23,7 +23,7 @@ const UserAgent = "OmniLLM/1.0"
 // Default ModelScope inference endpoint.
 const BaseURL = "https://api-inference.modelscope.cn/v1"
 
-var httpClient = &http.Client{Timeout: 120 * time.Second}
+var httpClient = shared.DefaultHTTPClient(120 * time.Second)
 
 // TokenData is the persisted credential record for a ModelScope instance.
 type TokenData struct {

--- a/internal/providers/openaicompat/http.go
+++ b/internal/providers/openaicompat/http.go
@@ -26,17 +26,8 @@ func cappedBody(b []byte) []byte {
 }
 
 var (
-	httpClient = &http.Client{
-		Timeout: 120 * time.Second,
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-		},
-	}
-	streamClient = &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-		},
-	}
+	httpClient = shared.DefaultHTTPClient(120 * time.Second)
+	streamClient = shared.DefaultStreamClient()
 )
 
 // APIError preserves upstream HTTP failures so adapters can decide whether to
@@ -109,9 +100,9 @@ func shouldRetryPOSTTimeout(_ *http.Request, _ error) bool {
 	return false
 }
 
-func startSSEStream(body io.ReadCloser, parser func(io.ReadCloser, chan cif.CIFStreamEvent)) <-chan cif.CIFStreamEvent {
+func startSSEStream(ctx context.Context, body io.ReadCloser, parser func(context.Context, io.ReadCloser, chan cif.CIFStreamEvent)) <-chan cif.CIFStreamEvent {
 	eventCh := make(chan cif.CIFStreamEvent, 64)
-	go parser(body, eventCh)
+	go parser(ctx, body, eventCh)
 	return eventCh
 }
 
@@ -167,7 +158,7 @@ func Stream(ctx context.Context, url string, headers map[string]string, cr *Chat
 		return nil, fmt.Errorf("openaicompat: stream request failed: %w", err)
 	}
 
-	return startSSEStream(resp.Body, ParseSSE), nil
+	return startSSEStream(ctx, resp.Body, ParseSSE), nil
 }
 
 // CollectStream is a convenience wrapper: runs Stream and assembles CIF response.

--- a/internal/providers/openaicompat/responses.go
+++ b/internal/providers/openaicompat/responses.go
@@ -387,12 +387,14 @@ func StreamResponses(ctx context.Context, url string, headers map[string]string,
 		return nil, fmt.Errorf("openaicompat: responses stream request failed: %w", err)
 	}
 
-	return startSSEStream(resp.Body, ParseResponsesSSE), nil
+	return startSSEStream(ctx, resp.Body, ParseResponsesSSE), nil
 }
 
-func ParseResponsesSSE(body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
+func ParseResponsesSSE(ctx context.Context, body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
 	defer body.Close()
 	defer close(eventCh)
+	stop := context.AfterFunc(ctx, func() { body.Close() })
+	defer stop()
 
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 4*1024), 1024*1024)

--- a/internal/providers/openaicompat/serialization.go
+++ b/internal/providers/openaicompat/serialization.go
@@ -10,6 +10,7 @@ package openaicompat
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -301,9 +302,13 @@ func StopReason(reason string) cif.CIFStopReason {
 //   - reasoning_content deltas → CIFThinkingPart / ThinkingDelta (Qwen3 / o1)
 //   - finish_reason "stop" when tool calls were observed → upgraded to ToolUse
 //   - tool_call.index continuations mapped across chunks
-func ParseSSE(body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
+func ParseSSE(ctx context.Context, body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
 	defer body.Close()
 	defer close(eventCh)
+	// When the request context is cancelled (client disconnect), close the body
+	// so the scanner's Read call unblocks and the goroutine exits cleanly.
+	stop := context.AfterFunc(ctx, func() { body.Close() })
+	defer stop()
 
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 4*1024), 1024*1024)

--- a/internal/providers/shared/http.go
+++ b/internal/providers/shared/http.go
@@ -1,0 +1,43 @@
+package shared
+
+import (
+	"net/http"
+	"time"
+)
+
+// DefaultHTTPTransport returns a new *http.Transport with production-safe
+// connection pool settings. Every provider client should use this instead of
+// repeating the same boilerplate or relying on Go's default Transport
+// (which has MaxIdleConnsPerHost=2 — far too low under concurrent load).
+//
+// Callers that need a streaming client should omit Timeout (set it to 0) so
+// long-lived SSE connections are not cut off by an idle timeout.
+func DefaultHTTPTransport() *http.Transport {
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   20,
+		MaxConnsPerHost:       50,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+// DefaultHTTPClient returns an *http.Client suitable for non-streaming
+// (request-response) provider calls. Uses DefaultHTTPTransport.
+func DefaultHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: DefaultHTTPTransport(),
+	}
+}
+
+// DefaultStreamClient returns an *http.Client suitable for streaming (SSE)
+// provider calls — no Timeout so long-lived connections are not cut off.
+func DefaultStreamClient() *http.Client {
+	return &http.Client{
+		Transport: DefaultHTTPTransport(),
+	}
+}

--- a/internal/providers/shared/openai_messages.go
+++ b/internal/providers/shared/openai_messages.go
@@ -108,7 +108,7 @@ func StreamOpenAIWithPayload(ctx context.Context, url string, headers map[string
 	}
 
 	eventCh := make(chan cif.CIFStreamEvent, 64)
-	go ParseOpenAISSE(resp.Body, eventCh)
+	go ParseOpenAISSE(ctx, resp.Body, eventCh)
 	return eventCh, nil
 }
 

--- a/internal/providers/shared/openai_sse.go
+++ b/internal/providers/shared/openai_sse.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"io"
 	"omnillm/internal/cif"
@@ -11,6 +12,9 @@ import (
 )
 
 // ParseOpenAISSE parses an OpenAI-compatible SSE stream into CIF events.
+// ctx is the request context; when it is cancelled (e.g. client disconnect)
+// the response body is closed which causes the scanner to exit, so the
+// goroutine terminates rather than blocking forever on a send.
 //
 // Qwen3/Alibaba quirks handled here:
 //   - finish_reason may be "stop" even when tool calls were made; the stop
@@ -18,9 +22,13 @@ import (
 //     were observed during the stream.
 //   - reasoning_content in delta chunks (Qwen3 thinking) is forwarded as
 //     ThinkingDelta events so the thinking is not silently dropped.
-func ParseOpenAISSE(body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
+func ParseOpenAISSE(ctx context.Context, body io.ReadCloser, eventCh chan cif.CIFStreamEvent) {
 	defer body.Close()
 	defer close(eventCh)
+	// When the request context is cancelled (client disconnect), close the body
+	// so the scanner's Read call unblocks and the goroutine exits cleanly.
+	stop := context.AfterFunc(ctx, func() { body.Close() })
+	defer stop()
 
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 4*1024), 1024*1024)

--- a/internal/providers/shared/openai_sse_test.go
+++ b/internal/providers/shared/openai_sse_test.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"context"
 	"io"
 	"omnillm/internal/cif"
 	"strings"
@@ -16,7 +17,7 @@ func sseBody(s string) io.ReadCloser {
 // all events as a slice.
 func collectSSE(body io.ReadCloser) []cif.CIFStreamEvent {
 	ch := make(chan cif.CIFStreamEvent, 64)
-	go ParseOpenAISSE(body, ch)
+	go ParseOpenAISSE(context.Background(), body, ch)
 	var events []cif.CIFStreamEvent
 	for evt := range ch {
 		events = append(events, evt)

--- a/internal/routes/metering.go
+++ b/internal/routes/metering.go
@@ -5,8 +5,6 @@ import (
 	"omnillm/internal/database"
 	"strings"
 	"time"
-
-	"github.com/rs/zerolog/log"
 )
 
 // recordUsage writes a metering row asynchronously after a completed request.
@@ -61,12 +59,5 @@ func recordUsage(
 		CreatedAt:    time.Now().UTC(),
 	}
 
-	go func() {
-		db := database.GetDatabase()
-		if err := db.InsertMeteringRecord(rec); err != nil {
-			log.Error().Err(err).
-				Str("request_id", requestID).
-				Msg("Failed to record metering data")
-		}
-	}()
+	database.EnqueueMeteringRecord(rec)
 }

--- a/internal/routes/model_resolution.go
+++ b/internal/routes/model_resolution.go
@@ -1,8 +1,6 @@
 package routes
 
 import (
-	"strings"
-
 	"omnillm/internal/database"
 	"omnillm/internal/lib/modelrouting"
 	"omnillm/internal/lib/virtualmodelrouting"
@@ -50,27 +48,19 @@ func resolveRequestedModels(requestID, requestedModel string) []resolvedModelAtt
 
 	normalizedModel := modelrouting.NormalizeModelName(requestedModel)
 
-	virtualmodelStore := database.NewVirtualModelStore()
-	vm, err := virtualmodelStore.Get(requestedModel)
-	if err != nil {
-		log.Warn().Err(err).Str("request_id", requestID).Str("model", requestedModel).Str("normalized_model", normalizedModel).Msg("Failed to load virtual model")
-		return []resolvedModelAttempt{{RequestedModel: requestedModel, NormalizedModel: normalizedModel}}
-	}
+	cache := database.GetModelResolutionCache()
+
+	vm := cache.GetVirtualModel(requestedModel)
 	if vm == nil && normalizedModel != requestedModel {
-		vm, err = virtualmodelStore.Get(normalizedModel)
-		if err != nil {
-			log.Warn().Err(err).Str("request_id", requestID).Str("model", requestedModel).Str("normalized_model", normalizedModel).Msg("Failed to load normalized virtual model")
-			return []resolvedModelAttempt{{RequestedModel: requestedModel, NormalizedModel: normalizedModel}}
-		}
+		vm = cache.GetVirtualModel(normalizedModel)
 	}
 	if vm == nil || !vm.Enabled {
 		return []resolvedModelAttempt{{RequestedModel: requestedModel, NormalizedModel: normalizedModel}}
 	}
 
-	upstreamStore := database.NewVirtualModelUpstreamStore()
-	upstreams, err := upstreamStore.GetForVModel(vm.VirtualModelID)
-	if err != nil {
-		log.Warn().Err(err).Str("request_id", requestID).Str("virtual_model", vm.VirtualModelID).Msg("Failed to load virtual model upstreams")
+	upstreams := cache.GetUpstreams(vm.VirtualModelID)
+	if len(upstreams) == 0 {
+		log.Warn().Str("request_id", requestID).Str("virtual_model", vm.VirtualModelID).Msg("Virtual model has no routable upstream")
 		return []resolvedModelAttempt{{RequestedModel: requestedModel, NormalizedModel: normalizedModel}}
 	}
 
@@ -120,28 +110,5 @@ func resolveRequestedModels(requestID, requestedModel string) []resolvedModelAtt
 // If neither matches, the original prefix is returned unchanged so the caller
 // can produce a meaningful "provider not found" error downstream.
 func resolveProviderPrefix(prefix string) string {
-	instanceStore := database.NewProviderInstanceStore()
-	instances, err := instanceStore.GetAll()
-	if err != nil {
-		return prefix
-	}
-
-	lowerPrefix := strings.ToLower(prefix)
-
-	var subtitleMatch string
-	for _, inst := range instances {
-		// 1. Exact instance ID match — highest priority.
-		if inst.InstanceID == prefix {
-			return prefix
-		}
-		// 2. Case-insensitive subtitle match — collect first hit.
-		if subtitleMatch == "" && strings.ToLower(inst.Subtitle) == lowerPrefix {
-			subtitleMatch = inst.InstanceID
-		}
-	}
-
-	if subtitleMatch != "" {
-		return subtitleMatch
-	}
-	return prefix
+	return database.GetModelResolutionCache().ResolveProviderPrefix(prefix)
 }

--- a/internal/serialization/to_anthropic.go
+++ b/internal/serialization/to_anthropic.go
@@ -2,7 +2,6 @@ package serialization
 
 import (
 	"encoding/json"
-	"fmt"
 	"omnillm/internal/cif"
 	"strings"
 
@@ -366,7 +365,16 @@ func FormatAnthropicSSEData(eventType string, data interface{}) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("event: %s\ndata: %s\n\n", eventType, string(jsonBytes)), nil
+	// Use strings.Builder to avoid the extra string(jsonBytes) copy and the
+	// additional allocation from fmt.Sprintf.
+	var b strings.Builder
+	b.Grow(len("event: ") + len(eventType) + len("\ndata: ") + len(jsonBytes) + len("\n\n"))
+	b.WriteString("event: ")
+	b.WriteString(eventType)
+	b.WriteString("\ndata: ")
+	b.Write(jsonBytes)
+	b.WriteString("\n\n")
+	return b.String(), nil
 }
 
 func convertStopReasonToAnthropic(reason cif.CIFStopReason) *string {

--- a/internal/serialization/to_openai.go
+++ b/internal/serialization/to_openai.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"omnillm/internal/cif"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -67,13 +68,13 @@ type OpenAIUsage struct {
 
 // SerializeToOpenAI converts a CIF response to OpenAI format
 func SerializeToOpenAI(response *cif.CanonicalResponse) (*OpenAIResponse, error) {
-	var contentText string
+	var contentBuf strings.Builder
 	var toolCalls []OpenAIToolCall
 
 	for _, part := range response.Content {
 		switch p := part.(type) {
 		case cif.CIFTextPart:
-			contentText += p.Text
+			contentBuf.WriteString(p.Text)
 		case cif.CIFToolCallPart:
 			args, err := json.Marshal(p.ToolArguments)
 			if err != nil {
@@ -105,7 +106,8 @@ func SerializeToOpenAI(response *cif.CanonicalResponse) (*OpenAIResponse, error)
 		FinishReason: finishReason,
 	}
 
-	if contentText != "" {
+	if contentBuf.Len() > 0 {
+		contentText := contentBuf.String()
 		choice.Message.Content = &contentText
 	}
 
@@ -315,7 +317,14 @@ func formatSSEData(data interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("data: %s\n\n", string(jsonBytes)), nil
+	// Use strings.Builder to avoid the extra string(jsonBytes) copy and the
+	// additional allocation from fmt.Sprintf.
+	var b strings.Builder
+	b.Grow(len("data: ") + len(jsonBytes) + len("\n\n"))
+	b.WriteString("data: ")
+	b.Write(jsonBytes)
+	b.WriteString("\n\n")
+	return b.String(), nil
 }
 
 func convertStopReasonToOpenAI(reason cif.CIFStopReason) *string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,13 +1,17 @@
 package server
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/gin-contrib/cors"
@@ -19,9 +23,9 @@ import (
 	"omnillm/internal/lib/ratelimit"
 	alibabapkg "omnillm/internal/providers/alibaba"
 	antigravitypkg "omnillm/internal/providers/antigravity"
-	"omnillm/internal/providers/copilot"
 	azurepkg "omnillm/internal/providers/azure"
 	codexpkg "omnillm/internal/providers/codex"
+	"omnillm/internal/providers/copilot"
 	googlepkg "omnillm/internal/providers/google"
 	kimipkg "omnillm/internal/providers/kimi"
 	modelscopepkg "omnillm/internal/providers/modelscope"
@@ -30,6 +34,7 @@ import (
 	"omnillm/internal/registry"
 	"omnillm/internal/routes"
 )
+
 type StartOptions struct {
 	Port                int
 	Host                string
@@ -124,7 +129,44 @@ func RunServer(options StartOptions) error {
 
 	log.Info().Str("api_key_path", filepath.Join(configDir, apiKeyFileName)).Msg("Inbound API authentication enabled")
 
-	return r.Run(bindAddr)
+	srv := &http.Server{
+		Addr:    bindAddr,
+		Handler: r.Handler(),
+	}
+
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+		}
+		close(serverErr)
+	}()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	select {
+	case err := <-serverErr:
+		if err != nil {
+			return err
+		}
+		return nil
+	case sig := <-sigCh:
+		log.Info().Str("signal", sig.String()).Msg("OmniLLM server shutting down")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("shutdown server: %w", err)
+	}
+
+	database.StopAsyncWorkers()
+	if err := database.GetDatabase().Close(); err != nil {
+		return fmt.Errorf("close database: %w", err)
+	}
+	return nil
 }
 
 func buildRouter(port int, apiKey string, chatOptions routes.ChatCompletionOptions) *gin.Engine {


### PR DESCRIPTION
## Summary
- cache model resolution, provider instance, and model state lookups to reduce repeated SQLite work on request hot paths
- move metering and token `last_used_at` writes onto bounded async worker pools
- gracefully shut down the HTTP server and drain async DB workers before closing SQLite

Closes #145

## Test plan
- [x] `go test ./...`
- [x] `bun test --timeout 30000 tests/`
- [x] `bun run typecheck`
- [x] `bun run lint:all`
- [x] `bun run build`
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)