### PR TITLE
Fix provider model cache reuse

### DIFF
--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -323,6 +323,51 @@ func TestVirtualModelStoresCRUD(t *testing.T) {
 	}
 }
 
+func TestProviderInstanceStoreDeleteRemovesProviderModelsCache(t *testing.T) {
+	instanceID := "cache-delete-provider"
+	instanceStore := NewProviderInstanceStore()
+	cacheStore := NewProviderModelsCacheStore()
+
+	if err := instanceStore.Save(&ProviderInstanceRecord{InstanceID: instanceID, ProviderID: "google", Name: "Google"}); err != nil {
+		t.Fatalf("setup provider instance: %v", err)
+	}
+	if err := cacheStore.Save(instanceID, "google", `[{"id":"gemini"}]`); err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+	if err := instanceStore.Delete(instanceID); err != nil {
+		t.Fatalf("delete provider instance: %v", err)
+	}
+
+	cached, err := cacheStore.Get(instanceID, "google", DefaultCacheTTL)
+	if err != nil {
+		t.Fatalf("get cache: %v", err)
+	}
+	if cached != nil {
+		t.Fatalf("expected provider deletion to remove model cache, got %#v", cached)
+	}
+}
+
+func TestProviderModelsCacheStoreGetIgnoresProviderTypeMismatch(t *testing.T) {
+	instanceID := "cache-type-provider"
+	instanceStore := NewProviderInstanceStore()
+	cacheStore := NewProviderModelsCacheStore()
+
+	if err := instanceStore.Save(&ProviderInstanceRecord{InstanceID: instanceID, ProviderID: "google", Name: "Google"}); err != nil {
+		t.Fatalf("setup provider instance: %v", err)
+	}
+	if err := cacheStore.Save(instanceID, "openai-compatible", `[{"id":"moonshot"}]`); err != nil {
+		t.Fatalf("save stale cache: %v", err)
+	}
+
+	cached, err := cacheStore.Get(instanceID, "google", DefaultCacheTTL)
+	if err != nil {
+		t.Fatalf("get cache: %v", err)
+	}
+	if cached != nil {
+		t.Fatalf("expected provider-type mismatch to miss cache, got %#v", cached)
+	}
+}
+
 func TestCreateTablesIsIdempotentForBackfill(t *testing.T) {
 	db := GetDatabase()
 	if err := db.createTables(); err != nil {
@@ -413,7 +458,7 @@ func TestCreateTablesMigratesLegacyProviderModelsCache(t *testing.T) {
 	}
 
 	cacheStore := &ProviderModelsCacheStore{db: legacy}
-	if err := cacheStore.Save("legacy-provider", `{"models":["x"]}`); err != nil {
+	if err := cacheStore.Save("legacy-provider", "mock", `{"models":["x"]}`); err != nil {
 		t.Fatalf("save migrated cache row: %v", err)
 	}
 

--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -139,6 +139,7 @@ func (db *Database) createTables() error {
 		// Cached model list returned by each provider's /models endpoint.
 		`CREATE TABLE IF NOT EXISTS provider_models_cache (
 			instance_id TEXT PRIMARY KEY,
+			provider_id TEXT    NOT NULL DEFAULT '',
 			models_data TEXT    NOT NULL,
 			cached_at   DATETIME NOT NULL DEFAULT (datetime('now')),
 			updated_at  DATETIME NOT NULL DEFAULT (datetime('now')),
@@ -266,11 +267,11 @@ var migrations = []migration{
 	// v1: add subtitle to provider_instances (backfill for pre-subtitle databases).
 	{1, []string{`ALTER TABLE provider_instances ADD COLUMN subtitle TEXT NOT NULL DEFAULT ''`}},
 	// v2: add provider_id to virtual_model_upstreams (backfill for pre-provider_id databases).
-	{2, []string{`ALTER TABLE virtual_model_upstreams ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`} },
+	{2, []string{`ALTER TABLE virtual_model_upstreams ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`}},
 	// v3: add provider_id column to tokens for existing rows that pre-date its removal
 	//     from the schema (kept for backward-compat reads; new code ignores it).
 	//     No-op on fresh databases where the column was never added.
-	{3, []string{`ALTER TABLE tokens ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`} },
+	{3, []string{`ALTER TABLE tokens ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`}},
 	// v4: add updated_at to provider_models_cache using a SQLite-safe backfill path.
 	{4, []string{
 		`ALTER TABLE provider_models_cache ADD COLUMN updated_at DATETIME`,
@@ -377,6 +378,8 @@ var migrations = []migration{
 		`UPDATE chat_sessions SET api_shape = 'anthropic' WHERE api_shape IS NULL OR api_shape = '' OR api_shape != 'anthropic'`,
 		`UPDATE chat_sessions SET agent_backend = 'omnicode' WHERE agent_backend IS NULL OR agent_backend = '' OR agent_backend != 'omnicode'`,
 	}},
+	// v14: bind provider model cache rows to provider type so reused instance IDs cannot read stale model lists.
+	{14, []string{`ALTER TABLE provider_models_cache ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`}},
 }
 
 // applyMigrations runs any migrations that have not yet been applied.

--- a/internal/database/store_cache.go
+++ b/internal/database/store_cache.go
@@ -18,15 +18,15 @@ func NewProviderModelsCacheStore() *ProviderModelsCacheStore {
 	return &ProviderModelsCacheStore{db: GetDatabase()}
 }
 
-// Get returns the cached model list if it exists and is still valid (not expired).
+// Get returns the cached model list if it exists, matches the provider type, and is still valid.
 // Returns nil, nil if no cache entry exists or it has expired.
-func (cs *ProviderModelsCacheStore) Get(instanceID string, ttl time.Duration) (*ProviderModelsCacheRecord, error) {
+func (cs *ProviderModelsCacheStore) Get(instanceID, providerID string, ttl time.Duration) (*ProviderModelsCacheRecord, error) {
 	var record ProviderModelsCacheRecord
 	var cachedAtStr string
 	err := cs.db.db.QueryRow(`
-		SELECT instance_id, models_data, cached_at
-		FROM provider_models_cache WHERE instance_id = ?
-	`, instanceID).Scan(&record.InstanceID, &record.ModelsData, &cachedAtStr)
+		SELECT instance_id, provider_id, models_data, cached_at
+		FROM provider_models_cache WHERE instance_id = ? AND provider_id = ?
+	`, instanceID, providerID).Scan(&record.InstanceID, &record.ProviderID, &record.ModelsData, &cachedAtStr)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -37,7 +37,6 @@ func (cs *ProviderModelsCacheStore) Get(instanceID string, ttl time.Duration) (*
 
 	record.CachedAt = parseTime(cachedAtStr)
 
-	// Check if cache has expired
 	if time.Since(record.CachedAt) > ttl {
 		return nil, nil
 	}
@@ -46,15 +45,16 @@ func (cs *ProviderModelsCacheStore) Get(instanceID string, ttl time.Duration) (*
 }
 
 // Save stores the model list in the cache.
-func (cs *ProviderModelsCacheStore) Save(instanceID, modelsData string) error {
+func (cs *ProviderModelsCacheStore) Save(instanceID, providerID, modelsData string) error {
 	_, err := cs.db.db.Exec(`
-		INSERT INTO provider_models_cache (instance_id, models_data, cached_at, updated_at)
-		VALUES (?, ?, datetime('now'), datetime('now'))
+		INSERT INTO provider_models_cache (instance_id, provider_id, models_data, cached_at, updated_at)
+		VALUES (?, ?, ?, datetime('now'), datetime('now'))
 		ON CONFLICT(instance_id) DO UPDATE SET
+			provider_id = excluded.provider_id,
 			models_data = excluded.models_data,
 			cached_at = datetime('now'),
 			updated_at = datetime('now')
-	`, instanceID, modelsData)
+	`, instanceID, providerID, modelsData)
 	return err
 }
 

--- a/internal/database/store_provider_instances.go
+++ b/internal/database/store_provider_instances.go
@@ -84,6 +84,9 @@ func (pis *ProviderInstanceStore) Save(record *ProviderInstanceRecord) error {
 }
 
 func (pis *ProviderInstanceStore) Delete(instanceID string) error {
+	if err := NewProviderModelsCacheStore().Delete(instanceID); err != nil {
+		return err
+	}
 	_, err := pis.db.db.Exec("DELETE FROM provider_instances WHERE instance_id = ?", instanceID)
 	if err == nil {
 		GetModelResolutionCache().InvalidateInstances()

--- a/internal/database/types.go
+++ b/internal/database/types.go
@@ -79,6 +79,7 @@ type ModelConfigRecord struct {
 
 type ProviderModelsCacheRecord struct {
 	InstanceID string    `json:"instance_id"`
+	ProviderID string    `json:"provider_id"`
 	ModelsData string    `json:"models_data"` // JSON array of cached models
 	CachedAt   time.Time `json:"cached_at"`
 }

--- a/internal/routes/admin_provider_config.go
+++ b/internal/routes/admin_provider_config.go
@@ -190,7 +190,7 @@ func loadProviderModels(provider types.Provider, forceRefresh bool) ([]providerM
 
 	// Check cache first (unless force refresh)
 	if !forceRefresh {
-		if cached, err := cacheStore.Get(instanceID, database.DefaultCacheTTL); err == nil && cached != nil {
+		if cached, err := cacheStore.Get(instanceID, provider.GetID(), database.DefaultCacheTTL); err == nil && cached != nil {
 			var models []providerModelView
 			if err := json.Unmarshal([]byte(cached.ModelsData), &models); err == nil {
 				// Re-apply enabled states from DB (may have changed since cache)
@@ -282,7 +282,7 @@ func loadProviderModels(provider types.Provider, forceRefresh bool) ([]providerM
 
 	// Save to cache
 	if modelsJSON, err := json.Marshal(models); err == nil {
-		if err := cacheStore.Save(instanceID, string(modelsJSON)); err != nil {
+		if err := cacheStore.Save(instanceID, provider.GetID(), string(modelsJSON)); err != nil {
 			log.Warn().Err(err).Str("provider", instanceID).Msg("Failed to cache provider models")
 		}
 	}


### PR DESCRIPTION
## Summary
- keep provider model cache entries in sync when admin provider config changes
- update provider instance metadata refresh logic to reuse the correct cached model state
- add test coverage for provider model cache reuse behavior

## Test Plan
- [x] go test ./...