### PR TITLE
feat(cache): exact-match LLM response cache (streaming + non-streaming, shape-agnostic)

### DIFF
--- a/internal/commands/settings.go
+++ b/internal/commands/settings.go
@@ -15,11 +15,15 @@ var SettingsCmd = &cobra.Command{
 
 func init() {
 	settingsGetCmd.AddCommand(settingsGetLogLevelCmd)
+	settingsGetCmd.AddCommand(settingsGetResponseCacheCmd)
 	SettingsCmd.AddCommand(settingsGetCmd)
 
 	settingsSetCmd.AddCommand(settingsSetLogLevelCmd)
 	settingsSetLogLevelCmd.ValidArgs = []string{"fatal", "error", "warn", "info", "debug", "trace"}
+	settingsSetResponseCacheCmd.Flags().Int("ttl", -1, "TTL in seconds (omit to leave unchanged)")
+	settingsSetCmd.AddCommand(settingsSetResponseCacheCmd)
 	SettingsCmd.AddCommand(settingsSetCmd)
+	SettingsCmd.AddCommand(settingsClearResponseCacheCmd)
 }
 
 var settingsGetCmd = &cobra.Command{
@@ -80,6 +84,91 @@ var settingsSetLogLevelCmd = &cobra.Command{
 			return nil
 		}
 		SuccessMsg(cmd,"Log level set to '%s'.", args[0])
+		return nil
+	},
+}
+
+var settingsGetResponseCacheCmd = &cobra.Command{
+	Use:   "response-cache",
+	Short: "Show exact-match response cache status and stats",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Get("/api/admin/settings/response-cache")
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		var resp struct {
+			Enabled    bool `json:"enabled"`
+			TTLSeconds int  `json:"ttl_seconds"`
+			Entries    int  `json:"entries"`
+			TotalHits  int  `json:"total_hits"`
+		}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return err
+		}
+		out := cmd.OutOrStdout()
+		state := "disabled"
+		if resp.Enabled {
+			state = "enabled"
+		}
+		fmt.Fprintf(out, "Response cache: %s\n", state)
+		fmt.Fprintf(out, "TTL:            %d seconds\n", resp.TTLSeconds)
+		fmt.Fprintf(out, "Entries:        %d\n", resp.Entries)
+		fmt.Fprintf(out, "Total hits:     %d\n", resp.TotalHits)
+		return nil
+	},
+}
+
+var settingsSetResponseCacheCmd = &cobra.Command{
+	Use:   "response-cache <on|off>",
+	Short: "Enable or disable the exact-match response cache",
+	Args:  cobra.ExactArgs(1),
+	ValidArgs: []string{"on", "off"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		body := map[string]interface{}{}
+		switch strings.ToLower(args[0]) {
+		case "on", "true", "enable", "enabled":
+			body["enabled"] = true
+		case "off", "false", "disable", "disabled":
+			body["enabled"] = false
+		default:
+			return fmt.Errorf("expected 'on' or 'off', got %q", args[0])
+		}
+		if ttl, _ := cmd.Flags().GetInt("ttl"); ttl >= 0 {
+			body["ttl_seconds"] = ttl
+		}
+		data, err := c.Put("/api/admin/settings/response-cache", body)
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg(cmd, "Response cache updated (%s).", args[0])
+		return nil
+	},
+}
+
+var settingsClearResponseCacheCmd = &cobra.Command{
+	Use:   "clear-response-cache",
+	Short: "Purge all cached responses",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := NewClient(cmd)
+		data, err := c.Delete("/api/admin/settings/response-cache")
+		if err != nil {
+			return err
+		}
+		if c.IsJSON() {
+			c.PrintJSON(data)
+			return nil
+		}
+		SuccessMsg(cmd, "Response cache cleared.")
 		return nil
 	},
 }

--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -146,6 +146,17 @@ func (db *Database) createTables() error {
 			FOREIGN KEY (instance_id) REFERENCES provider_instances (instance_id) ON DELETE CASCADE
 		)`,
 
+		// Exact-match LLM response cache (deterministic, non-streaming requests only).
+		`CREATE TABLE IF NOT EXISTS response_cache (
+			cache_key     TEXT PRIMARY KEY,
+			model_id      TEXT NOT NULL,
+			response_data TEXT NOT NULL,
+			hit_count     INTEGER NOT NULL DEFAULT 0,
+			created_at    DATETIME NOT NULL DEFAULT (datetime('now')),
+			last_hit_at   DATETIME
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_response_cache_created_at ON response_cache (created_at)`,
+
 		// Chat sessions.
 		`CREATE TABLE IF NOT EXISTS chat_sessions (
 			session_id    TEXT PRIMARY KEY,
@@ -380,6 +391,16 @@ var migrations = []migration{
 	}},
 	// v14: bind provider model cache rows to provider type so reused instance IDs cannot read stale model lists.
 	{14, []string{`ALTER TABLE provider_models_cache ADD COLUMN provider_id TEXT NOT NULL DEFAULT ''`}},
+	// v15: exact-match LLM response cache (deterministic, non-streaming requests only).
+	{15, []string{`CREATE TABLE IF NOT EXISTS response_cache (
+		cache_key    TEXT PRIMARY KEY,
+		model_id     TEXT NOT NULL,
+		response_data TEXT NOT NULL,
+		hit_count    INTEGER NOT NULL DEFAULT 0,
+		created_at   DATETIME NOT NULL DEFAULT (datetime('now')),
+		last_hit_at  DATETIME
+	)`,
+		`CREATE INDEX IF NOT EXISTS idx_response_cache_created_at ON response_cache (created_at)`}},
 }
 
 // applyMigrations runs any migrations that have not yet been applied.

