### PR TITLE
fix: avoid forcing chat completions for MAI responses-only models

### DIFF
--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -253,6 +253,12 @@ func TestProviderCmdStructure(t *testing.T) {
 	}
 }
 
+func TestProviderListCommandHasNoAliases(t *testing.T) {
+	if len(providerListCmd.Aliases) != 0 {
+		t.Fatalf("provider list should not expose command aliases, got %v", providerListCmd.Aliases)
+	}
+}
+
 func TestProviderAddFlagDefaults(t *testing.T) {
 	for _, flagName := range []string{"api-key", "token", "endpoint", "region", "plan"} {
 		found := false

--- a/internal/commands/provider.go
+++ b/internal/commands/provider.go
@@ -166,11 +166,12 @@ var providerListCmd = &cobra.Command{
 			return PrintEmpty(cmd.OutOrStdout(), "providers configured")
 		}
 
-		table := NewTable("ID", "TYPE", "NAME", "AUTH", "ACTIVE", "MODELS")
+		table := NewTable("ID", "TYPE", "NAME", "ALIAS", "AUTH", "ACTIVE", "MODELS")
 		for _, p := range providers {
 			id, _ := p["id"].(string)
 			pType, _ := p["type"].(string)
 			name, _ := p["name"].(string)
+			alias, _ := p["subtitle"].(string)
 			auth, _ := p["authStatus"].(string)
 			active := "no"
 			if v, ok := p["isActive"].(bool); ok && v {
@@ -179,7 +180,7 @@ var providerListCmd = &cobra.Command{
 			total, _ := p["totalModelCount"].(float64)
 			enabled, _ := p["enabledModelCount"].(float64)
 			models := fmt.Sprintf("%d/%d", int(enabled), int(total))
-			table.AddRow(id, pType, name, auth, active, models)
+			table.AddRow(id, pType, name, alias, auth, active, models)
 		}
 		return table.Render(cmd.OutOrStdout())
 	},

--- a/internal/providerdispatch/executor.go
+++ b/internal/providerdispatch/executor.go
@@ -155,9 +155,18 @@ func shouldForceChatCompletions(provider types.Provider, request *cif.CanonicalR
 		}
 	}
 
+	if isKnownCopilotResponsesOnlyModel(request.Model) {
+		return false
+	}
+
 	if shared.IsGPT5Family(request.Model) {
 		return false
 	}
 
 	return true
+}
+
+func isKnownCopilotResponsesOnlyModel(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	return strings.HasPrefix(model, "mai-code-1-flash")
 }

--- a/internal/providerdispatch/executor_test.go
+++ b/internal/providerdispatch/executor_test.go
@@ -126,6 +126,15 @@ func TestApplyGitHubCopilotSingleUpstreamMode_ResponsesOnlyModelNotForced(t *tes
 	}
 }
 
+func TestApplyGitHubCopilotSingleUpstreamMode_KnownMAIResponsesOnlyModelNotForcedWithoutCatalog(t *testing.T) {
+	req := &cif.CanonicalRequest{Model: "mai-code-1-flash-picker"}
+	ApplyGitHubCopilotSingleUpstreamMode(newCopilotProvider(), req)
+
+	if req.Extensions.ForceChatCompletions != nil {
+		t.Fatalf("expected ForceChatCompletions to stay unset for known MAI responses-only model without catalog metadata, got %v", *req.Extensions.ForceChatCompletions)
+	}
+}
+
 // DisableAuthRetry and DisableStreamingFallback must always be set for Copilot,
 // regardless of which shape branch we take.
 func TestApplyGitHubCopilotSingleUpstreamMode_AlwaysSetsDisableFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

- avoid forcing chat completions for MAI models that only support responses-based routing
- add an ALIAS column to the provider list output

## Testing

- go test ./internal/commands ./internal/providerdispatch