### PR TITLE
Fix Gemini historical tool call metadata

### DIFF
--- a/internal/providers/google/provider.go
+++ b/internal/providers/google/provider.go
@@ -11,6 +11,7 @@ import (
 	"omnillm/internal/cif"
 	"omnillm/internal/database"
 	"omnillm/internal/providers/shared"
+	"omnillm/internal/providers/shared/gemini"
 	"omnillm/internal/providers/types"
 	"strings"
 	"time"
@@ -179,7 +180,7 @@ func StreamURL(baseURL, model string) string {
 
 // BuildPayload builds the request body for the Gemini API.
 func BuildPayload(model string, request *cif.CanonicalRequest) map[string]interface{} {
-	contents := shared.CIFMessagesToGemini(request.Messages)
+	contents := gemini.CIFMessagesToGemini(request.Messages)
 
 	payload := map[string]interface{}{
 		"model":    model,
@@ -199,7 +200,7 @@ func BuildPayload(model string, request *cif.CanonicalRequest) map[string]interf
 		for _, tool := range request.Tools {
 			decl := map[string]interface{}{
 				"name":       tool.Name,
-				"parameters": shared.SanitizeGeminiSchema(tool.ParametersSchema),
+				"parameters": gemini.SanitizeGeminiSchema(tool.ParametersSchema),
 			}
 			if tool.Description != nil {
 				decl["description"] = *tool.Description
@@ -240,7 +241,7 @@ func Stream(ctx context.Context, token, baseURL string, request *cif.CanonicalRe
 	}
 
 	model := request.Model
-	contents := shared.CIFMessagesToGemini(request.Messages)
+	contents := gemini.CIFMessagesToGemini(request.Messages)
 
 	geminiReq := map[string]interface{}{
 		"contents": contents,
@@ -259,7 +260,7 @@ func Stream(ctx context.Context, token, baseURL string, request *cif.CanonicalRe
 		for _, tool := range request.Tools {
 			decl := map[string]interface{}{
 				"name":       tool.Name,
-				"parameters": shared.SanitizeGeminiSchema(tool.ParametersSchema),
+				"parameters": gemini.SanitizeGeminiSchema(tool.ParametersSchema),
 			}
 			if tool.Description != nil {
 				decl["description"] = *tool.Description

--- a/internal/providers/google/provider_test.go
+++ b/internal/providers/google/provider_test.go
@@ -258,6 +258,60 @@ func TestBuildPayloadSystemInstruction(t *testing.T) {
 	}
 }
 
+func TestBuildPayloadAddsSkipThoughtSignatureToHistoricalToolCalls(t *testing.T) {
+	request := &cif.CanonicalRequest{
+		Model: "gemini-3.1-flash-lite",
+		Messages: []cif.CIFMessage{
+			cif.CIFAssistantMessage{Role: "assistant", Content: []cif.CIFContentPart{
+				cif.CIFToolCallPart{
+					Type:          "tool_call",
+					ToolCallID:    "call_123",
+					ToolName:      "Read",
+					ToolArguments: map[string]interface{}{"file_path": "README.md"},
+				},
+			}},
+		},
+	}
+
+	payload := BuildPayload("gemini-3.1-flash-lite", request)
+	contents := payload["contents"].([]map[string]interface{})
+	parts := contents[0]["parts"].([]map[string]interface{})
+	if got := parts[0]["thoughtSignature"]; got != "skip_thought_signature_validator" {
+		t.Fatalf("thoughtSignature = %v, want skip_thought_signature_validator", got)
+	}
+}
+
+func TestBuildPayloadAddsToolResultNameFromPriorToolCall(t *testing.T) {
+	request := &cif.CanonicalRequest{
+		Model: "gemini-3.1-flash-lite",
+		Messages: []cif.CIFMessage{
+			cif.CIFAssistantMessage{Role: "assistant", Content: []cif.CIFContentPart{
+				cif.CIFToolCallPart{
+					Type:          "tool_call",
+					ToolCallID:    "call_123",
+					ToolName:      "Read",
+					ToolArguments: map[string]interface{}{"file_path": "README.md"},
+				},
+			}},
+			cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{
+				cif.CIFToolResultPart{
+					Type:       "tool_result",
+					ToolCallID: "call_123",
+					Content:    "contents",
+				},
+			}},
+		},
+	}
+
+	payload := BuildPayload("gemini-3.1-flash-lite", request)
+	contents := payload["contents"].([]map[string]interface{})
+	parts := contents[1]["parts"].([]map[string]interface{})
+	functionResponse := parts[0]["functionResponse"].(map[string]interface{})
+	if got := functionResponse["name"]; got != "Read" {
+		t.Fatalf("functionResponse name = %v, want Read", got)
+	}
+}
+
 func TestBuildPayloadWithTools(t *testing.T) {
 	desc := "Search the web"
 	request := &cif.CanonicalRequest{

--- a/internal/providers/shared/gemini/gemini.go
+++ b/internal/providers/shared/gemini/gemini.go
@@ -1,0 +1,113 @@
+package gemini
+
+import "omnillm/internal/cif"
+
+const skipThoughtSignatureValidator = "skip_thought_signature_validator"
+
+// CIFMessagesToGemini converts CIF messages to the Google Gemini contents format.
+func CIFMessagesToGemini(messages []cif.CIFMessage) []map[string]interface{} {
+	var contents []map[string]interface{}
+	toolCallNamesByID := make(map[string]string)
+	for _, msg := range messages {
+		switch m := msg.(type) {
+		case cif.CIFSystemMessage:
+			// System messages are handled via systemInstruction; skip here
+			_ = m
+		case cif.CIFUserMessage:
+			var parts []map[string]interface{}
+			for _, part := range m.Content {
+				switch p := part.(type) {
+				case cif.CIFTextPart:
+					parts = append(parts, map[string]interface{}{"text": p.Text})
+				case cif.CIFToolResultPart:
+					toolName := p.ToolName
+					if toolName == "" {
+						toolName = toolCallNamesByID[p.ToolCallID]
+					}
+					parts = append(parts, map[string]interface{}{
+						"functionResponse": map[string]interface{}{
+							"name":     toolName,
+							"response": map[string]interface{}{"output": p.Content},
+						},
+					})
+				case cif.CIFImagePart:
+					if p.Data != nil {
+						parts = append(parts, map[string]interface{}{
+							"inlineData": map[string]interface{}{
+								"mimeType": p.MediaType,
+								"data":     *p.Data,
+							},
+						})
+					}
+				}
+			}
+			if len(parts) > 0 {
+				contents = append(contents, map[string]interface{}{"role": "user", "parts": parts})
+			}
+		case cif.CIFAssistantMessage:
+			var parts []map[string]interface{}
+			for _, part := range m.Content {
+				switch p := part.(type) {
+				case cif.CIFTextPart:
+					parts = append(parts, map[string]interface{}{"text": p.Text})
+				case cif.CIFToolCallPart:
+					functionCall := map[string]interface{}{
+						"name": p.ToolName,
+						"args": p.ToolArguments,
+					}
+					if p.ToolCallID != "" {
+						functionCall["id"] = p.ToolCallID
+						toolCallNamesByID[p.ToolCallID] = p.ToolName
+					}
+					part := map[string]interface{}{
+						"functionCall":     functionCall,
+						"thoughtSignature": skipThoughtSignatureValidator,
+					}
+					parts = append(parts, part)
+				case cif.CIFThinkingPart:
+					parts = append(parts, map[string]interface{}{"text": p.Thinking})
+				}
+			}
+			if len(parts) > 0 {
+				contents = append(contents, map[string]interface{}{"role": "model", "parts": parts})
+			}
+		}
+	}
+	return contents
+}
+
+// SanitizeGeminiSchema removes fields that Gemini rejects from JSON Schema objects.
+func SanitizeGeminiSchema(schema map[string]interface{}) map[string]interface{} {
+	if schema == nil {
+		return nil
+	}
+	blocked := map[string]bool{
+		"$schema": true, "$id": true, "patternProperties": true, "prefill": true,
+		"enumTitles": true, "deprecated": true, "propertyNames": true,
+		"exclusiveMinimum": true, "exclusiveMaximum": true, "const": true,
+		"additionalProperties": true,
+	}
+	clean := make(map[string]interface{}, len(schema))
+	for k, v := range schema {
+		if blocked[k] {
+			continue
+		}
+		switch nested := v.(type) {
+		case map[string]interface{}:
+			clean[k] = SanitizeGeminiSchema(nested)
+		case []interface{}:
+			cleaned := make([]interface{}, 0, len(nested))
+			for _, item := range nested {
+				if m, ok := item.(map[string]interface{}); ok {
+					cleaned = append(cleaned, SanitizeGeminiSchema(m))
+				} else {
+					cleaned = append(cleaned, item)
+				}
+			}
+			clean[k] = cleaned
+		default:
+			clean[k] = v
+		}
+	}
+	return clean
+}


### PR DESCRIPTION
## Summary
- route Gemini payload building through a shared helper package
- preserve prior Gemini tool call names when serializing tool results
- attach the skip thought signature sentinel for historical Gemini tool calls and cover both cases with tests

## Test Plan
- [x] go test ./...