### PR TITLE
Fix Anthropic system messages in parser

### DIFF
--- a/internal/ingestion/from_anthropic.go
+++ b/internal/ingestion/from_anthropic.go
@@ -73,19 +73,38 @@ func ParseAnthropicMessages(raw json.RawMessage) (*cif.CanonicalRequest, error) 
 		Stream:      req.Stream != nil && *req.Stream,
 	}
 
+	systemParts := make([]string, 0, 2)
 	if systemPrompt := normalizeAnthropicSystem(req.System); systemPrompt != nil {
-		canonical.SystemPrompt = systemPrompt
+		systemParts = append(systemParts, *systemPrompt)
 	}
 	if req.Metadata != nil && req.Metadata.UserID != "" {
 		canonical.UserID = &req.Metadata.UserID
 	}
 
 	for _, msg := range req.Messages {
+		// Workaround for Claude Code v2.1.154+ ("Lean System Prompt") regression:
+		// it emits role:"system" entries inside the messages[] array, which the
+		// Anthropic Messages spec disallows (messages may only be user/assistant;
+		// system must be a top-level field). Hoist any such entries into the
+		// top-level system prompt instead of failing the request.
+		// See https://github.com/anthropics/claude-code/issues/63457
+		if msg.Role == "system" {
+			if text := extractAnthropicSystemText(msg.Content); text != "" {
+				systemParts = append(systemParts, text)
+			}
+			continue
+		}
+
 		cifMsg, err := convertAnthropicMessage(msg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert message: %w", err)
 		}
 		canonical.Messages = append(canonical.Messages, cifMsg)
+	}
+
+	if len(systemParts) > 0 {
+		merged := strings.Join(systemParts, "\n\n")
+		canonical.SystemPrompt = &merged
 	}
 
 	for _, tool := range req.Tools {
@@ -291,6 +310,33 @@ func normalizeAnthropicSystem(system interface{}) *string {
 		return &result
 	default:
 		return nil
+	}
+}
+
+// extractAnthropicSystemText pulls the text out of a message whose role is
+// "system". The content may be a plain string or an array of content blocks
+// (Claude Code emits text blocks). Non-text blocks are ignored.
+func extractAnthropicSystemText(content interface{}) string {
+	switch value := content.(type) {
+	case string:
+		return value
+	case []interface{}:
+		parts := make([]string, 0, len(value))
+		for _, rawPart := range value {
+			partMap, ok := rawPart.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if partType, _ := partMap["type"].(string); partType != "text" {
+				continue
+			}
+			if text, ok := partMap["text"].(string); ok && text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, "\n\n")
+	default:
+		return ""
 	}
 }
 

--- a/internal/ingestion/ingestion_test.go
+++ b/internal/ingestion/ingestion_test.go
@@ -427,6 +427,44 @@ func TestParseAnthropic_SystemPrompt(t *testing.T) {
 	}
 }
 
+// TestParseAnthropic_HoistsSystemRoleMessage covers the Claude Code v2.1.154+
+// regression where a role:"system" entry is emitted inside messages[] instead
+// of the top-level system field. We hoist it into the system prompt rather than
+// failing. See https://github.com/anthropics/claude-code/issues/63457
+func TestParseAnthropic_HoistsSystemRoleMessage(t *testing.T) {
+	payload := map[string]interface{}{
+		"model":  "claude-3-5-sonnet-20241022",
+		"system": "Top-level system.",
+		"messages": []interface{}{
+			map[string]interface{}{
+				"role": "system",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "Agent instructions."},
+				},
+			},
+			map[string]interface{}{
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "Hello"},
+				},
+			},
+		},
+	}
+	req, err := ParseAnthropicMessages(mustRaw(t, payload))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.SystemPrompt == nil || *req.SystemPrompt != "Top-level system.\n\nAgent instructions." {
+		t.Errorf("unexpected system prompt: %v", req.SystemPrompt)
+	}
+	if len(req.Messages) != 1 {
+		t.Fatalf("expected system message to be hoisted out, got %d messages", len(req.Messages))
+	}
+	if _, ok := req.Messages[0].(cif.CIFUserMessage); !ok {
+		t.Errorf("expected remaining message to be a user message, got %T", req.Messages[0])
+	}
+}
+
 func TestParseAnthropic_ToolUseBlock(t *testing.T) {
 	payload := map[string]interface{}{
 		"model": "claude-3-5-sonnet-20241022",


### PR DESCRIPTION
## Summary
- hoist `messages[].role == "system"` content into the canonical system prompt
- preserve message ordering while avoiding parser failures on Claude Code emitted payloads
- add regression coverage for system-role message handling

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