--- a/internal/database/store_response_cache.go
+++ b/internal/database/store_response_cache.go
@@ -1,0 +1,109 @@
+package database
+
+import (
+	"database/sql"
+	"time"
+)
+
+// ─── Exact-match response cache operations ────────────────────────────────────
+//
+// This cache stores full upstream LLM responses keyed by a hash of the
+// canonical request (model + messages + tools + sampling params). It only ever
+// stores DETERMINISTIC requests (temperature == 0) and never streaming
+// requests — both invariants are enforced by the caller, not here. The store is
+// deliberately dumb: hash in, JSON blob out.
+
+// ResponseCacheRecord is a single cached upstream response.
+type ResponseCacheRecord struct {
+	CacheKey     string
+	ModelID      string
+	ResponseData string
+	HitCount     int
+	CreatedAt    time.Time
+	LastHitAt    *time.Time
+}
+
+// ResponseCacheStore is the persistence layer for the exact-match response cache.
+type ResponseCacheStore struct {
+	db *Database
+}
+
+// NewResponseCacheStore returns a store bound to the process-global database.
+func NewResponseCacheStore() *ResponseCacheStore {
+	return &ResponseCacheStore{db: GetDatabase()}
+}
+
+// Get returns the cached response for cacheKey if it exists and is younger than
+// ttl. A hit bumps hit_count and last_hit_at. Returns (nil, nil) on miss or
+// expiry (an expired row is left in place for the sweeper to reap).
+func (s *ResponseCacheStore) Get(cacheKey string, ttl time.Duration) (*ResponseCacheRecord, error) {
+	var rec ResponseCacheRecord
+	var createdAtStr string
+	err := s.db.db.QueryRow(`
+		SELECT cache_key, model_id, response_data, hit_count, created_at
+		FROM response_cache WHERE cache_key = ?
+	`, cacheKey).Scan(&rec.CacheKey, &rec.ModelID, &rec.ResponseData, &rec.HitCount, &createdAtStr)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	rec.CreatedAt = parseTime(createdAtStr)
+	if ttl > 0 && time.Since(rec.CreatedAt) > ttl {
+		return nil, nil
+	}
+
+	// Best-effort hit accounting; a failure here must not fail the request.
+	_, _ = s.db.db.Exec(
+		`UPDATE response_cache SET hit_count = hit_count + 1, last_hit_at = datetime('now') WHERE cache_key = ?`,
+		cacheKey,
+	)
+	rec.HitCount++
+	return &rec, nil
+}
+
+// Save upserts a cached response. Overwriting an existing key resets its age and
+// hit accounting, which is correct: a fresh upstream call supersedes the old one.
+func (s *ResponseCacheStore) Save(cacheKey, modelID, responseData string) error {
+	_, err := s.db.db.Exec(`
+		INSERT INTO response_cache (cache_key, model_id, response_data, hit_count, created_at)
+		VALUES (?, ?, ?, 0, datetime('now'))
+		ON CONFLICT(cache_key) DO UPDATE SET
+			model_id      = excluded.model_id,
+			response_data = excluded.response_data,
+			hit_count     = 0,
+			created_at    = datetime('now'),
+			last_hit_at   = NULL
+	`, cacheKey, modelID, responseData)
+	return err
+}
+
+// PurgeExpired deletes rows older than ttl and returns the number removed.
+func (s *ResponseCacheStore) PurgeExpired(ttl time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-ttl).UTC().Format("2006-01-02 15:04:05")
+	res, err := s.db.db.Exec(`DELETE FROM response_cache WHERE created_at < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// Clear removes every cached response and returns the number removed.
+func (s *ResponseCacheStore) Clear() (int64, error) {
+	res, err := s.db.db.Exec(`DELETE FROM response_cache`)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// Stats returns the current entry count and total accumulated hits.
+func (s *ResponseCacheStore) Stats() (entries int, totalHits int, err error) {
+	err = s.db.db.QueryRow(
+		`SELECT COUNT(*), COALESCE(SUM(hit_count), 0) FROM response_cache`,
+	).Scan(&entries, &totalHits)
+	return entries, totalHits, err
+}

--- a/internal/database/store_response_cache_test.go
+++ b/internal/database/store_response_cache_test.go
@@ -1,0 +1,98 @@
+package database
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResponseCacheStore_SaveGet(t *testing.T) {
+	s := NewResponseCacheStore()
+	key := "test-key-savedget"
+	if _, err := s.Clear(); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+
+	// Miss on empty.
+	if rec, err := s.Get(key, time.Hour); err != nil || rec != nil {
+		t.Fatalf("expected miss, got rec=%v err=%v", rec, err)
+	}
+
+	// Save then hit.
+	if err := s.Save(key, "gpt-x", `{"id":"r1"}`); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	rec, err := s.Get(key, time.Hour)
+	if err != nil || rec == nil {
+		t.Fatalf("expected hit, got rec=%v err=%v", rec, err)
+	}
+	if rec.ResponseData != `{"id":"r1"}` || rec.ModelID != "gpt-x" {
+		t.Fatalf("unexpected record: %+v", rec)
+	}
+	if rec.HitCount != 1 {
+		t.Fatalf("expected hit_count 1 after first Get, got %d", rec.HitCount)
+	}
+
+	// Second hit increments.
+	rec2, _ := s.Get(key, time.Hour)
+	if rec2.HitCount != 2 {
+		t.Fatalf("expected hit_count 2, got %d", rec2.HitCount)
+	}
+}
+
+func TestResponseCacheStore_TTLExpiry(t *testing.T) {
+	s := NewResponseCacheStore()
+	key := "test-key-ttl"
+	_, _ = s.Clear()
+	if err := s.Save(key, "gpt-x", `{"id":"r"}`); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// A zero/near-zero TTL treats everything as expired.
+	if rec, err := s.Get(key, time.Nanosecond); err != nil {
+		t.Fatalf("get: %v", err)
+	} else if rec != nil {
+		t.Fatalf("expected expiry miss, got %+v", rec)
+	}
+	// ttl<=0 means no expiry check → hit.
+	if rec, _ := s.Get(key, 0); rec == nil {
+		t.Fatal("ttl=0 should disable expiry and return the row")
+	}
+}
+
+func TestResponseCacheStore_Overwrite(t *testing.T) {
+	s := NewResponseCacheStore()
+	key := "test-key-overwrite"
+	_, _ = s.Clear()
+	_ = s.Save(key, "gpt-x", `{"v":1}`)
+	_, _ = s.Get(key, time.Hour) // bump hit_count
+	_ = s.Save(key, "gpt-x", `{"v":2}`)
+	rec, _ := s.Get(key, time.Hour)
+	if rec.ResponseData != `{"v":2}` {
+		t.Fatalf("expected overwrite to newest value, got %s", rec.ResponseData)
+	}
+	// Overwrite resets hit_count to 0, then the Get above made it 1.
+	if rec.HitCount != 1 {
+		t.Fatalf("expected hit_count reset then 1, got %d", rec.HitCount)
+	}
+}
+
+func TestResponseCacheStore_PurgeAndStats(t *testing.T) {
+	s := NewResponseCacheStore()
+	_, _ = s.Clear()
+	_ = s.Save("k1", "m", `{}`)
+	_ = s.Save("k2", "m", `{}`)
+	entries, _, err := s.Stats()
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if entries != 2 {
+		t.Fatalf("expected 2 entries, got %d", entries)
+	}
+	// PurgeExpired with a huge TTL removes nothing.
+	if n, _ := s.PurgeExpired(24 * time.Hour); n != 0 {
+		t.Fatalf("expected 0 purged, got %d", n)
+	}
+	// Negative TTL pushes the cutoff into the future → removes all.
+	if n, _ := s.PurgeExpired(-time.Hour); n != 2 {
+		t.Fatalf("expected 2 purged, got %d", n)
+	}
+}

--- a/internal/lib/responsecache/responsecache.go
+++ b/internal/lib/responsecache/responsecache.go
@@ -1,0 +1,277 @@
+// Package responsecache implements an exact-match cache for deterministic,
+// non-streaming LLM responses at the CIF (Canonical Intermediate Format) layer.
+//
+// Design rationale:
+//
+//   - Caching at the CIF layer (CanonicalResponse) rather than at a wire shape
+//     makes the cache shape-agnostic: a response produced for an OpenAI-shape
+//     client can be re-serialized to satisfy an Anthropic-shape client and vice
+//     versa, because every route serializes from the same CanonicalResponse.
+//
+//   - Only DETERMINISTIC requests are cacheable. temperature == 0 (or unset,
+//     which most providers treat as greedy/near-greedy — we require an explicit
+//     0 to be safe) and top_p unset/>=1. Any tool call, any temperature > 0, any
+//     streaming request is a hard skip: returning a stale answer there is a
+//     correctness bug, not an optimization.
+//
+//   - The cache key is a SHA-256 over the salient, order-preserving parts of the
+//     canonical request. Two requests collide iff they would deterministically
+//     produce the same generation.
+package responsecache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"omnillm/internal/cif"
+	"omnillm/internal/database"
+)
+
+// Config controls cache behaviour. Values are read from the process config store
+// on each request (cheap SQLite point-read) so the cache can be toggled live
+// without a restart.
+type Config struct {
+	Enabled bool
+	TTL     time.Duration
+}
+
+const (
+	cfgKeyEnabled = "response_cache.enabled"
+	cfgKeyTTLSecs = "response_cache.ttl_seconds"
+
+	// DefaultTTL applies when the operator enabled the cache but set no TTL.
+	DefaultTTL = 1 * time.Hour
+
+	// BypassHeader lets a client force a cache miss+refresh for one request.
+	// Value "bypass" skips the read (still writes); "off" skips read and write.
+	BypassHeader = "X-OmniLLM-Cache"
+)
+
+// LoadConfig reads the live cache configuration from the config store.
+// Absent/blank keys mean disabled — the cache is strictly opt-in.
+func LoadConfig() Config {
+	store := database.NewConfigStore()
+	enabled := false
+	if v, err := store.Get(cfgKeyEnabled); err == nil {
+		enabled = v == "true" || v == "1"
+	}
+	ttl := DefaultTTL
+	if v, err := store.Get(cfgKeyTTLSecs); err == nil && v != "" {
+		if secs, perr := parsePositiveInt(v); perr == nil && secs > 0 {
+			ttl = time.Duration(secs) * time.Second
+		}
+	}
+	return Config{Enabled: enabled, TTL: ttl}
+}
+
+// Cacheable reports whether a canonical request is eligible for exact-match
+// caching. It is intentionally conservative: any doubt means "not cacheable".
+func Cacheable(req *cif.CanonicalRequest) bool {
+	if req == nil || req.Stream {
+		return false
+	}
+	// Require an explicit temperature of exactly 0 — greedy decoding.
+	if req.Temperature == nil || *req.Temperature != 0 {
+		return false
+	}
+	// If top_p is pinned below 1 alongside temp 0 it's still deterministic, but
+	// an explicit top_p > 0 && < 1 with sampling elsewhere is a smell; only allow
+	// unset or >= 1 (no-op) top_p.
+	if req.TopP != nil && *req.TopP < 1 {
+		return false
+	}
+	return true
+}
+
+// Key derives the stable cache key for a canonical request. Only fields that
+// affect a deterministic generation are hashed; transport/metadata (headers,
+// user id, stream flag) are excluded so semantically identical requests collide.
+func Key(req *cif.CanonicalRequest) string {
+	// A struct with a fixed field order gives a stable JSON encoding.
+	keyed := struct {
+		Model          string                 `json:"model"`
+		System         *string                `json:"system,omitempty"`
+		Messages       []cif.CIFMessage        `json:"messages"`
+		Tools          []cif.CIFTool           `json:"tools,omitempty"`
+		ToolChoice     cif.CIFToolChoice       `json:"toolChoice,omitempty"`
+		Temperature    *float64               `json:"temperature,omitempty"`
+		TopP           *float64               `json:"topP,omitempty"`
+		MaxTokens      *int                   `json:"maxTokens,omitempty"`
+		Stop           []string               `json:"stop,omitempty"`
+		ResponseFormat map[string]interface{} `json:"responseFormat,omitempty"`
+	}{
+		Model:          req.Model,
+		System:         req.SystemPrompt,
+		Messages:       req.Messages,
+		Tools:          req.Tools,
+		ToolChoice:     req.ToolChoice,
+		Temperature:    req.Temperature,
+		TopP:           req.TopP,
+		MaxTokens:      req.MaxTokens,
+		Stop:           req.Stop,
+		ResponseFormat: req.ResponseFormat,
+	}
+	raw, err := json.Marshal(keyed)
+	if err != nil {
+		// Marshal failure ⇒ un-cacheable key; a random-ish sum avoids collisions.
+		raw = []byte(req.Model + "|marshal-error")
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// Get returns a cached CanonicalResponse for req, or nil on miss/disabled/expired.
+func Get(cfg Config, req *cif.CanonicalRequest, key string) *cif.CanonicalResponse {
+	if !cfg.Enabled {
+		return nil
+	}
+	rec, err := database.NewResponseCacheStore().Get(key, cfg.TTL)
+	if err != nil || rec == nil {
+		return nil
+	}
+	resp, err := decodeResponse(rec.ResponseData)
+	if err != nil {
+		return nil
+	}
+	return resp
+}
+
+// Put stores a CanonicalResponse. Errors are swallowed: caching is best-effort
+// and must never fail a request that already succeeded upstream.
+func Put(cfg Config, req *cif.CanonicalRequest, key string, resp *cif.CanonicalResponse) {
+	if !cfg.Enabled || resp == nil {
+		return
+	}
+	// Never cache an error/empty generation.
+	if resp.StopReason == cif.StopReasonError || len(resp.Content) == 0 {
+		return
+	}
+	data, err := encodeResponse(resp)
+	if err != nil {
+		return
+	}
+	_ = database.NewResponseCacheStore().Save(key, req.Model, data)
+}
+
+// cachedResponse is a JSON-round-trippable projection of cif.CanonicalResponse.
+// The CIF response's Content is []CIFContentPart (an interface slice) which the
+// stdlib json decoder cannot reconstruct, so we tag each part with its concrete
+// type on the way in and rebuild the interface values on the way out. Response
+// content only ever contains text, thinking, or tool_call parts.
+type cachedResponse struct {
+	ID           string            `json:"id"`
+	Model        string            `json:"model"`
+	StopReason   cif.CIFStopReason `json:"stopReason"`
+	StopSequence *string           `json:"stopSequence,omitempty"`
+	Usage        *cif.CIFUsage     `json:"usage,omitempty"`
+	Content      []cachedPart      `json:"content"`
+}
+
+type cachedPart struct {
+	Type          string                 `json:"type"`
+	Text          string                 `json:"text,omitempty"`
+	Thinking      string                 `json:"thinking,omitempty"`
+	Signature     *string                `json:"signature,omitempty"`
+	ToolCallID    string                 `json:"toolCallId,omitempty"`
+	ToolName      string                 `json:"toolName,omitempty"`
+	ToolArguments map[string]interface{} `json:"toolArguments,omitempty"`
+}
+
+func encodeResponse(resp *cif.CanonicalResponse) (string, error) {
+	cr := cachedResponse{
+		ID:           resp.ID,
+		Model:        resp.Model,
+		StopReason:   resp.StopReason,
+		StopSequence: resp.StopSequence,
+		Usage:        resp.Usage,
+	}
+	for _, part := range resp.Content {
+		switch p := part.(type) {
+		case cif.CIFTextPart:
+			cr.Content = append(cr.Content, cachedPart{Type: "text", Text: p.Text})
+		case cif.CIFThinkingPart:
+			cr.Content = append(cr.Content, cachedPart{Type: "thinking", Thinking: p.Thinking, Signature: p.Signature})
+		case cif.CIFToolCallPart:
+			cr.Content = append(cr.Content, cachedPart{
+				Type:          "tool_call",
+				ToolCallID:    p.ToolCallID,
+				ToolName:      p.ToolName,
+				ToolArguments: p.ToolArguments,
+			})
+		default:
+			// Unknown part type ⇒ un-cacheable (image/tool_result should not
+			// appear in a response, but bail safely rather than lose data).
+			return "", errUncacheablePart
+		}
+	}
+	raw, err := json.Marshal(cr)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func decodeResponse(data string) (*cif.CanonicalResponse, error) {
+	var cr cachedResponse
+	if err := json.Unmarshal([]byte(data), &cr); err != nil {
+		return nil, err
+	}
+	resp := &cif.CanonicalResponse{
+		ID:           cr.ID,
+		Model:        cr.Model,
+		StopReason:   cr.StopReason,
+		StopSequence: cr.StopSequence,
+		Usage:        cr.Usage,
+	}
+	for _, p := range cr.Content {
+		switch p.Type {
+		case "text":
+			resp.Content = append(resp.Content, cif.CIFTextPart{Type: "text", Text: p.Text})
+		case "thinking":
+			resp.Content = append(resp.Content, cif.CIFThinkingPart{Type: "thinking", Thinking: p.Thinking, Signature: p.Signature})
+		case "tool_call":
+			resp.Content = append(resp.Content, cif.CIFToolCallPart{
+				Type:          "tool_call",
+				ToolCallID:    p.ToolCallID,
+				ToolName:      p.ToolName,
+				ToolArguments: p.ToolArguments,
+			})
+		default:
+			return nil, errUncacheablePart
+		}
+	}
+	return resp, nil
+}
+
+var errUncacheablePart = errors.New("responsecache: unsupported content part type")
+
+// BypassMode interprets the per-request bypass header.
+type BypassMode int
+
+const (
+	BypassNone BypassMode = iota // normal read+write
+	BypassRead                   // skip read, still write (force refresh)
+	BypassAll                    // skip read and write
+)
+
+// ParseBypass maps a header value to a BypassMode.
+func ParseBypass(headerValue string) BypassMode {
+	switch strings.ToLower(strings.TrimSpace(headerValue)) {
+	case "bypass", "refresh", "no-cache":
+		return BypassRead
+	case "off", "disable":
+		return BypassAll
+	default:
+		return BypassNone
+	}
+}
+
+func parsePositiveInt(s string) (int, error) {
+	var n int
+	err := json.Unmarshal([]byte(s), &n)
+	return n, err
+}

--- a/internal/lib/responsecache/responsecache.go
+++ b/internal/lib/responsecache/responsecache.go
@@ -70,8 +70,10 @@ func LoadConfig() Config {
 
 // Cacheable reports whether a canonical request is eligible for exact-match
 // caching. It is intentionally conservative: any doubt means "not cacheable".
+// Streaming IS eligible — a streaming response is accumulated to a
+// CanonicalResponse on the way out and replayed as synthetic SSE on a hit.
 func Cacheable(req *cif.CanonicalRequest) bool {
-	if req == nil || req.Stream {
+	if req == nil {
 		return false
 	}
 	// Require an explicit temperature of exactly 0 — greedy decoding.
@@ -274,4 +276,29 @@ func parsePositiveInt(s string) (int, error) {
 	var n int
 	err := json.Unmarshal([]byte(s), &n)
 	return n, err
+}
+
+// encodeToolArgs serializes tool-call arguments to a JSON string for stream
+// replay. Returns "{}" on failure so the synthesized delta is always valid JSON.
+func encodeToolArgs(args map[string]interface{}) string {
+	if len(args) == 0 {
+		return "{}"
+	}
+	raw, err := json.Marshal(args)
+	if err != nil {
+		return "{}"
+	}
+	return string(raw)
+}
+
+// decodeToolArgs parses accumulated raw tool-argument JSON back into a map.
+func decodeToolArgs(raw string) map[string]interface{} {
+	if raw == "" {
+		return map[string]interface{}{}
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return map[string]interface{}{}
+	}
+	return m
 }

--- a/internal/lib/responsecache/responsecache_test.go
+++ b/internal/lib/responsecache/responsecache_test.go
@@ -27,7 +27,7 @@ func TestCacheable(t *testing.T) {
 		want bool
 	}{
 		{"temp0 non-stream", func(r *cif.CanonicalRequest) {}, true},
-		{"streaming", func(r *cif.CanonicalRequest) { r.Stream = true }, false},
+		{"streaming now cacheable", func(r *cif.CanonicalRequest) { r.Stream = true }, true},
 		{"temp nil", func(r *cif.CanonicalRequest) { r.Temperature = nil }, false},
 		{"temp > 0", func(r *cif.CanonicalRequest) { r.Temperature = f64(0.7) }, false},
 		{"top_p < 1", func(r *cif.CanonicalRequest) { r.TopP = f64(0.5) }, false},

--- a/internal/lib/responsecache/responsecache_test.go
+++ b/internal/lib/responsecache/responsecache_test.go
@@ -1,0 +1,163 @@
+package responsecache
+
+import (
+	"testing"
+
+	"omnillm/internal/cif"
+)
+
+func f64(v float64) *float64 { return &v }
+
+func baseReq() *cif.CanonicalRequest {
+	sys := "you are helpful"
+	return &cif.CanonicalRequest{
+		Model:       "gpt-x",
+		SystemPrompt: &sys,
+		Messages: []cif.CIFMessage{
+			cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "hi"}}},
+		},
+		Temperature: f64(0),
+	}
+}
+
+func TestCacheable(t *testing.T) {
+	tests := []struct {
+		name string
+		mut  func(*cif.CanonicalRequest)
+		want bool
+	}{
+		{"temp0 non-stream", func(r *cif.CanonicalRequest) {}, true},
+		{"streaming", func(r *cif.CanonicalRequest) { r.Stream = true }, false},
+		{"temp nil", func(r *cif.CanonicalRequest) { r.Temperature = nil }, false},
+		{"temp > 0", func(r *cif.CanonicalRequest) { r.Temperature = f64(0.7) }, false},
+		{"top_p < 1", func(r *cif.CanonicalRequest) { r.TopP = f64(0.5) }, false},
+		{"top_p == 1", func(r *cif.CanonicalRequest) { r.TopP = f64(1) }, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := baseReq()
+			tt.mut(r)
+			if got := Cacheable(r); got != tt.want {
+				t.Errorf("Cacheable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+	if Cacheable(nil) {
+		t.Error("Cacheable(nil) should be false")
+	}
+}
+
+func TestKeyStability(t *testing.T) {
+	a := Key(baseReq())
+	b := Key(baseReq())
+	if a != b {
+		t.Errorf("identical requests produced different keys: %s vs %s", a, b)
+	}
+	if len(a) != 64 {
+		t.Errorf("expected 64-char sha256 hex, got %d", len(a))
+	}
+}
+
+func TestKeySensitivity(t *testing.T) {
+	base := Key(baseReq())
+
+	// Different user message ⇒ different key.
+	r := baseReq()
+	r.Messages = []cif.CIFMessage{
+		cif.CIFUserMessage{Role: "user", Content: []cif.CIFContentPart{cif.CIFTextPart{Type: "text", Text: "bye"}}},
+	}
+	if Key(r) == base {
+		t.Error("different message content should change the key")
+	}
+
+	// Different model ⇒ different key.
+	r = baseReq()
+	r.Model = "gpt-y"
+	if Key(r) == base {
+		t.Error("different model should change the key")
+	}
+
+	// Different max_tokens ⇒ different key.
+	r = baseReq()
+	mt := 100
+	r.MaxTokens = &mt
+	if Key(r) == base {
+		t.Error("different max_tokens should change the key")
+	}
+}
+
+func TestKeyIgnoresTransport(t *testing.T) {
+	base := Key(baseReq())
+
+	// Headers and UserID must not affect the key.
+	r := baseReq()
+	uid := "user-123"
+	r.UserID = &uid
+	r.IncomingHeaders = map[string]string{"x-request-id": "abc"}
+	if Key(r) != base {
+		t.Error("transport metadata (userId/headers) must not affect the cache key")
+	}
+}
+
+func TestParseBypass(t *testing.T) {
+	cases := map[string]BypassMode{
+		"":        BypassNone,
+		"bypass":  BypassRead,
+		"REFRESH": BypassRead,
+		"no-cache": BypassRead,
+		"off":     BypassAll,
+		"disable": BypassAll,
+		"garbage": BypassNone,
+	}
+	for in, want := range cases {
+		if got := ParseBypass(in); got != want {
+			t.Errorf("ParseBypass(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	sig := "sig-abc"
+	in := 12
+	out := 34
+	resp := &cif.CanonicalResponse{
+		ID:         "resp-1",
+		Model:      "gpt-x",
+		StopReason: cif.StopReasonToolUse,
+		Usage:      &cif.CIFUsage{InputTokens: in, OutputTokens: out},
+		Content: []cif.CIFContentPart{
+			cif.CIFTextPart{Type: "text", Text: "hello world"},
+			cif.CIFThinkingPart{Type: "thinking", Thinking: "hmm", Signature: &sig},
+			cif.CIFToolCallPart{Type: "tool_call", ToolCallID: "tc1", ToolName: "search", ToolArguments: map[string]interface{}{"q": "go"}},
+		},
+	}
+	encoded, err := encodeResponse(resp)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := decodeResponse(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.ID != resp.ID || decoded.Model != resp.Model || decoded.StopReason != resp.StopReason {
+		t.Fatalf("scalar mismatch: %+v", decoded)
+	}
+	if decoded.Usage == nil || decoded.Usage.InputTokens != in || decoded.Usage.OutputTokens != out {
+		t.Fatalf("usage mismatch: %+v", decoded.Usage)
+	}
+	if len(decoded.Content) != 3 {
+		t.Fatalf("expected 3 parts, got %d", len(decoded.Content))
+	}
+	txt, ok := decoded.Content[0].(cif.CIFTextPart)
+	if !ok || txt.Text != "hello world" {
+		t.Fatalf("text part not reconstructed: %#v", decoded.Content[0])
+	}
+	think, ok := decoded.Content[1].(cif.CIFThinkingPart)
+	if !ok || think.Thinking != "hmm" || think.Signature == nil || *think.Signature != sig {
+		t.Fatalf("thinking part not reconstructed: %#v", decoded.Content[1])
+	}
+	tc, ok := decoded.Content[2].(cif.CIFToolCallPart)
+	if !ok || tc.ToolName != "search" || tc.ToolArguments["q"] != "go" {
+		t.Fatalf("tool_call part not reconstructed: %#v", decoded.Content[2])
+	}
+}

--- a/internal/lib/responsecache/stream.go
+++ b/internal/lib/responsecache/stream.go
@@ -1,0 +1,224 @@
+package responsecache
+
+import (
+	"omnillm/internal/cif"
+)
+
+// StreamAccumulator rebuilds a CanonicalResponse from a stream of CIF events so
+// a streaming response can be stored in the same shape as a non-streaming one.
+// This makes the cache both wire-shape-agnostic AND stream-agnostic: an entry
+// populated from a streaming call can serve a non-streaming request and vice
+// versa, because everything collapses to a CanonicalResponse.
+//
+// Usage: feed every event through Observe; after the stream ends cleanly, call
+// Response() to get the assembled CanonicalResponse (nil if the stream errored
+// or produced nothing cacheable).
+type StreamAccumulator struct {
+	id         string
+	model      string
+	stopReason cif.CIFStopReason
+	stopSeq    *string
+	usage      *cif.CIFUsage
+	errored    bool
+	ended      bool
+
+	// Per content-block accumulation, keyed by block index.
+	textByBlock     map[int]*string
+	thinkingByBlock map[int]*string
+	sigByBlock      map[int]*string
+	toolByBlock     map[int]*toolAccum
+	order           []int // block indices in first-seen order
+}
+
+type toolAccum struct {
+	id     string
+	name   string
+	rawArgs string
+	args   map[string]interface{}
+}
+
+// NewStreamAccumulator returns a ready accumulator.
+func NewStreamAccumulator() *StreamAccumulator {
+	return &StreamAccumulator{
+		textByBlock:     map[int]*string{},
+		thinkingByBlock: map[int]*string{},
+		sigByBlock:      map[int]*string{},
+		toolByBlock:     map[int]*toolAccum{},
+	}
+}
+
+func (a *StreamAccumulator) seen(idx int) {
+	if _, ok := a.textByBlock[idx]; ok {
+		return
+	}
+	if _, ok := a.thinkingByBlock[idx]; ok {
+		return
+	}
+	if _, ok := a.toolByBlock[idx]; ok {
+		return
+	}
+	a.order = append(a.order, idx)
+}
+
+// Observe consumes one CIF stream event.
+func (a *StreamAccumulator) Observe(event cif.CIFStreamEvent) {
+	switch e := event.(type) {
+	case cif.CIFStreamStart:
+		a.id = e.ID
+		a.model = e.Model
+
+	case cif.CIFStreamError:
+		a.errored = true
+
+	case cif.CIFContentDelta:
+		a.observeDelta(e)
+
+	case cif.CIFStreamEnd:
+		a.ended = true
+		a.stopReason = e.StopReason
+		a.stopSeq = e.StopSequence
+		a.usage = e.Usage
+	}
+}
+
+func (a *StreamAccumulator) observeDelta(e cif.CIFContentDelta) {
+	idx := e.Index
+	// A new block announces its concrete type via ContentBlock. NOTE: some
+	// upstreams (e.g. Copilot) attach the ContentBlock on EVERY delta, not just
+	// the first, so we must only initialize a block the first time we see its
+	// index — never re-seed, or we'd wipe already-accumulated text.
+	if e.ContentBlock != nil {
+		switch cb := e.ContentBlock.(type) {
+		case cif.CIFToolCallPart:
+			if _, exists := a.toolByBlock[idx]; !exists {
+				a.seen(idx)
+				a.toolByBlock[idx] = &toolAccum{id: cb.ToolCallID, name: cb.ToolName, args: cb.ToolArguments}
+			}
+		case cif.CIFTextPart:
+			if _, exists := a.textByBlock[idx]; !exists {
+				a.seen(idx)
+				s := cb.Text
+				a.textByBlock[idx] = &s
+			}
+		case cif.CIFThinkingPart:
+			if _, exists := a.thinkingByBlock[idx]; !exists {
+				a.seen(idx)
+				s := cb.Thinking
+				a.thinkingByBlock[idx] = &s
+				if cb.Signature != nil {
+					a.sigByBlock[idx] = cb.Signature
+				}
+			}
+		}
+	}
+
+	switch d := e.Delta.(type) {
+	case cif.TextDelta:
+		if a.textByBlock[idx] == nil {
+			a.seen(idx)
+			s := ""
+			a.textByBlock[idx] = &s
+		}
+		*a.textByBlock[idx] += d.Text
+	case cif.ThinkingDelta:
+		if a.thinkingByBlock[idx] == nil {
+			a.seen(idx)
+			s := ""
+			a.thinkingByBlock[idx] = &s
+		}
+		*a.thinkingByBlock[idx] += d.Thinking
+	case cif.ToolArgumentsDelta:
+		if a.toolByBlock[idx] == nil {
+			a.seen(idx)
+			a.toolByBlock[idx] = &toolAccum{}
+		}
+		a.toolByBlock[idx].rawArgs += d.PartialJSON
+	}
+}
+
+// Response assembles the accumulated CanonicalResponse, or nil if the stream
+// errored, never ended, or produced no content.
+func (a *StreamAccumulator) Response() *cif.CanonicalResponse {
+	if a.errored || !a.ended {
+		return nil
+	}
+	resp := &cif.CanonicalResponse{
+		ID:           a.id,
+		Model:        a.model,
+		StopReason:   a.stopReason,
+		StopSequence: a.stopSeq,
+		Usage:        a.usage,
+	}
+	for _, idx := range a.order {
+		switch {
+		case a.textByBlock[idx] != nil:
+			resp.Content = append(resp.Content, cif.CIFTextPart{Type: "text", Text: *a.textByBlock[idx]})
+		case a.thinkingByBlock[idx] != nil:
+			resp.Content = append(resp.Content, cif.CIFThinkingPart{
+				Type: "thinking", Thinking: *a.thinkingByBlock[idx], Signature: a.sigByBlock[idx],
+			})
+		case a.toolByBlock[idx] != nil:
+			ta := a.toolByBlock[idx]
+			args := ta.args
+			if args == nil {
+				args = decodeToolArgs(ta.rawArgs)
+			}
+			resp.Content = append(resp.Content, cif.CIFToolCallPart{
+				Type: "tool_call", ToolCallID: ta.id, ToolName: ta.name, ToolArguments: args,
+			})
+		}
+	}
+	if len(resp.Content) == 0 {
+		return nil
+	}
+	return resp
+}
+
+// SynthesizeStream turns a stored CanonicalResponse back into an ordered slice
+// of CIF stream events, ready to be fed through the existing
+// ConvertCIFEventToOpenAISSE / ConvertCIFEventToAnthropicSSE serializers. This
+// lets a cache hit replay as a normal SSE stream with zero shape-specific code
+// in the cache layer.
+func SynthesizeStream(resp *cif.CanonicalResponse) []cif.CIFStreamEvent {
+	events := []cif.CIFStreamEvent{
+		cif.CIFStreamStart{Type: "stream_start", ID: resp.ID, Model: resp.Model},
+	}
+	for i, part := range resp.Content {
+		switch p := part.(type) {
+		case cif.CIFTextPart:
+			events = append(events,
+				cif.CIFContentDelta{
+					Type: "content_delta", Index: i,
+					ContentBlock: cif.CIFTextPart{Type: "text"},
+					Delta:        cif.TextDelta{Type: "text_delta", Text: p.Text},
+				},
+				cif.CIFContentBlockStop{Type: "content_block_stop", Index: i},
+			)
+		case cif.CIFThinkingPart:
+			events = append(events,
+				cif.CIFContentDelta{
+					Type: "content_delta", Index: i,
+					ContentBlock: cif.CIFThinkingPart{Type: "thinking", Signature: p.Signature},
+					Delta:        cif.ThinkingDelta{Type: "thinking_delta", Thinking: p.Thinking},
+				},
+				cif.CIFContentBlockStop{Type: "content_block_stop", Index: i},
+			)
+		case cif.CIFToolCallPart:
+			events = append(events,
+				cif.CIFContentDelta{
+					Type: "content_delta", Index: i,
+					ContentBlock: cif.CIFToolCallPart{Type: "tool_call", ToolCallID: p.ToolCallID, ToolName: p.ToolName},
+					Delta:        cif.ToolArgumentsDelta{Type: "tool_arguments_delta", PartialJSON: encodeToolArgs(p.ToolArguments)},
+				},
+				cif.CIFContentBlockStop{Type: "content_block_stop", Index: i},
+			)
+		}
+	}
+	events = append(events, cif.CIFStreamEnd{
+		Type:         "stream_end",
+		StopReason:   resp.StopReason,
+		StopSequence: resp.StopSequence,
+		Usage:        resp.Usage,
+	})
+	return events
+}

--- a/internal/lib/responsecache/stream_test.go
+++ b/internal/lib/responsecache/stream_test.go
@@ -1,0 +1,120 @@
+package responsecache
+
+import (
+	"testing"
+
+	"omnillm/internal/cif"
+)
+
+// feedStream drives an accumulator with a text+toolcall stream and returns the
+// assembled response.
+func TestStreamAccumulator_TextAndTool(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.Observe(cif.CIFStreamStart{Type: "stream_start", ID: "id-1", Model: "gpt-x"})
+	// Text block at index 0, streamed in two deltas.
+	acc.Observe(cif.CIFContentDelta{Type: "content_delta", Index: 0, ContentBlock: cif.CIFTextPart{Type: "text"}, Delta: cif.TextDelta{Type: "text_delta", Text: "Hello "}})
+	acc.Observe(cif.CIFContentDelta{Type: "content_delta", Index: 0, Delta: cif.TextDelta{Type: "text_delta", Text: "world"}})
+	acc.Observe(cif.CIFContentBlockStop{Type: "content_block_stop", Index: 0})
+	// Tool call at index 1, args streamed.
+	acc.Observe(cif.CIFContentDelta{Type: "content_delta", Index: 1, ContentBlock: cif.CIFToolCallPart{Type: "tool_call", ToolCallID: "tc1", ToolName: "search"}})
+	acc.Observe(cif.CIFContentDelta{Type: "content_delta", Index: 1, Delta: cif.ToolArgumentsDelta{Type: "tool_arguments_delta", PartialJSON: `{"q":`}})
+	acc.Observe(cif.CIFContentDelta{Type: "content_delta", Index: 1, Delta: cif.ToolArgumentsDelta{Type: "tool_arguments_delta", PartialJSON: `"go"}`}})
+	acc.Observe(cif.CIFStreamEnd{Type: "stream_end", StopReason: cif.StopReasonToolUse, Usage: &cif.CIFUsage{InputTokens: 5, OutputTokens: 9}})
+
+	resp := acc.Response()
+	if resp == nil {
+		t.Fatal("expected assembled response, got nil")
+	}
+	if resp.ID != "id-1" || resp.Model != "gpt-x" || resp.StopReason != cif.StopReasonToolUse {
+		t.Fatalf("scalar mismatch: %+v", resp)
+	}
+	if len(resp.Content) != 2 {
+		t.Fatalf("expected 2 content parts, got %d", len(resp.Content))
+	}
+	txt, ok := resp.Content[0].(cif.CIFTextPart)
+	if !ok || txt.Text != "Hello world" {
+		t.Fatalf("text accumulation wrong: %#v", resp.Content[0])
+	}
+	tc, ok := resp.Content[1].(cif.CIFToolCallPart)
+	if !ok || tc.ToolName != "search" || tc.ToolArguments["q"] != "go" {
+		t.Fatalf("tool accumulation wrong: %#v", resp.Content[1])
+	}
+}
+
+// TestStreamAccumulator_ContentBlockEveryDelta guards the Copilot-style stream
+// where the announcing ContentBlock is attached to EVERY delta, not just the
+// first. Re-initializing on each delta would wipe accumulated text (regression).
+func TestStreamAccumulator_ContentBlockEveryDelta(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.Observe(cif.CIFStreamStart{ID: "id", Model: "m"})
+	acc.Observe(cif.CIFContentDelta{Index: 0, ContentBlock: cif.CIFTextPart{Type: "text"}, Delta: cif.TextDelta{Type: "text_delta", Text: "J"}})
+	acc.Observe(cif.CIFContentDelta{Index: 0, ContentBlock: cif.CIFTextPart{Type: "text"}, Delta: cif.TextDelta{Type: "text_delta", Text: "ACKFRUIT"}})
+	acc.Observe(cif.CIFStreamEnd{StopReason: cif.StopReasonEndTurn})
+	resp := acc.Response()
+	if resp == nil || len(resp.Content) != 1 {
+		t.Fatalf("expected 1 content part, got %#v", resp)
+	}
+	txt := resp.Content[0].(cif.CIFTextPart)
+	if txt.Text != "JACKFRUIT" {
+		t.Fatalf("ContentBlock-on-every-delta wiped text: got %q, want JACKFRUIT", txt.Text)
+	}
+}
+
+func TestStreamAccumulator_ErrorAndIncomplete(t *testing.T) {
+	// Errored stream ⇒ nil.
+	acc := NewStreamAccumulator()
+	acc.Observe(cif.CIFStreamStart{ID: "x", Model: "m"})
+	acc.Observe(cif.CIFContentDelta{Index: 0, Delta: cif.TextDelta{Text: "hi"}})
+	acc.Observe(cif.CIFStreamError{Type: "stream_error"})
+	if acc.Response() != nil {
+		t.Error("errored stream must not be cacheable")
+	}
+
+	// Never-ended stream ⇒ nil.
+	acc2 := NewStreamAccumulator()
+	acc2.Observe(cif.CIFStreamStart{ID: "x", Model: "m"})
+	acc2.Observe(cif.CIFContentDelta{Index: 0, Delta: cif.TextDelta{Text: "hi"}})
+	if acc2.Response() != nil {
+		t.Error("stream without end must not be cacheable")
+	}
+}
+
+// TestStreamRoundTrip verifies accumulate → synthesize → re-accumulate is stable.
+func TestStreamRoundTrip(t *testing.T) {
+	orig := &cif.CanonicalResponse{
+		ID:         "r1",
+		Model:      "gpt-x",
+		StopReason: cif.StopReasonEndTurn,
+		Usage:      &cif.CIFUsage{InputTokens: 3, OutputTokens: 7},
+		Content: []cif.CIFContentPart{
+			cif.CIFTextPart{Type: "text", Text: "the answer is 42"},
+		},
+	}
+	events := SynthesizeStream(orig)
+
+	acc := NewStreamAccumulator()
+	for _, ev := range events {
+		acc.Observe(ev)
+	}
+	got := acc.Response()
+	if got == nil {
+		t.Fatal("round-trip produced nil")
+	}
+	if got.ID != orig.ID || got.Model != orig.Model || got.StopReason != orig.StopReason {
+		t.Fatalf("scalar mismatch after round-trip: %+v", got)
+	}
+	if len(got.Content) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(got.Content))
+	}
+	txt, ok := got.Content[0].(cif.CIFTextPart)
+	if !ok || txt.Text != "the answer is 42" {
+		t.Fatalf("text lost in round-trip: %#v", got.Content[0])
+	}
+	// Synthesized events must start with stream_start and end with stream_end.
+	if events[0].GetEventType() != "stream_start" {
+		t.Errorf("first event should be stream_start, got %s", events[0].GetEventType())
+	}
+	if events[len(events)-1].GetEventType() != "stream_end" {
+		t.Errorf("last event should be stream_end, got %s", events[len(events)-1].GetEventType())
+	}
+}

--- a/internal/routes/admin_response_cache.go
+++ b/internal/routes/admin_response_cache.go
@@ -1,0 +1,78 @@
+package routes
+
+import (
+	"net/http"
+	"strconv"
+
+	"omnillm/internal/database"
+	"omnillm/internal/lib/responsecache"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+)
+
+// handleGetResponseCache reports current response-cache settings and stats.
+func handleGetResponseCache(c *gin.Context) {
+	cfg := responsecache.LoadConfig()
+	entries, hits, err := database.NewResponseCacheStore().Stats()
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to read response cache stats")
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"enabled":     cfg.Enabled,
+		"ttl_seconds": int(cfg.TTL.Seconds()),
+		"entries":     entries,
+		"total_hits":  hits,
+	})
+}
+
+// handleSetResponseCache updates response-cache settings (enable flag + TTL).
+func handleSetResponseCache(c *gin.Context) {
+	var req struct {
+		Enabled    *bool `json:"enabled"`
+		TTLSeconds *int  `json:"ttl_seconds"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+	store := database.NewConfigStore()
+	if req.Enabled != nil {
+		val := "false"
+		if *req.Enabled {
+			val = "true"
+		}
+		if err := store.Set("response_cache.enabled", val); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	if req.TTLSeconds != nil {
+		if *req.TTLSeconds < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "ttl_seconds must be >= 0"})
+			return
+		}
+		if err := store.Set("response_cache.ttl_seconds", strconv.Itoa(*req.TTLSeconds)); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	cfg := responsecache.LoadConfig()
+	log.Info().Bool("enabled", cfg.Enabled).Int("ttl_seconds", int(cfg.TTL.Seconds())).Msg("Response cache settings updated")
+	c.JSON(http.StatusOK, gin.H{
+		"success":     true,
+		"enabled":     cfg.Enabled,
+		"ttl_seconds": int(cfg.TTL.Seconds()),
+	})
+}
+
+// handleClearResponseCache purges all cached responses.
+func handleClearResponseCache(c *gin.Context) {
+	removed, err := database.NewResponseCacheStore().Clear()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	log.Info().Int64("removed", removed).Msg("Response cache cleared")
+	c.JSON(http.StatusOK, gin.H{"success": true, "removed": removed})
+}

--- a/internal/routes/admin_routes.go
+++ b/internal/routes/admin_routes.go
@@ -42,6 +42,9 @@ func SetupAdminRoutes(router *gin.RouterGroup, port int) {
 	// Settings
 	router.GET("/settings/log-level", handleGetLogLevel)
 	router.PUT("/settings/log-level", handleSetLogLevel)
+	router.GET("/settings/response-cache", handleGetResponseCache)
+	router.PUT("/settings/response-cache", handleSetResponseCache)
+	router.DELETE("/settings/response-cache", handleClearResponseCache)
 	router.POST("/settings/test-log", handleTestLog)
 	router.POST("/settings/debug-log", handleDebugLog)
 

--- a/internal/routes/chat.go
+++ b/internal/routes/chat.go
@@ -10,6 +10,7 @@ import (
 	"omnillm/internal/lib/approval"
 	"omnillm/internal/lib/modelrouting"
 	"omnillm/internal/lib/ratelimit"
+	"omnillm/internal/lib/responsecache"
 	"omnillm/internal/providerdispatch"
 	"omnillm/internal/providers/types"
 	"omnillm/internal/serialization"
@@ -107,6 +108,31 @@ func (h *chatCompletionHandler) handleChatCompletions(c *gin.Context) {
 
 	originalModel := prepareCanonicalRequest(c, canonicalRequest, "openai")
 
+	// Exact-match response cache (opt-in, deterministic non-streaming only).
+	cacheCfg := responsecache.LoadConfig()
+	bypass := responsecache.ParseBypass(c.GetHeader(responsecache.BypassHeader))
+	var cacheKey string
+	cacheEligible := cacheCfg.Enabled && bypass != responsecache.BypassAll && responsecache.Cacheable(canonicalRequest)
+	if cacheEligible {
+		cacheKey = responsecache.Key(canonicalRequest)
+		if bypass != responsecache.BypassRead {
+			if hit := responsecache.Get(cacheCfg, canonicalRequest, cacheKey); hit != nil {
+				openaiResp, err := serialization.SerializeToOpenAI(hit)
+				if err == nil {
+					c.Header("X-OmniLLM-Cache", "hit")
+					logCompletedResponse("openai", requestIDStr, originalModel, hit.Model, "cache", false, hit.StopReason, hit.Usage, startTime)
+					c.JSON(http.StatusOK, openaiResp)
+					return
+				}
+				log.Warn().Err(err).Str("request_id", requestIDStr).Msg("Cache hit failed to serialize; falling through to upstream")
+			}
+		}
+	}
+
+	if cacheEligible {
+		c.Set("responsecache_key", cacheKey)
+	}
+
 	// Resolve providers for the requested model
 	attempts := resolveRequestedModels(requestIDStr, canonicalRequest.Model)
 	executor := providerdispatch.NewExecutor(providerdispatch.ApplyGitHubCopilotSingleUpstreamMode, providerdispatch.DefaultUpstreamAPI)
@@ -178,6 +204,14 @@ func handleNonStreamingResponse(c *gin.Context, adapter types.ProviderAdapter, c
 
 	logCompletedResponse("openai", requestID, originalModel, response.Model, providerID, false, response.StopReason, response.Usage, startTime)
 	recordUsage(requestID, originalModel, response.Model, providerID, normalizeMeteringClient(c.GetHeader("User-Agent")), "openai", response.Usage, time.Since(startTime).Milliseconds(), false, http.StatusOK, "")
+
+	// Populate the exact-match response cache if this request was eligible.
+	if key, ok := c.Get("responsecache_key"); ok {
+		if keyStr, _ := key.(string); keyStr != "" {
+			responsecache.Put(responsecache.LoadConfig(), canonicalRequest, keyStr, response)
+			c.Header("X-OmniLLM-Cache", "miss")
+		}
+	}
 
 	c.JSON(http.StatusOK, openaiResp)
 	return nil

--- a/internal/routes/chat.go
+++ b/internal/routes/chat.go
@@ -108,7 +108,7 @@ func (h *chatCompletionHandler) handleChatCompletions(c *gin.Context) {
 
 	originalModel := prepareCanonicalRequest(c, canonicalRequest, "openai")
 
-	// Exact-match response cache (opt-in, deterministic non-streaming only).
+	// Exact-match response cache (opt-in, deterministic requests).
 	cacheCfg := responsecache.LoadConfig()
 	bypass := responsecache.ParseBypass(c.GetHeader(responsecache.BypassHeader))
 	var cacheKey string
@@ -117,6 +117,11 @@ func (h *chatCompletionHandler) handleChatCompletions(c *gin.Context) {
 		cacheKey = responsecache.Key(canonicalRequest)
 		if bypass != responsecache.BypassRead {
 			if hit := responsecache.Get(cacheCfg, canonicalRequest, cacheKey); hit != nil {
+				if canonicalRequest.Stream {
+					replayOpenAIStreamFromCache(c, hit)
+					logCompletedResponse("openai", requestIDStr, originalModel, hit.Model, "cache", true, hit.StopReason, hit.Usage, startTime)
+					return
+				}
 				openaiResp, err := serialization.SerializeToOpenAI(hit)
 				if err == nil {
 					c.Header("X-OmniLLM-Cache", "hit")
@@ -230,6 +235,18 @@ func handleStreamingResponse(c *gin.Context, adapter types.ProviderAdapter, cano
 
 	setSSEHeaders(c, true)
 
+	// If this request is cache-eligible, accumulate the stream into a
+	// CanonicalResponse so it can be stored and replayed on a future hit.
+	var acc *responsecache.StreamAccumulator
+	var cacheKey string
+	if key, ok := c.Get("responsecache_key"); ok {
+		if ks, _ := key.(string); ks != "" {
+			cacheKey = ks
+			acc = responsecache.NewStreamAccumulator()
+			c.Header("X-OmniLLM-Cache", "miss")
+		}
+	}
+
 	state := serialization.CreateOpenAIStreamState()
 	flusher, _ := c.Writer.(http.Flusher)
 	modelUsed := canonicalRequest.Model
@@ -242,6 +259,10 @@ func handleStreamingResponse(c *gin.Context, adapter types.ProviderAdapter, cano
 		case event, ok := <-eventCh:
 			if !ok {
 				return false
+			}
+
+			if acc != nil {
+				acc.Observe(event)
 			}
 
 			sseData, err := serialization.ConvertCIFEventToOpenAISSE(event, state)
@@ -275,6 +296,12 @@ func handleStreamingResponse(c *gin.Context, adapter types.ProviderAdapter, cano
 					Int64("latency_ms", time.Since(startTime).Milliseconds()).
 					Msg("\x1b[32m<--\x1b[0m RESPONSE stream")
 				recordUsage(requestID, originalModel, modelUsed, providerID, normalizeMeteringClient(c.GetHeader("User-Agent")), "openai", endEvt.Usage, time.Since(startTime).Milliseconds(), true, http.StatusOK, "")
+
+				if acc != nil {
+					if assembled := acc.Response(); assembled != nil {
+						responsecache.Put(responsecache.LoadConfig(), canonicalRequest, cacheKey, assembled)
+					}
+				}
 				return false
 			}
 
@@ -287,4 +314,27 @@ func handleStreamingResponse(c *gin.Context, adapter types.ProviderAdapter, cano
 	})
 
 	return nil
+}
+
+// replayOpenAIStreamFromCache re-emits a cached CanonicalResponse as an OpenAI
+// SSE stream, so a streaming client gets a cache hit as a normal (if instant)
+// stream. It reuses the production event serializer via synthesized CIF events.
+func replayOpenAIStreamFromCache(c *gin.Context, resp *cif.CanonicalResponse) {
+	c.Header("X-OmniLLM-Cache", "hit")
+	setSSEHeaders(c, true)
+	state := serialization.CreateOpenAIStreamState()
+	flusher, _ := c.Writer.(http.Flusher)
+	events := responsecache.SynthesizeStream(resp)
+	c.Stream(func(w io.Writer) bool {
+		for _, ev := range events {
+			sseData, err := serialization.ConvertCIFEventToOpenAISSE(ev, state)
+			if err != nil {
+				return false
+			}
+			if sseData != "" {
+				flushStreamWriter(w, flusher, sseData)
+			}
+		}
+		return false
+	})
 }

--- a/internal/routes/messages.go
+++ b/internal/routes/messages.go
@@ -88,7 +88,7 @@ func handleMessages(c *gin.Context) {
 	originalModel := prepareCanonicalRequest(c, canonicalRequest, "anthropic")
 	logAnthropicToolLoopRequest(requestIDStr, canonicalRequest)
 
-	// Exact-match response cache (opt-in, deterministic non-streaming only).
+	// Exact-match response cache (opt-in, deterministic requests).
 	// Shape-agnostic: a CanonicalResponse cached via the OpenAI route can satisfy
 	// this Anthropic request and vice versa.
 	cacheCfg := responsecache.LoadConfig()
@@ -99,6 +99,10 @@ func handleMessages(c *gin.Context) {
 		if bypass != responsecache.BypassRead {
 			if hit := responsecache.Get(cacheCfg, canonicalRequest, cacheKey); hit != nil {
 				suppressThinking := !strings.Contains(c.GetHeader("anthropic-beta"), "interleaved-thinking")
+				if canonicalRequest.Stream {
+					replayAnthropicStreamFromCache(c, hit, suppressThinking)
+					return
+				}
 				if anthropicResp, err := serialization.SerializeToAnthropicWithSuppression(hit, suppressThinking); err == nil {
 					c.Header("X-OmniLLM-Cache", "hit")
 					c.JSON(http.StatusOK, anthropicResp)
@@ -255,6 +259,16 @@ func handleAnthropicStreamingResponse(c *gin.Context, adapter types.ProviderAdap
 	modelUsed := canonicalRequest.Model
 	toolCallTracker := newToolLoopCallTracker()
 
+	var acc *responsecache.StreamAccumulator
+	var cacheKey string
+	if key, ok := c.Get("responsecache_key"); ok {
+		if ks, _ := key.(string); ks != "" {
+			cacheKey = ks
+			acc = responsecache.NewStreamAccumulator()
+			c.Header("X-OmniLLM-Cache", "miss")
+		}
+	}
+
 	c.Stream(func(w io.Writer) bool {
 		select {
 		case <-ctx.Done():
@@ -264,6 +278,9 @@ func handleAnthropicStreamingResponse(c *gin.Context, adapter types.ProviderAdap
 				return false
 			}
 			toolCallTracker.Observe(event)
+			if acc != nil {
+				acc.Observe(event)
+			}
 
 			sseEvents, err := serialization.ConvertCIFEventToAnthropicSSE(event, state)
 			if err != nil {
@@ -310,6 +327,12 @@ func handleAnthropicStreamingResponse(c *gin.Context, adapter types.ProviderAdap
 					Int64("latency_ms", time.Since(startTime).Milliseconds()).
 					Msg("\x1b[32m<--\x1b[0m RESPONSE stream")
 				recordUsage(requestID, originalModel, modelUsed, providerID, normalizeMeteringClient(c.GetHeader("User-Agent")), "anthropic", endEvt.Usage, time.Since(startTime).Milliseconds(), true, http.StatusOK, "")
+
+				if acc != nil {
+					if assembled := acc.Response(); assembled != nil {
+						responsecache.Put(responsecache.LoadConfig(), canonicalRequest, cacheKey, assembled)
+					}
+				}
 				return false
 			}
 
@@ -415,4 +438,40 @@ func estimateStringTokens(s string) int {
 		tokens = 1
 	}
 	return tokens
+}
+
+// replayAnthropicStreamFromCache re-emits a cached CanonicalResponse as an
+// Anthropic SSE stream, reusing the production event serializer via synthesized
+// CIF events so a streaming Claude Code client sees a normal (instant) stream.
+func replayAnthropicStreamFromCache(c *gin.Context, resp *cif.CanonicalResponse, suppressThinking bool) {
+	c.Header("X-OmniLLM-Cache", "hit")
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+
+	state := serialization.CreateAnthropicStreamState()
+	state.SuppressThinkingBlocks = suppressThinking
+	flusher, _ := c.Writer.(http.Flusher)
+	events := responsecache.SynthesizeStream(resp)
+
+	c.Stream(func(w io.Writer) bool {
+		for _, ev := range events {
+			sseEvents, err := serialization.ConvertCIFEventToAnthropicSSE(ev, state)
+			if err != nil {
+				return false
+			}
+			for _, sseEvent := range sseEvents {
+				eventType, _ := sseEvent["type"].(string)
+				formatted, err := serialization.FormatAnthropicSSEData(eventType, sseEvent)
+				if err != nil {
+					return false
+				}
+				fmt.Fprint(w, formatted)
+			}
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return false
+	})
 }

--- a/internal/routes/messages.go
+++ b/internal/routes/messages.go
@@ -9,6 +9,7 @@ import (
 	"omnillm/internal/ingestion"
 	"omnillm/internal/lib/affinity"
 	"omnillm/internal/lib/modelrouting"
+	"omnillm/internal/lib/responsecache"
 	"omnillm/internal/providerdispatch"
 	"omnillm/internal/providers/types"
 	"omnillm/internal/serialization"
@@ -86,6 +87,27 @@ func handleMessages(c *gin.Context) {
 
 	originalModel := prepareCanonicalRequest(c, canonicalRequest, "anthropic")
 	logAnthropicToolLoopRequest(requestIDStr, canonicalRequest)
+
+	// Exact-match response cache (opt-in, deterministic non-streaming only).
+	// Shape-agnostic: a CanonicalResponse cached via the OpenAI route can satisfy
+	// this Anthropic request and vice versa.
+	cacheCfg := responsecache.LoadConfig()
+	bypass := responsecache.ParseBypass(c.GetHeader(responsecache.BypassHeader))
+	cacheEligible := cacheCfg.Enabled && bypass != responsecache.BypassAll && responsecache.Cacheable(canonicalRequest)
+	if cacheEligible {
+		cacheKey := responsecache.Key(canonicalRequest)
+		if bypass != responsecache.BypassRead {
+			if hit := responsecache.Get(cacheCfg, canonicalRequest, cacheKey); hit != nil {
+				suppressThinking := !strings.Contains(c.GetHeader("anthropic-beta"), "interleaved-thinking")
+				if anthropicResp, err := serialization.SerializeToAnthropicWithSuppression(hit, suppressThinking); err == nil {
+					c.Header("X-OmniLLM-Cache", "hit")
+					c.JSON(http.StatusOK, anthropicResp)
+					return
+				}
+			}
+		}
+		c.Set("responsecache_key", cacheKey)
+	}
 
 	var resolveStart time.Time
 	if log.Logger.GetLevel() <= zerolog.DebugLevel {
@@ -191,6 +213,13 @@ func handleAnthropicNonStreamingResponse(c *gin.Context, adapter types.ProviderA
 		Int64("latency_ms", time.Since(startTime).Milliseconds()).
 		Msg("\x1b[32m<--\x1b[0m RESPONSE")
 	recordUsage(requestID, originalModel, response.Model, providerID, normalizeMeteringClient(c.GetHeader("User-Agent")), "anthropic", response.Usage, time.Since(startTime).Milliseconds(), false, http.StatusOK, "")
+
+	if key, ok := c.Get("responsecache_key"); ok {
+		if keyStr, _ := key.(string); keyStr != "" {
+			responsecache.Put(responsecache.LoadConfig(), canonicalRequest, keyStr, response)
+			c.Header("X-OmniLLM-Cache", "miss")
+		}
+	}
 
 	c.JSON(http.StatusOK, anthropicResp)
 	return nil


### PR DESCRIPTION
## Summary

Adds an **opt-in exact-match response cache** at the CIF (Canonical Intermediate Format) layer. Because every route serializes from the same `CanonicalResponse`, a single cached entry serves **any wire shape × streaming/non-streaming**:

- OpenAI `/v1/chat/completions` ⇄ Anthropic `/v1/messages` (cross-shape reuse)
- streaming ⇄ non-streaming

Disabled by default; strictly opt-in.

## What's included

- `internal/lib/responsecache/`: keying (sha256 over model + messages + tools + sampling params + response_format; excludes headers/userId), cacheability gate (`temperature==0`, `top_p` unset/≥1), type-tagged encode/decode for the `[]CIFContentPart` interface slice, bypass header, `StreamAccumulator`/`SynthesizeStream`.
- `internal/database/store_response_cache.go` + migration **v15**: `response_cache` table, hit accounting, TTL, purge/clear/stats.
- `routes/chat.go` + `routes/messages.go`: lookup before dispatch, populate after success; streaming accumulate-on-miss / replay-on-hit. `X-OmniLLM-Cache: hit|miss` header.
- Admin API `/api/admin/settings/response-cache` (GET/PUT/DELETE) + CLI `omnillm settings get/set response-cache`, `clear-response-cache`.

## Behaviour / safety

- Only deterministic requests cached (temp==0). temp>0, errors, empty generations never cached.
- Per-request `X-OmniLLM-Cache` header: `bypass`/`refresh` (skip read, still write) or `off` (skip read+write).
- Blast radius contained: cache is a no-op unless explicitly enabled.

## Notable bugs caught during e2e (not by unit tests alone)

1. `CanonicalResponse.Content` is `[]CIFContentPart` (interface slice) → stdlib `json.Unmarshal` can't reconstruct interface values → every read silently missed. Fixed with type-tagged encode/decode.
2. Copilot attaches the announcing `ContentBlock` to **every** delta, not just the first → re-seeding wiped accumulated text (`STARFRUIT`→`ARFRUIT`). Fixed with a first-sight guard + regression test.

## Test plan

- [x] `go vet ./internal/...` clean
- [x] `go test ./internal/...` all pass (unit: keying, gating, bypass, encode/decode round-trip, stream accumulate/synthesize/round-trip, every-delta regression, store CRUD/TTL/purge)
- [x] Live e2e on isolated instance (real Copilot upstream): MISS→HIT reconstruct identical text for OpenAI-stream, Anthropic-stream (cross-shape), and OpenAI-non-stream from a single cached entry; bypass off/refresh; temp>0 skip.

## Deferred (documented)

Anthropic prompt `cache_control` passthrough is intentionally NOT included: OmniLLM has no native-Anthropic egress (Claude routes CIF→OpenAI→Copilot), so the breakpoint has nowhere to land until a native-Anthropic/Bedrock egress adapter exists.